### PR TITLE
fix: rune-aware truncation in stepName to prevent invalid UTF-8 in JSON-LD

### DIFF
--- a/internal/archdocs/pssg/schema/jsonld.go
+++ b/internal/archdocs/pssg/schema/jsonld.go
@@ -290,9 +290,10 @@ func stepName(step string) string {
 			return step[:idx+1]
 		}
 	}
-	// Truncate if too long
-	if len(step) > 80 {
-		return step[:77] + "..."
+	// Truncate if too long (rune-aware to avoid splitting multi-byte UTF-8).
+	runes := []rune(step)
+	if len(runes) > 80 {
+		return string(runes[:77]) + "..."
 	}
 	return step
 }

--- a/internal/archdocs/pssg/schema/jsonld_test.go
+++ b/internal/archdocs/pssg/schema/jsonld_test.go
@@ -1,8 +1,56 @@
 package schema
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
+
+func TestStepName_ShortStep(t *testing.T) {
+	short := "Mix well."
+	if got := stepName(short); got != short {
+		t.Errorf("stepName(%q) = %q, want unchanged", short, got)
+	}
+}
+
+func TestStepName_FirstSentence(t *testing.T) {
+	step := "Sauté the onions. Then add garlic and cook for 2 more minutes."
+	got := stepName(step)
+	if got != "Sauté the onions." {
+		t.Errorf("stepName first-sentence: got %q", got)
+	}
+}
+
+func TestStepName_TruncatesLongASCII(t *testing.T) {
+	long := strings.Repeat("a", 81)
+	got := stepName(long)
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("long step should end with '...', got %q", got)
+	}
+	if len([]rune(got)) > 80 {
+		t.Errorf("truncated step too long: %d runes", len([]rune(got)))
+	}
+}
+
+// TestStepName_MultiByteUTF8 is the regression test for the byte-based slicing
+// bug: a step whose byte length exceeds 80 but rune count is near the boundary
+// must produce valid UTF-8 when truncated.
+func TestStepName_MultiByteUTF8(t *testing.T) {
+	// "é" is 2 bytes. 75 ASCII chars + 4 "é" = 75 + 8 = 83 bytes > 80,
+	// but only 79 runes — just under the limit.
+	// A step with 81 runes of "é" should be truncated to 77 "é" + "...".
+	long := strings.Repeat("é", 81) // 162 bytes, 81 runes
+	got := stepName(long)
+	if !utf8.ValidString(got) {
+		t.Errorf("stepName output contains invalid UTF-8: %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("long multi-byte step should be truncated with '...', got %q", got)
+	}
+	if strings.Contains(got, strings.Repeat("é", 81)) {
+		t.Errorf("long multi-byte step should be truncated, not returned in full")
+	}
+}
 
 func TestParseDurationMinutes(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Summary

- `stepName` in `internal/archdocs/pssg/schema/jsonld.go` used byte-based slicing (`step[:77]`) to cap long recipe instruction steps
- When a step contains multi-byte UTF-8 characters (e.g. "sauté", "jalapeño", "crème brûlée"), slicing at byte 77 can land mid-sequence, producing invalid UTF-8 in the generated JSON-LD `<script>` tag
- Fix converts to `[]rune` before truncating — same pattern already used in `ReadClaudeMD`, `dotEscape`, and other truncation points in the codebase

## Test plan

- [ ] `TestStepName_MultiByteUTF8`: 81 × "é" (162 bytes, 81 runes) — verifies output is valid UTF-8 and is truncated
- [ ] `TestStepName_ShortStep`: short step returned unchanged
- [ ] `TestStepName_FirstSentence`: first-sentence extraction unaffected
- [ ] `TestStepName_TruncatesLongASCII`: ASCII truncation still works
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string truncation logic to properly handle multi-byte UTF-8 characters without splitting them mid-character.

* **Tests**
  * Added comprehensive unit tests for instruction step string handling, covering ASCII truncation, first-sentence extraction, and UTF-8 character validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->