### PR TITLE
feat: wire MCP server to dedicated dead-code and impact API endpoints

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -262,18 +262,7 @@ func (s *server) toolDeadCode(ctx context.Context, args map[string]any) (string,
 		return "", err
 	}
 
-	if len(result.DeadCodeCandidates) == 0 {
-		return "No dead code detected.", nil
-	}
-
-	var sb strings.Builder
-	fmt.Fprintf(&sb, "%d dead code candidate(s) out of %d total declarations:\n\n",
-		result.Metadata.DeadCodeCandidates, result.Metadata.TotalDeclarations)
-	for i := range result.DeadCodeCandidates {
-		c := &result.DeadCodeCandidates[i]
-		fmt.Fprintf(&sb, "- [%s] %s:%d %s — %s\n", c.Confidence, c.File, c.Line, c.Name, c.Reason)
-	}
-	return sb.String(), nil
+	return formatDeadCode(result), nil
 }
 
 // toolBlastRadius calls the dedicated /v1/analysis/impact endpoint.
@@ -296,6 +285,46 @@ func (s *server) toolBlastRadius(ctx context.Context, args map[string]any) (stri
 		return "", err
 	}
 
+	return formatImpact(result), nil
+}
+
+// toolGetGraph returns a filtered graph slice.
+func (s *server) toolGetGraph(ctx context.Context, args map[string]any) (string, error) {
+	force := boolArg(args, "force")
+	g, _, err := s.getOrAnalyze(ctx, force)
+	if err != nil {
+		return "", err
+	}
+	label, _ := args["label"].(string)
+	relType, _ := args["rel_type"].(string)
+
+	out := filterGraph(g, label, relType)
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// --- Formatting helpers ------------------------------------------------------
+
+// formatDeadCode formats a DeadCodeResult as human-readable text.
+func formatDeadCode(result *api.DeadCodeResult) string {
+	if len(result.DeadCodeCandidates) == 0 {
+		return "No dead code detected."
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "%d dead code candidate(s) out of %d total declarations:\n\n",
+		result.Metadata.DeadCodeCandidates, result.Metadata.TotalDeclarations)
+	for i := range result.DeadCodeCandidates {
+		c := &result.DeadCodeCandidates[i]
+		fmt.Fprintf(&sb, "- [%s] %s:%d %s — %s\n", c.Confidence, c.File, c.Line, c.Name, c.Reason)
+	}
+	return sb.String()
+}
+
+// formatImpact formats an ImpactResult as human-readable text.
+func formatImpact(result *api.ImpactResult) string {
 	if len(result.Impacts) == 0 {
 		if len(result.GlobalMetrics.MostCriticalFiles) > 0 {
 			var sb strings.Builder
@@ -304,9 +333,9 @@ func (s *server) toolBlastRadius(ctx context.Context, args map[string]any) (stri
 				f := &result.GlobalMetrics.MostCriticalFiles[i]
 				fmt.Fprintf(&sb, "- %s (%d dependents)\n", f.File, f.DependentCount)
 			}
-			return sb.String(), nil
+			return sb.String()
 		}
-		return "No impact detected.", nil
+		return "No impact detected."
 	}
 
 	var sb strings.Builder
@@ -337,25 +366,7 @@ func (s *server) toolBlastRadius(ctx context.Context, args map[string]any) (stri
 	}
 	fmt.Fprintf(&sb, "%d target(s) analyzed across %d files and %d functions.\n",
 		result.Metadata.TargetsAnalyzed, result.Metadata.TotalFiles, result.Metadata.TotalFunctions)
-	return sb.String(), nil
-}
-
-// toolGetGraph returns a filtered graph slice.
-func (s *server) toolGetGraph(ctx context.Context, args map[string]any) (string, error) {
-	force := boolArg(args, "force")
-	g, _, err := s.getOrAnalyze(ctx, force)
-	if err != nil {
-		return "", err
-	}
-	label, _ := args["label"].(string)
-	relType, _ := args["rel_type"].(string)
-
-	out := filterGraph(g, label, relType)
-	data, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
+	return sb.String()
 }
 
 // --- Shared helpers ----------------------------------------------------------

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/api"
+)
+
+func TestFormatDeadCode_Empty(t *testing.T) {
+	result := &api.DeadCodeResult{}
+	got := formatDeadCode(result)
+	if got != "No dead code detected." {
+		t.Errorf("expected 'No dead code detected.', got: %s", got)
+	}
+}
+
+func TestFormatDeadCode_WithCandidates(t *testing.T) {
+	result := &api.DeadCodeResult{
+		Metadata: api.DeadCodeMetadata{TotalDeclarations: 100, DeadCodeCandidates: 2},
+		DeadCodeCandidates: []api.DeadCodeCandidate{
+			{File: "src/a.ts", Line: 10, Name: "unused", Confidence: "high", Reason: "No callers"},
+			{File: "src/b.ts", Line: 42, Name: "old", Confidence: "medium", Reason: "Transitively dead"},
+		},
+	}
+	got := formatDeadCode(result)
+	for _, want := range []string{
+		"2 dead code candidate(s) out of 100 total declarations",
+		"[high] src/a.ts:10 unused — No callers",
+		"[medium] src/b.ts:42 old — Transitively dead",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatImpact_Empty(t *testing.T) {
+	result := &api.ImpactResult{}
+	got := formatImpact(result)
+	if got != "No impact detected." {
+		t.Errorf("expected 'No impact detected.', got: %s", got)
+	}
+}
+
+func TestFormatImpact_GlobalCouplingMap(t *testing.T) {
+	result := &api.ImpactResult{
+		GlobalMetrics: api.ImpactGlobalMetrics{
+			MostCriticalFiles: []api.CriticalFileMetric{
+				{File: "src/db.ts", DependentCount: 42},
+			},
+		},
+	}
+	got := formatImpact(result)
+	if !strings.Contains(got, "Most critical files") {
+		t.Errorf("expected global coupling header, got:\n%s", got)
+	}
+	if !strings.Contains(got, "src/db.ts (42 dependents)") {
+		t.Errorf("expected file with count, got:\n%s", got)
+	}
+}
+
+func TestFormatImpact_WithTarget(t *testing.T) {
+	result := &api.ImpactResult{
+		Metadata: api.ImpactMetadata{TargetsAnalyzed: 1, TotalFiles: 100, TotalFunctions: 500},
+		Impacts: []api.ImpactTarget{
+			{
+				Target: api.ImpactTargetInfo{File: "src/auth.ts", Type: "file"},
+				BlastRadius: api.BlastRadius{
+					DirectDependents: 10, TransitiveDependents: 30, AffectedFiles: 5,
+					RiskScore: "high", RiskFactors: []string{"High fan-in"},
+				},
+				AffectedFiles: []api.AffectedFile{
+					{File: "src/routes.ts", DirectDependencies: 3, TransitiveDependencies: 7},
+				},
+				EntryPointsAffected: []api.AffectedEntryPoint{
+					{File: "src/routes.ts", Name: "/login", Type: "route_handler"},
+				},
+			},
+		},
+	}
+	got := formatImpact(result)
+	for _, want := range []string{
+		"Target: src/auth.ts",
+		"Risk: high",
+		"Direct: 10",
+		"Transitive: 30",
+		"High fan-in",
+		"src/routes.ts (direct: 3, transitive: 7)",
+		"/login (route_handler)",
+		"1 target(s) analyzed across 100 files and 500 functions",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatImpact_NoEntryPoints(t *testing.T) {
+	result := &api.ImpactResult{
+		Metadata: api.ImpactMetadata{TargetsAnalyzed: 1, TotalFiles: 50, TotalFunctions: 200},
+		Impacts: []api.ImpactTarget{
+			{
+				Target:      api.ImpactTargetInfo{File: "src/util.ts", Type: "file"},
+				BlastRadius: api.BlastRadius{DirectDependents: 2, RiskScore: "low"},
+			},
+		},
+	}
+	got := formatImpact(result)
+	if strings.Contains(got, "Entry points") {
+		t.Error("should not contain entry points section when none affected")
+	}
+}


### PR DESCRIPTION
Closes #27

## Summary
Replace inline graph traversal in the MCP server with calls to the real API endpoints. The MCP `dead_code` and `blast_radius` tools now use `client.DeadCode()` and `client.Impact()` — same data quality as the CLI commands.

## What changed
1 file: `internal/mcp/server.go` — net -4 lines (157 added, 161 removed)

**Removed:** `findDeadFunctions`, `findAffected`, `isEntryPoint`, `pathMatches`, `deadFn`, `affected` — ~100 lines of inline graph traversal

**Added:** `toolDeadCode` → `client.DeadCode()`, `toolBlastRadius` → `client.Impact()`, `ensureZip` helper, `intArg` helper

**Updated tool schemas:**
- `dead_code`: removed `include_exports`, added `min_confidence` and `limit`
- `blast_radius`: removed `depth`, `file` is now optional (omit for global coupling map)

## Before (inline graph traversal)
```
717 unreachable function(s):
- __add__
- __aenter__
...
```

## After (real API)
```
119 dead code candidate(s) out of 1131 total declarations:
- [high] src/.../MeteredUsage.java:9 MeteredUsage — Type/interface with no references
- [high] src/.../RequiresScopes.java:8 RequiresScopes — Type/interface with no references
...
```

## Test plan
- [x] `go test ./...` — all pass
- [x] Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Tool parameters changed: dead-code now uses min_confidence and limit; blast-radius accepts an optional file (omitting it triggers global analysis).
  * Analysis outputs expanded to include confidence, file/line context, risk scores, dependents, and detailed impact metrics.

* **New Features**
  * Dedicated analysis/reporting handlers with idempotent repo packaging and formatted dead-code/impact reports.

* **Refactor**
  * Simplified tool dispatch with clearer error handling for unknown tools.

* **Tests**
  * Added unit tests covering formatted report output and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->