### PR TITLE
fix: use correct API endpoint /v1/graphs/supermodel

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -54,7 +54,7 @@ func (c *Client) Analyze(ctx context.Context, zipPath, idempotencyKey string) (*
 	mw.Close()
 
 	var g Graph
-	if err := c.request(ctx, http.MethodPost, "/v1/supermodel", mw.FormDataContentType(), &buf, idempotencyKey, &g); err != nil {
+	if err := c.request(ctx, http.MethodPost, "/v1/graphs/supermodel", mw.FormDataContentType(), &buf, idempotencyKey, &g); err != nil {
 		return nil, err
 	}
 	return &g, nil

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -40,7 +40,7 @@ type Relationship struct {
 	Properties map[string]any `json:"properties,omitempty"`
 }
 
-// Graph is the unified response type for /v1/supermodel and
+// Graph is the unified response type for /v1/graphs/supermodel and
 // /v1/repos/{id}/graph/display. The API serialises relationships as either
 // "edges" or "relationships" depending on the endpoint; Rels() unifies both.
 type Graph struct {

--- a/scripts/check-architecture/main.go
+++ b/scripts/check-architecture/main.go
@@ -46,7 +46,7 @@ var sharedKernel = map[string]bool{
 }
 
 // --- Supermodel API response types -------------------------------------------
-// Schema: DisplayGraphResponse from api.supermodeltools.com/v1/supermodel
+// Schema: DisplayGraphResponse from api.supermodeltools.com/v1/graphs/supermodel
 
 type graphResponse struct {
 	Nodes         []graphNode    `json:"nodes"`
@@ -235,7 +235,7 @@ func callAPI(apiBase, apiKey, zipPath string) (*graphResponse, error) {
 	}
 	mw.Close()
 
-	req, err := http.NewRequest(http.MethodPost, apiBase+"/v1/supermodel", &buf)
+	req, err := http.NewRequest(http.MethodPost, apiBase+"/v1/graphs/supermodel", &buf)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- The `Analyze` client method and the `check-architecture` script were hitting `/v1/supermodel`, which doesn't exist on the API
- The correct endpoint is `/v1/graphs/supermodel`
- This caused all `supermodel analyze` invocations to receive a **302 redirect** to the OAuth login page, which the CLI reported as an opaque `HTTP 400`

## Changes
- `internal/api/client.go:57` — fix endpoint path in `Analyze()`
- `scripts/check-architecture/main.go:238` — fix endpoint path in `callAPI()`
- `internal/api/types.go:43` — update comment to match

## How I found it
```
$ curl -v -X POST "https://api.supermodeltools.com/v1/supermodel" \
  -H "X-Api-Key: ..." -H "Idempotency-Key: ..." -F "file=@repo.zip"
# → HTTP 302 → /oauth2/authorization/github

$ curl -v -X POST "https://api.supermodeltools.com/v1/graphs/supermodel" \
  -H "X-Api-Key: ..." -H "Idempotency-Key: ..." -F "file=@repo.zip"
# → HTTP 202 → {"status":"pending",...}
```

## Test plan
- [ ] `supermodel analyze` completes successfully against a real repo
- [ ] `go run ./scripts/check-architecture` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the Supermodel API endpoint path to a unified /v1/graphs/supermodel for improved API consistency.
* **Documentation**
  * Aligned related docs and schema references to the new endpoint path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->