### PR TITLE
fix: rootCmd args parsed as directory path — breaks watch cache loading

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ enters daemon mode. Listens for file-change notifications from the
 Press Ctrl+C to stop and remove graph files.
 
 See https://supermodeltools.com for documentation.`,
-	Args:         cobra.MaximumNArgs(1),
+	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Walk up to the root command name to get the subcommand.
@@ -68,10 +68,7 @@ See https://supermodeltools.com for documentation.`,
 		if err := cfg.RequireAPIKey(); err != nil {
 			return err
 		}
-		dir := "."
-		if len(args) > 0 {
-			dir = args[0]
-		}
+		dir := watchDir
 		opts := shards.WatchOptions{
 			CacheFile:    watchCacheFile,
 			Debounce:     watchDebounce,
@@ -84,6 +81,7 @@ See https://supermodeltools.com for documentation.`,
 }
 
 var (
+	watchDir          string
 	watchCacheFile    string
 	watchDebounce     time.Duration
 	watchNotifyPort   int
@@ -92,6 +90,7 @@ var (
 )
 
 func init() {
+	rootCmd.Flags().StringVar(&watchDir, "dir", ".", "project directory")
 	rootCmd.Flags().StringVar(&watchCacheFile, "cache-file", "", "override cache file path")
 	rootCmd.Flags().DurationVar(&watchDebounce, "debounce", 2*time.Second, "debounce duration before processing changes")
 	rootCmd.Flags().IntVar(&watchNotifyPort, "notify-port", 7734, "UDP port for hook notifications")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var noConfigCommands = map[string]bool{
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "supermodel [path]",
+	Use:   "supermodel",
 	Short: "Give your AI coding agent a map of your codebase",
 	Long: `Runs a full generate on startup (using cached graph if available), then
 enters daemon mode. Listens for file-change notifications from the


### PR DESCRIPTION
## Problem

`rootCmd` accepted `MaximumNArgs(1)` and used `args[0]` as the working directory. Since watch is the default behavior on rootCmd (not a subcommand), any trailing token would be used as the directory path. The daemon would create and read from a wrong directory (e.g. `./watch/.supermodel/shards.json` instead of `./.supermodel/shards.json`), loading a stale 1-node cache instead of the 2000-node cache from `analyze`.

## Fix

Switch to `cobra.NoArgs` + explicit `--dir` flag. 4 lines changed.

## Production E2E results

Tested against production API v0.12.0 on the supermodeltools/cli repo:

| Step | Result |
|------|--------|
| analyze --force | 1993 nodes, 4471 rels, 126 shards |
| Daemon cache load | **1993 nodes** (was 1 before fix) |
| Incremental (hook → UDP → API → merge) | 1 file → 15 shards re-rendered |
| Node churn | 99% kept (10 removed, 26 added) |
| Domains | Preserved (identical before/after) |
| Dangling edges | 0 |

Fixes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Project directory must now be specified with the --dir flag (default: current directory) instead of as a positional argument.
  * CLI no longer accepts a positional path; update invocations to use, for example, `supermodel --dir /path/to/project` (or omit to use the current directory).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->