### PR TITLE
fix: match lowercase relationship types returned by API

### DIFF
--- a/internal/blastradius/handler.go
+++ b/internal/blastradius/handler.go
@@ -62,7 +62,7 @@ func findBlastRadius(g *api.Graph, repoDir, target string, maxDepth int) ([]Resu
 	// Build reverse adjacency: nodeID → set of node IDs that import it.
 	importedBy := make(map[string][]string)
 	for _, rel := range g.Rels() {
-		if rel.Type == "IMPORTS" || rel.Type == "WILDCARD_IMPORTS" {
+		if rel.Type == "imports" || rel.Type == "wildcard_imports" {
 			importedBy[rel.EndNode] = append(importedBy[rel.EndNode], rel.StartNode)
 		}
 	}

--- a/internal/blastradius/handler_test.go
+++ b/internal/blastradius/handler_test.go
@@ -37,8 +37,8 @@ func TestFindBlastRadius(t *testing.T) {
 			fileNode("c", "internal/c/c.go"),
 		},
 		Relationships: []api.Relationship{
-			{ID: "r1", Type: "IMPORTS", StartNode: "a", EndNode: "b"},
-			{ID: "r2", Type: "IMPORTS", StartNode: "c", EndNode: "a"},
+			{ID: "r1", Type: "imports", StartNode: "a", EndNode: "b"},
+			{ID: "r2", Type: "imports", StartNode: "c", EndNode: "a"},
 		},
 	}
 

--- a/internal/deadcode/handler.go
+++ b/internal/deadcode/handler.go
@@ -45,7 +45,7 @@ func findDeadCode(g *api.Graph, includeExports bool) []Result {
 	// Build set of function node IDs that receive at least one CALLS edge.
 	called := make(map[string]bool)
 	for _, rel := range g.Rels() {
-		if rel.Type == "CALLS" || rel.Type == "CONTAINS_CALL" {
+		if rel.Type == "calls" || rel.Type == "contains_call" {
 			called[rel.EndNode] = true
 		}
 	}

--- a/internal/deadcode/handler_test.go
+++ b/internal/deadcode/handler_test.go
@@ -46,7 +46,7 @@ func TestFindDeadCode(t *testing.T) {
 			node("f4", "Function", "Handler", "server.go"), // exported → excluded by default
 		},
 		Relationships: []api.Relationship{
-			{ID: "r1", Type: "CALLS", StartNode: "f2", EndNode: "f1"}, // main → process
+			{ID: "r1", Type: "calls", StartNode: "f2", EndNode: "f1"}, // main → process
 		},
 	}
 

--- a/internal/focus/handler.go
+++ b/internal/focus/handler.go
@@ -206,7 +206,7 @@ func reachableImports(g *api.Graph, seedID string, nodeByID map[string]*api.Node
 func functionNodesForFile(g *api.Graph, fileID string, rels []api.Relationship) []string {
 	var ids []string
 	for _, rel := range rels {
-		if (rel.Type == "DEFINES_FUNCTION" || rel.Type == "DEFINES") && rel.StartNode == fileID {
+		if (rel.Type == "defines_function" || rel.Type == "defines") && rel.StartNode == fileID {
 			ids = append(ids, rel.EndNode)
 		}
 	}
@@ -225,7 +225,7 @@ func functionNodesForFile(g *api.Graph, fileID string, rels []api.Relationship) 
 func buildCalleesOf(rels []api.Relationship) map[string][]string {
 	m := make(map[string][]string)
 	for _, rel := range rels {
-		if rel.Type == "CALLS" || rel.Type == "CONTAINS_CALL" {
+		if rel.Type == "calls" || rel.Type == "contains_call" {
 			m[rel.StartNode] = append(m[rel.StartNode], rel.EndNode)
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -339,7 +339,7 @@ type deadFn struct{ name, file string }
 func findDeadFunctions(g *api.Graph, includeExports bool) []deadFn {
 	called := make(map[string]bool)
 	for _, rel := range g.Rels() {
-		if rel.Type == "CALLS" || rel.Type == "CONTAINS_CALL" {
+		if rel.Type == "calls" || rel.Type == "contains_call" {
 			called[rel.EndNode] = true
 		}
 	}
@@ -366,7 +366,7 @@ type affected struct {
 func findAffected(g *api.Graph, target string) []affected {
 	importedBy := make(map[string][]string)
 	for _, rel := range g.Rels() {
-		if rel.Type == "IMPORTS" || rel.Type == "WILDCARD_IMPORTS" {
+		if rel.Type == "imports" || rel.Type == "wildcard_imports" {
 			importedBy[rel.EndNode] = append(importedBy[rel.EndNode], rel.StartNode)
 		}
 	}

--- a/scripts/check-architecture/main.go
+++ b/scripts/check-architecture/main.go
@@ -114,7 +114,7 @@ func main() {
 
 	var violations []string
 	for _, rel := range graph.rels() {
-		if rel.Type != "IMPORTS" && rel.Type != "WILDCARD_IMPORTS" {
+		if rel.Type != "imports" && rel.Type != "wildcard_imports" {
 			continue
 		}
 		src := nodePackage[rel.StartNode]


### PR DESCRIPTION
## Summary
The API returns relationship types in lowercase (`imports`, `calls`, `defines_function`) but handlers compared against uppercase (`IMPORTS`, `CALLS`, `DEFINES_FUNCTION`). Since Go string comparison is case-sensitive, every check silently failed.

## What broke
- **dead-code**: thought nothing calls anything → reported every function as dead (1,337 vs correct 717)
- **blast-radius**: thought nothing imports anything → always returned 0 affected files
- **focus**: couldn't find function definitions or call chains → returned empty context

## Changes
10 string literals upppercase → lowercase across 7 files. Nothing else.

## Test results (before → after)
```
dead-code:     1,337 → 717 unreachable functions
blast-radius:  0 → 25 affected files (AuthConstants.java)
focus:         ~12 empty tokens → 5 function definitions
```

Unit tests: all pass. Integration test: pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed relationship type matching in dead code detection, blast radius analysis, code focus analysis, and architecture validation to correctly identify code dependencies and affected files.
  * Improvements ensure accurate analysis results across all code scanning features.

* **Tests**
  * Updated test fixtures to align with corrected relationship type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->