### PR TITLE
fix: rune-safe byte slicing in token estimator, error snippets, and maskKey

### DIFF
--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -245,7 +245,9 @@ func copyFileIntoZip(path string, w io.Writer) error {
 		return err
 	}
 	_, err = io.Copy(w, src)
-	src.Close()
+	if closeErr := src.Close(); err == nil {
+		err = closeErr
+	}
 	return err
 }
 

--- a/internal/analyze/zip_test.go
+++ b/internal/analyze/zip_test.go
@@ -3,6 +3,7 @@ package analyze
 import (
 	"archive/zip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -87,6 +88,30 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	}
 }
 
+func TestWalkZip_SkipsLargeFiles(t *testing.T) {
+	src := t.TempDir()
+	// Create a file just over 10 MB
+	bigFile := filepath.Join(src, "huge.dat")
+	if err := os.WriteFile(bigFile, make([]byte, 10<<20+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "small.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readZipEntries(t, dest)
+	if entries["huge.dat"] {
+		t.Error("file over 10 MB should be excluded from zip")
+	}
+	if !entries["small.go"] {
+		t.Error("small file should be included in zip")
+	}
+}
+
 func TestCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
@@ -99,6 +124,109 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	defer os.Remove(path)
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("zip file not created: %v", err)
+	}
+}
+
+func TestWalkZip_CreateDestError(t *testing.T) {
+	src := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "nonexistent-subdir", "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when dest directory does not exist")
+	}
+}
+
+func TestWalkZip_WalkError(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip("/nonexistent-dir-xyzzy-analyze", dest); err == nil {
+		t.Error("walkZip should fail when source directory does not exist")
+	}
+}
+
+func TestWalkZip_OpenFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	secret := filepath.Join(src, "secret.go")
+	if err := os.WriteFile(secret, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(secret, 0600) }) //nolint:errcheck
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when a source file cannot be opened")
+	}
+}
+
+func TestCreateZip_CreateTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
+	_, err := createZip(t.TempDir())
+	if err == nil {
+		t.Error("createZip should fail when os.CreateTemp fails")
+	}
+}
+
+func TestCreateZip_NonExistentDir(t *testing.T) {
+	_, err := createZip("/nonexistent-dir-analyze-createzip-xyz")
+	if err == nil {
+		t.Error("createZip should fail when directory does not exist")
+	}
+}
+
+func initCleanAnalyzeGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "ci@test.local")
+	run("git", "config", "user.name", "CI")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	return dir
+}
+
+func TestGitArchive_CleanRepo(t *testing.T) {
+	dir := initCleanAnalyzeGitRepo(t)
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := gitArchive(dir, dest); err != nil {
+		t.Fatalf("gitArchive: %v", err)
+	}
+	entries := readZipEntries(t, dest)
+	if !entries["main.go"] {
+		t.Error("git archive should contain main.go")
+	}
+}
+
+func TestIsWorktreeClean_CleanRepo(t *testing.T) {
+	dir := initCleanAnalyzeGitRepo(t)
+	if !isWorktreeClean(dir) {
+		t.Error("freshly committed repo should be considered clean")
+	}
+}
+
+func TestCreateZip_CleanGitRepo(t *testing.T) {
+	dir := initCleanAnalyzeGitRepo(t)
+	path, err := createZip(dir)
+	if err != nil {
+		t.Fatalf("createZip on clean git repo: %v", err)
+	}
+	defer os.Remove(path)
+	entries := readZipEntries(t, path)
+	if !entries["main.go"] {
+		t.Error("zip should contain main.go from git archive")
 	}
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -313,8 +313,8 @@ func (c *Client) request(ctx context.Context, method, path, contentType string, 
 			return &apiErr
 		}
 		snippet := string(respBody)
-		if len(snippet) > 300 {
-			snippet = snippet[:300] + "..."
+		if runes := []rune(snippet); len(runes) > 300 {
+			snippet = string(runes[:300]) + "..."
 		}
 		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, snippet)
 	}

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -232,6 +232,15 @@ func TestError_Error_WithoutCode(t *testing.T) {
 	}
 }
 
+func TestError_Error_FallsBackToStatus(t *testing.T) {
+	// When StatusCode is 0, Error() should use the Status field.
+	e := &Error{StatusCode: 0, Status: 404, Message: "not found"}
+	got := e.Error()
+	if !containsStr(got, "404") {
+		t.Errorf("Error() = %q, should contain '404' (from Status field)", got)
+	}
+}
+
 // ── GraphFromShardIR ──────────────────────────────────────────────────────────
 
 func TestGraphFromShardIR_NodesAndRels(t *testing.T) {

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -232,6 +232,108 @@ func TestError_Error_WithoutCode(t *testing.T) {
 	}
 }
 
+// ── GraphFromShardIR ──────────────────────────────────────────────────────────
+
+func TestGraphFromShardIR_NodesAndRels(t *testing.T) {
+	ir := &ShardIR{
+		Repo: "myorg/myrepo",
+		Graph: ShardGraph{
+			Nodes: []Node{
+				{ID: "n1", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+				{ID: "n2", Labels: []string{"Function"}, Properties: map[string]any{"name": "doThing"}},
+			},
+			Relationships: []Relationship{
+				{ID: "r1", Type: "defines_function", StartNode: "n1", EndNode: "n2"},
+			},
+		},
+	}
+	g := GraphFromShardIR(ir)
+
+	if len(g.Nodes) != 2 {
+		t.Errorf("nodes: got %d, want 2", len(g.Nodes))
+	}
+	if len(g.Relationships) != 1 {
+		t.Errorf("relationships: got %d, want 1", len(g.Relationships))
+	}
+	if g.Nodes[0].ID != "n1" {
+		t.Errorf("first node ID: got %q", g.Nodes[0].ID)
+	}
+}
+
+func TestGraphFromShardIR_RepoID(t *testing.T) {
+	ir := &ShardIR{Repo: "acme/backend"}
+	g := GraphFromShardIR(ir)
+	if got := g.RepoID(); got != "acme/backend" {
+		t.Errorf("RepoID: got %q, want 'acme/backend'", got)
+	}
+}
+
+func TestGraphFromShardIR_RelsViaRels(t *testing.T) {
+	// Rels() should return the Relationships slice (not Edges)
+	ir := &ShardIR{
+		Graph: ShardGraph{
+			Relationships: []Relationship{
+				{ID: "r1", Type: "imports"},
+				{ID: "r2", Type: "calls"},
+			},
+		},
+	}
+	g := GraphFromShardIR(ir)
+	rels := g.Rels()
+	if len(rels) != 2 {
+		t.Errorf("Rels(): got %d, want 2", len(rels))
+	}
+}
+
+func TestGraphFromShardIR_Empty(t *testing.T) {
+	ir := &ShardIR{}
+	g := GraphFromShardIR(ir)
+	if g == nil {
+		t.Fatal("GraphFromShardIR returned nil")
+	}
+	if len(g.Nodes) != 0 {
+		t.Errorf("empty IR: expected 0 nodes, got %d", len(g.Nodes))
+	}
+	if g.RepoID() != "" {
+		t.Errorf("empty IR: expected empty repoId, got %q", g.RepoID())
+	}
+}
+
+func TestGraphFromShardIR_NodeByID(t *testing.T) {
+	ir := &ShardIR{
+		Graph: ShardGraph{
+			Nodes: []Node{
+				{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "myFunc"}},
+			},
+		},
+	}
+	g := GraphFromShardIR(ir)
+	n, ok := g.NodeByID("fn1")
+	if !ok {
+		t.Fatal("NodeByID('fn1') returned false")
+	}
+	if n.Prop("name") != "myFunc" {
+		t.Errorf("name prop: got %q", n.Prop("name"))
+	}
+}
+
+func TestGraphFromShardIR_NodesByLabel(t *testing.T) {
+	ir := &ShardIR{
+		Graph: ShardGraph{
+			Nodes: []Node{
+				{ID: "f1", Labels: []string{"File"}},
+				{ID: "fn1", Labels: []string{"Function"}},
+				{ID: "f2", Labels: []string{"File"}},
+			},
+		},
+	}
+	g := GraphFromShardIR(ir)
+	files := g.NodesByLabel("File")
+	if len(files) != 2 {
+		t.Errorf("NodesByLabel('File'): got %d, want 2", len(files))
+	}
+}
+
 func containsStr(s, sub string) bool {
 	return len(s) >= len(sub) && (s == sub ||
 		func() bool {

--- a/internal/archdocs/graph2md/graph2md_test.go
+++ b/internal/archdocs/graph2md/graph2md_test.go
@@ -62,6 +62,312 @@ func buildGraphJSON(t *testing.T, nodes []Node, rels []Relationship) string {
 	return f.Name()
 }
 
+// ── getStr ────────────────────────────────────────────────────────────────────
+
+func TestGetStr(t *testing.T) {
+	m := map[string]interface{}{"name": "foo", "num": 42, "empty": ""}
+	if got := getStr(m, "name"); got != "foo" {
+		t.Errorf("got %q, want %q", got, "foo")
+	}
+	if got := getStr(m, "num"); got != "" {
+		t.Errorf("non-string: got %q, want empty", got)
+	}
+	if got := getStr(m, "missing"); got != "" {
+		t.Errorf("missing key: got %q, want empty", got)
+	}
+	if got := getStr(m, "empty"); got != "" {
+		t.Errorf("empty string: got %q, want empty", got)
+	}
+}
+
+// ── getNum ────────────────────────────────────────────────────────────────────
+
+func TestGetNum(t *testing.T) {
+	m := map[string]interface{}{"f64": float64(7), "i": 9, "str": "x"}
+	if got := getNum(m, "f64"); got != 7 {
+		t.Errorf("float64: got %d, want 7", got)
+	}
+	if got := getNum(m, "i"); got != 9 {
+		t.Errorf("int: got %d, want 9", got)
+	}
+	if got := getNum(m, "str"); got != 0 {
+		t.Errorf("wrong type: got %d, want 0", got)
+	}
+	if got := getNum(m, "missing"); got != 0 {
+		t.Errorf("missing key: got %d, want 0", got)
+	}
+}
+
+// ── mermaidID ─────────────────────────────────────────────────────────────────
+
+func TestMermaidID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"fn:src/foo.go:bar", "fn_src_foo_go_bar"},
+		{"hello_world", "hello_world"},
+		{"ABC123", "ABC123"},
+		{"", "node"},
+		{"---", "___"},
+	}
+	for _, tc := range cases {
+		got := mermaidID(tc.in)
+		if got != tc.want {
+			t.Errorf("mermaidID(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── generateSlug ─────────────────────────────────────────────────────────────
+
+func TestGenerateSlug_File(t *testing.T) {
+	n := Node{Properties: map[string]interface{}{"path": "src/main.go"}}
+	got := generateSlug(n, "File")
+	if !strings.HasPrefix(got, "file-") {
+		t.Errorf("File slug: got %q, want prefix 'file-'", got)
+	}
+	// empty path → empty slug
+	n2 := Node{Properties: map[string]interface{}{}}
+	if got2 := generateSlug(n2, "File"); got2 != "" {
+		t.Errorf("empty path File slug: got %q, want empty", got2)
+	}
+}
+
+func TestGenerateSlug_Function(t *testing.T) {
+	n := Node{Properties: map[string]interface{}{"name": "run", "filePath": "internal/api/handler.go"}}
+	got := generateSlug(n, "Function")
+	if !strings.HasPrefix(got, "fn-") {
+		t.Errorf("Function slug with path: got %q, want prefix 'fn-'", got)
+	}
+	n2 := Node{Properties: map[string]interface{}{"name": "run"}}
+	got2 := generateSlug(n2, "Function")
+	if !strings.HasPrefix(got2, "fn-") {
+		t.Errorf("Function slug without path: got %q, want prefix 'fn-'", got2)
+	}
+	n3 := Node{Properties: map[string]interface{}{}}
+	if got3 := generateSlug(n3, "Function"); got3 != "" {
+		t.Errorf("empty name: got %q, want empty", got3)
+	}
+}
+
+func TestGenerateSlug_ClassTypeLabels(t *testing.T) {
+	for _, label := range []string{"Class", "Type"} {
+		prefix := strings.ToLower(label) + "-"
+		n := Node{Properties: map[string]interface{}{"name": "MyEntity", "filePath": "src/foo.go"}}
+		got := generateSlug(n, label)
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("%s slug: got %q, want prefix %q", label, got, prefix)
+		}
+		n2 := Node{Properties: map[string]interface{}{"name": "MyEntity"}}
+		got2 := generateSlug(n2, label)
+		if !strings.HasPrefix(got2, prefix) {
+			t.Errorf("%s slug without path: got %q, want prefix %q", label, got2, prefix)
+		}
+		n3 := Node{Properties: map[string]interface{}{}}
+		if got3 := generateSlug(n3, label); got3 != "" {
+			t.Errorf("%s empty name: got %q, want empty", label, got3)
+		}
+	}
+}
+
+func TestGenerateSlug_DomainSubdomain(t *testing.T) {
+	dn := Node{Properties: map[string]interface{}{"name": "auth"}}
+	if got := generateSlug(dn, "Domain"); !strings.HasPrefix(got, "domain-") {
+		t.Errorf("Domain: got %q, want prefix 'domain-'", got)
+	}
+	sn := Node{Properties: map[string]interface{}{"name": "users"}}
+	if got := generateSlug(sn, "Subdomain"); !strings.HasPrefix(got, "subdomain-") {
+		t.Errorf("Subdomain: got %q, want prefix 'subdomain-'", got)
+	}
+	empty := Node{Properties: map[string]interface{}{}}
+	if got := generateSlug(empty, "Domain"); got != "" {
+		t.Errorf("Domain empty name: got %q, want empty", got)
+	}
+	if got := generateSlug(empty, "Subdomain"); got != "" {
+		t.Errorf("Subdomain empty name: got %q, want empty", got)
+	}
+}
+
+func TestGenerateSlug_Directory(t *testing.T) {
+	n := Node{Properties: map[string]interface{}{"path": "internal/api"}}
+	if got := generateSlug(n, "Directory"); !strings.HasPrefix(got, "dir-") {
+		t.Errorf("Directory: got %q, want prefix 'dir-'", got)
+	}
+	// path containing /app/repo-root/ → empty
+	n2 := Node{Properties: map[string]interface{}{"path": "/app/repo-root/internal"}}
+	if got := generateSlug(n2, "Directory"); got != "" {
+		t.Errorf("repo-root path: got %q, want empty", got)
+	}
+	// empty path → empty
+	n3 := Node{Properties: map[string]interface{}{}}
+	if got := generateSlug(n3, "Directory"); got != "" {
+		t.Errorf("empty path: got %q, want empty", got)
+	}
+}
+
+func TestGenerateSlug_Unknown(t *testing.T) {
+	n := Node{Properties: map[string]interface{}{"name": "foo"}}
+	if got := generateSlug(n, "Unknown"); got != "" {
+		t.Errorf("unknown label: got %q, want empty", got)
+	}
+}
+
+// ── node-type rendering ───────────────────────────────────────────────────────
+
+// TestRunClassNode verifies that a Class node generates a markdown file
+// containing class-specific frontmatter fields.
+func TestRunClassNode(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "class:src/auth.go:UserAuth",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{
+				"name":      "UserAuth",
+				"filePath":  "src/auth.go",
+				"startLine": float64(10),
+				"endLine":   float64(50),
+				"language":  "go",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "https://github.com/example/myrepo", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, err := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(content)
+	for _, want := range []string{`node_type: "Class"`, `class_name: "UserAuth"`, `language: "go"`, `start_line: 10`, `end_line: 50`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in class output:\n%s", want, body)
+		}
+	}
+}
+
+// TestRunTypeNode verifies that a Type node generates type-specific frontmatter.
+func TestRunTypeNode(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "type:src/types.go:UserID",
+			Labels: []string{"Type"},
+			Properties: map[string]interface{}{
+				"name":     "UserID",
+				"filePath": "src/types.go",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	body := string(content)
+	for _, want := range []string{`node_type: "Type"`, `type_name: "UserID"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in type output:\n%s", want, body)
+		}
+	}
+}
+
+// TestRunDomainNode verifies that a Domain node generates domain-specific frontmatter.
+func TestRunDomainNode(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "domain:auth",
+			Labels: []string{"Domain"},
+			Properties: map[string]interface{}{
+				"name":        "auth",
+				"description": "Authentication domain",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	body := string(content)
+	for _, want := range []string{`node_type: "Domain"`, `domain: "auth"`, `summary: "Authentication domain"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in domain output:\n%s", want, body)
+		}
+	}
+}
+
+// TestRunSubdomainNode verifies that a Subdomain node generates subdomain frontmatter.
+func TestRunSubdomainNode(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "subdomain:users",
+			Labels: []string{"Subdomain"},
+			Properties: map[string]interface{}{
+				"name": "users",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	body := string(content)
+	for _, want := range []string{`node_type: "Subdomain"`, `subdomain: "users"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in subdomain output:\n%s", want, body)
+		}
+	}
+}
+
+// TestRunDirectoryNode verifies that a Directory node generates directory frontmatter.
+func TestRunDirectoryNode(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "dir:internal/api",
+			Labels: []string{"Directory"},
+			Properties: map[string]interface{}{
+				"name": "api",
+				"path": "internal/api",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	body := string(content)
+	for _, want := range []string{`node_type: "Directory"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in directory output:\n%s", want, body)
+		}
+	}
+}
+
 // TestSlugCollisionResolution verifies that when two nodes produce the same
 // base slug, the second gets a "-2" suffix, AND that a third node which
 // naturally produces that same "-2" slug does not silently collide with it.

--- a/internal/archdocs/graph2md/graph2md_test.go
+++ b/internal/archdocs/graph2md/graph2md_test.go
@@ -2,6 +2,7 @@ package graph2md
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -368,6 +369,314 @@ func TestRunDirectoryNode(t *testing.T) {
 	}
 }
 
+// TestRunTypeNodeWithFile verifies that a Type node with a DEFINES relationship
+// generates the "Defined In" body section and the GitHub source link.
+func TestRunTypeNodeWithFile(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "file:src/types.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"filePath": "src/types.go",
+				"path":     "src/types.go",
+			},
+		},
+		{
+			ID:     "type:src/types.go:UserID",
+			Labels: []string{"Type"},
+			Properties: map[string]interface{}{
+				"name":      "UserID",
+				"filePath":  "src/types.go",
+				"startLine": float64(5),
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DEFINES", StartNode: "file:src/types.go", EndNode: "type:src/types.go:UserID"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "https://github.com/example/myrepo", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var typeFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "type-") {
+			typeFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if typeFile == "" {
+		t.Fatal("no type markdown file generated")
+	}
+	content, _ := os.ReadFile(typeFile)
+	body := string(content)
+	if !strings.Contains(body, "Defined In") {
+		t.Errorf("type with DEFINES rel should have 'Defined In' section:\n%s", body)
+	}
+	if !strings.Contains(body, "View on GitHub") {
+		t.Errorf("type with repoURL should have GitHub source link:\n%s", body)
+	}
+}
+
+// TestRunDomainWithSubdomains verifies that a Domain node linked to Subdomains
+// via partOf relationships generates Subdomains and Source Files body sections.
+func TestRunDomainWithSubdomains(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "domain:auth",
+			Labels: []string{"Domain"},
+			Properties: map[string]interface{}{
+				"name":        "auth",
+				"description": "Auth domain",
+			},
+		},
+		{
+			ID:     "subdomain:login",
+			Labels: []string{"Subdomain"},
+			Properties: map[string]interface{}{
+				"name": "login",
+			},
+		},
+		{
+			ID:     "file:src/auth.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"filePath": "src/auth.go",
+				"path":     "src/auth.go",
+			},
+		},
+		{
+			ID:     "fn:src/auth.go:Login",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{
+				"name":     "Login",
+				"filePath": "src/auth.go",
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "partOf", StartNode: "subdomain:login", EndNode: "domain:auth"},
+		{ID: "r2", Type: "DEFINES_FUNCTION", StartNode: "file:src/auth.go", EndNode: "fn:src/auth.go:Login"},
+		{ID: "r3", Type: "belongsTo", StartNode: "fn:src/auth.go:Login", EndNode: "domain:auth"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the domain markdown file
+	entries, _ := os.ReadDir(outDir)
+	var domainFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "domain-") {
+			domainFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if domainFile == "" {
+		t.Fatal("no domain markdown file generated")
+	}
+	content, _ := os.ReadFile(domainFile)
+	body := string(content)
+	if !strings.Contains(body, "Subdomains") {
+		t.Errorf("domain with subdomains should have 'Subdomains' section:\n%s", body)
+	}
+	if !strings.Contains(body, "Source Files") {
+		t.Errorf("domain with files should have 'Source Files' section:\n%s", body)
+	}
+}
+
+// TestRunSubdomainWithFunctions verifies that a Subdomain node renders its
+// parent domain link and linked functions.
+func TestRunSubdomainWithFunctions(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "domain:auth",
+			Labels: []string{"Domain"},
+			Properties: map[string]interface{}{
+				"name": "auth",
+			},
+		},
+		{
+			ID:     "subdomain:login",
+			Labels: []string{"Subdomain"},
+			Properties: map[string]interface{}{
+				"name": "login",
+			},
+		},
+		{
+			ID:     "fn:src/login.go:Login",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{
+				"name":     "Login",
+				"filePath": "src/login.go",
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "partOf", StartNode: "subdomain:login", EndNode: "domain:auth"},
+		{ID: "r2", Type: "belongsTo", StartNode: "fn:src/login.go:Login", EndNode: "subdomain:login"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find the subdomain markdown file
+	entries, _ := os.ReadDir(outDir)
+	var subFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "subdomain-") {
+			subFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if subFile == "" {
+		t.Fatal("no subdomain markdown file generated")
+	}
+	content, _ := os.ReadFile(subFile)
+	body := string(content)
+	if !strings.Contains(body, "Domain") {
+		t.Errorf("subdomain with parent domain should have 'Domain' section:\n%s", body)
+	}
+	if !strings.Contains(body, "Functions") {
+		t.Errorf("subdomain with functions should have 'Functions' section:\n%s", body)
+	}
+}
+
+// TestRunClassNodeWithRelationships verifies that a Class node with a DECLARES_CLASS
+// relationship generates the "Defined In" and "Extends" body sections.
+func TestRunClassNodeWithRelationships(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "file:src/models.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"filePath": "src/models.go",
+				"path":     "src/models.go",
+			},
+		},
+		{
+			ID:     "class:src/models.go:Animal",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{
+				"name":      "Animal",
+				"filePath":  "src/models.go",
+				"startLine": float64(10),
+			},
+		},
+		{
+			ID:     "class:src/models.go:Dog",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{
+				"name":     "Dog",
+				"filePath": "src/models.go",
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DECLARES_CLASS", StartNode: "file:src/models.go", EndNode: "class:src/models.go:Animal"},
+		{ID: "r2", Type: "DECLARES_CLASS", StartNode: "file:src/models.go", EndNode: "class:src/models.go:Dog"},
+		{ID: "r3", Type: "EXTENDS", StartNode: "class:src/models.go:Dog", EndNode: "class:src/models.go:Animal"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "https://github.com/example/myrepo", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entries, _ := os.ReadDir(outDir)
+	var dogFile string
+	for _, e := range entries {
+		content, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(content), `class_name: "Dog"`) {
+			dogFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if dogFile == "" {
+		t.Fatal("Dog class markdown file not found")
+	}
+	content, _ := os.ReadFile(dogFile)
+	body := string(content)
+	if !strings.Contains(body, "Defined In") {
+		t.Errorf("class with DECLARES_CLASS rel should have 'Defined In' section:\n%s", body)
+	}
+	if !strings.Contains(body, "Extends") {
+		t.Errorf("class with EXTENDS rel should have 'Extends' section:\n%s", body)
+	}
+	if !strings.Contains(body, "View on GitHub") {
+		t.Errorf("class with repoURL and filePath should have GitHub link:\n%s", body)
+	}
+}
+
+// TestRunDirectoryWithFilesAndSubdirs verifies that a Directory node with
+// CONTAINS_FILE and CHILD_DIRECTORY relationships generates body sections.
+func TestRunDirectoryWithFilesAndSubdirs(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "dir:src",
+			Labels: []string{"Directory"},
+			Properties: map[string]interface{}{
+				"name": "src",
+				"path": "src",
+			},
+		},
+		{
+			ID:     "dir:src/internal",
+			Labels: []string{"Directory"},
+			Properties: map[string]interface{}{
+				"name": "internal",
+				"path": "src/internal",
+			},
+		},
+		{
+			ID:     "file:src/main.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"filePath": "src/main.go",
+				"path":     "src/main.go",
+				"name":     "main.go",
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "CHILD_DIRECTORY", StartNode: "dir:src", EndNode: "dir:src/internal"},
+		{ID: "r2", Type: "CONTAINS_FILE", StartNode: "dir:src", EndNode: "file:src/main.go"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entries, _ := os.ReadDir(outDir)
+	var srcDirFile string
+	for _, e := range entries {
+		content, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		// Match the top-level "src" directory specifically via its dir_path frontmatter
+		if strings.Contains(string(content), `dir_path: "src"`) {
+			srcDirFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if srcDirFile == "" {
+		t.Fatal("src directory markdown file not found")
+	}
+	content, _ := os.ReadFile(srcDirFile)
+	body := string(content)
+	if !strings.Contains(body, "Subdirectories") {
+		t.Errorf("directory with CHILD_DIRECTORY should have 'Subdirectories' section:\n%s", body)
+	}
+	if !strings.Contains(body, "Files") {
+		t.Errorf("directory with CONTAINS_FILE should have 'Files' section:\n%s", body)
+	}
+}
+
 // TestSlugCollisionResolution verifies that when two nodes produce the same
 // base slug, the second gets a "-2" suffix, AND that a third node which
 // naturally produces that same "-2" slug does not silently collide with it.
@@ -558,4 +867,2146 @@ func TestGraphDataLineCountMissingStartLine(t *testing.T) {
 	if fnLC != 50 {
 		t.Errorf("graph_data lc = %d, want 50 (endLine=50, effectiveStart=1)", fnLC)
 	}
+}
+
+// ── writeFunctionBody domain+subdomain+source ─────────────────────────────────
+
+// TestRunFunctionBodyWithDomainAndSubdomain covers:
+//   - writeFunctionBody: Domain section, Subdomains section
+//   - writeFunctionBody: source link with startLine (#L5)
+//   - writeMermaidDiagram Function case: fileOfFunc → nodeCount=2 → diagram written
+func TestRunFunctionBodyWithDomainAndSubdomain(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:auth", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "auth"}},
+		{ID: "subdomain:login", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "login"}},
+		{
+			ID:     "file:src/login.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/login.go"},
+		},
+		{
+			ID:     "fn:src/login.go:Login",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{
+				"name": "Login", "filePath": "src/login.go", "startLine": float64(5),
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DEFINES_FUNCTION", StartNode: "file:src/login.go", EndNode: "fn:src/login.go:Login"},
+		{ID: "r2", Type: "belongsTo", StartNode: "fn:src/login.go:Login", EndNode: "subdomain:login"},
+		{ID: "r3", Type: "partOf", StartNode: "subdomain:login", EndNode: "domain:auth"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "https://github.com/example/myrepo", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fnFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "fn-") {
+			fnFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if fnFile == "" {
+		t.Fatal("function markdown file not found")
+	}
+	content, _ := os.ReadFile(fnFile)
+	body := string(content)
+	if !strings.Contains(body, "## Domain") {
+		t.Errorf("should have Domain section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Subdomains") {
+		t.Errorf("should have Subdomains section:\n%s", body)
+	}
+	if !strings.Contains(body, "#L5") {
+		t.Errorf("should have source link with line number #L5:\n%s", body)
+	}
+	if !strings.Contains(body, "mermaid_diagram:") {
+		t.Errorf("function with file relation should have mermaid diagram:\n%s", body)
+	}
+}
+
+// ── writeTypeBody domain+subdomain+source ─────────────────────────────────────
+
+// TestRunTypeBodyWithDomainSubdomainAndSource covers:
+//   - writeTypeBody: Domain section, Subdomains section
+//   - writeTypeBody: source link with startLine (#L10)
+//   - writeMermaidDiagram Type case: fileOfType → nodeCount=2 → diagram written
+func TestRunTypeBodyWithDomainSubdomainAndSource(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:core", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "core"}},
+		{ID: "subdomain:types", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "types"}},
+		{
+			ID:     "file:src/types.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/types.go"},
+		},
+		{
+			ID:     "type:src/types.go:UserID",
+			Labels: []string{"Type"},
+			Properties: map[string]interface{}{
+				"name": "UserID", "filePath": "src/types.go", "startLine": float64(10),
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DEFINES", StartNode: "file:src/types.go", EndNode: "type:src/types.go:UserID"},
+		{ID: "r2", Type: "belongsTo", StartNode: "type:src/types.go:UserID", EndNode: "subdomain:types"},
+		{ID: "r3", Type: "partOf", StartNode: "subdomain:types", EndNode: "domain:core"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "https://github.com/example/myrepo", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var typeFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "type-") {
+			typeFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if typeFile == "" {
+		t.Fatal("type markdown file not found")
+	}
+	content, _ := os.ReadFile(typeFile)
+	body := string(content)
+	if !strings.Contains(body, "## Domain") {
+		t.Errorf("type should have Domain section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Subdomains") {
+		t.Errorf("type should have Subdomains section:\n%s", body)
+	}
+	if !strings.Contains(body, "#L10") {
+		t.Errorf("type should have source link with line number #L10:\n%s", body)
+	}
+	if !strings.Contains(body, "mermaid_diagram:") {
+		t.Errorf("type with file relation should have mermaid diagram:\n%s", body)
+	}
+}
+
+// ── writeClassBody domain+subdomain ──────────────────────────────────────────
+
+// TestRunClassBodyWithDomainAndSubdomain covers:
+//   - writeClassBody: Domain section, Subdomains section
+func TestRunClassBodyWithDomainAndSubdomain(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:models", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "models"}},
+		{ID: "subdomain:entities", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "entities"}},
+		{
+			ID:     "class:src/user.go:User",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "User", "filePath": "src/user.go"},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "belongsTo", StartNode: "class:src/user.go:User", EndNode: "subdomain:entities"},
+		{ID: "r2", Type: "partOf", StartNode: "subdomain:entities", EndNode: "domain:models"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var classFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "class-") {
+			classFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if classFile == "" {
+		t.Fatal("class markdown file not found")
+	}
+	content, _ := os.ReadFile(classFile)
+	body := string(content)
+	if !strings.Contains(body, "## Domain") {
+		t.Errorf("class should have Domain section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Subdomains") {
+		t.Errorf("class should have Subdomains section:\n%s", body)
+	}
+}
+
+// ── writeSubdomainBody classes+files ─────────────────────────────────────────
+
+// TestRunSubdomainWithClassesAndFiles covers:
+//   - writeSubdomainBody: Classes section (subdomainClasses populated via belongsTo)
+//   - writeSubdomainBody: Source Files section (subdomainFiles populated via direct belongsTo)
+//   - writeMermaidDiagram Subdomain case: subdomainFiles non-empty → nodeCount>=2 → diagram
+func TestRunSubdomainWithClassesAndFiles(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:core", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "core"}},
+		{ID: "subdomain:models", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "models"}},
+		{
+			ID:     "class:src/models.go:User",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "User", "filePath": "src/models.go"},
+		},
+		{
+			ID:     "file:src/models.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/models.go"},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "partOf", StartNode: "subdomain:models", EndNode: "domain:core"},
+		// Class belongsTo subdomain → subdomainClasses["models"] populated
+		{ID: "r2", Type: "belongsTo", StartNode: "class:src/models.go:User", EndNode: "subdomain:models"},
+		// File belongsTo subdomain → subdomainFiles["models"] populated
+		{ID: "r3", Type: "belongsTo", StartNode: "file:src/models.go", EndNode: "subdomain:models"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var subFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "subdomain-") {
+			subFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if subFile == "" {
+		t.Fatal("subdomain markdown file not found")
+	}
+	content, _ := os.ReadFile(subFile)
+	body := string(content)
+	if !strings.Contains(body, "## Classes") {
+		t.Errorf("subdomain should have Classes section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Source Files") {
+		t.Errorf("subdomain should have Source Files section:\n%s", body)
+	}
+	if !strings.Contains(body, "mermaid_diagram:") {
+		t.Errorf("subdomain with file should have mermaid diagram:\n%s", body)
+	}
+}
+
+// ── writeMermaidDiagram Function case ────────────────────────────────────────
+
+// TestRunFunctionMermaidWithCallsAndCalledBy covers:
+//   - writeMermaidDiagram Function case: calledBy loop body and calls loop body
+//   - writeFunctionBody: Calls and Called By sections
+//   - writeFAQSection Function case: "What does X call?" and "What calls X?"
+func TestRunFunctionMermaidWithCallsAndCalledBy(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "src/a.go"}},
+		{ID: "fn:src/b.go:B", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "B", "filePath": "src/b.go"}},
+		{ID: "fn:src/c.go:C", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "C", "filePath": "src/c.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "calls", StartNode: "fn:src/a.go:A", EndNode: "fn:src/b.go:B"},
+		{ID: "r2", Type: "calls", StartNode: "fn:src/c.go:C", EndNode: "fn:src/a.go:A"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var aFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "A"`) {
+			aFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if aFile == "" {
+		t.Fatal("function A markdown file not found")
+	}
+	content, _ := os.ReadFile(aFile)
+	body := string(content)
+	if !strings.Contains(body, "## Calls") {
+		t.Errorf("function A should have Calls section:\n%s", body)
+	}
+	if !strings.Contains(body, "## Called By") {
+		t.Errorf("function A should have Called By section:\n%s", body)
+	}
+	if !strings.Contains(body, "mermaid_diagram:") {
+		t.Errorf("function with calls/calledBy should have mermaid diagram:\n%s", body)
+	}
+}
+
+// ── writeTags branches ────────────────────────────────────────────────────────
+
+// TestRunFileBodyHighDependencyTag covers:
+//   - writeTags: "High-Dependency" tag (ibCount >= 5)
+//   - writeFAQSection File case: importedBy list with >8 entries truncated
+func TestRunFileBodyHighDependencyTag(t *testing.T) {
+	nodes := []Node{
+		{ID: "file:center.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "center.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 9; i++ {
+		id := fmt.Sprintf("file:importer%d.go", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("importer%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "IMPORTS",
+			StartNode: id, EndNode: "file:center.go",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var centerFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "center.go"`) {
+			centerFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if centerFile == "" {
+		t.Fatal("center file markdown not found")
+	}
+	content := string(must(os.ReadFile(centerFile)))
+	if !strings.Contains(content, "High-Dependency") {
+		t.Errorf("file with 9 importers should have High-Dependency tag:\n%s", content)
+	}
+	// FAQ truncation: 9 importedBy > 8 → "and 1 more"
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("importedBy list should be truncated with 'and 1 more':\n%s", content)
+	}
+}
+
+// TestRunFileBodyManyImportsTag covers:
+//   - writeTags: "Many-Imports" tag (impCount >= 5)
+//   - writeFAQSection File case: deps list with >8 entries truncated
+func TestRunFileBodyManyImportsTag(t *testing.T) {
+	nodes := []Node{
+		{ID: "file:main.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "main.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 9; i++ {
+		id := fmt.Sprintf("file:dep%d.go", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("dep%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "IMPORTS",
+			StartNode: "file:main.go", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var mainFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "main.go"`) {
+			mainFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if mainFile == "" {
+		t.Fatal("main file markdown not found")
+	}
+	content := string(must(os.ReadFile(mainFile)))
+	if !strings.Contains(content, "Many-Imports") {
+		t.Errorf("file with 9 imports should have Many-Imports tag:\n%s", content)
+	}
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("deps list should be truncated with 'and 1 more':\n%s", content)
+	}
+}
+
+// TestRunFileBodyComplexTag covers:
+//   - writeTags: "Complex" tag (funcCount >= 10)
+//   - writeFAQSection File case: functions list with >10 entries truncated
+func TestRunFileBodyComplexTag(t *testing.T) {
+	nodes := []Node{
+		{ID: "file:big.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "big.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 11; i++ {
+		fnID := fmt.Sprintf("fn:big.go:Func%d", i)
+		nodes = append(nodes, Node{
+			ID: fnID, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Func%d", i), "filePath": "big.go"},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "DEFINES_FUNCTION",
+			StartNode: "file:big.go", EndNode: fnID,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var bigFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "big.go"`) {
+			bigFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if bigFile == "" {
+		t.Fatal("big.go markdown not found")
+	}
+	content := string(must(os.ReadFile(bigFile)))
+	if !strings.Contains(content, "Complex") {
+		t.Errorf("file with 11 functions should have Complex tag:\n%s", content)
+	}
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("functions list should be truncated with 'and 1 more':\n%s", content)
+	}
+}
+
+// ── resolveNameWithPath branches ──────────────────────────────────────────────
+
+// TestResolveNameWithPathBranches covers:
+//   - resolveNameWithPath: n == nil → returns nodeID
+//   - resolveNameWithPath: path="" name!="" → returns name field
+//   - resolveNameWithPath: path="" name="" → returns nodeID
+//   - internalLink: !ok (node not in slugLookup) → returns html.EscapeString(label)
+func TestResolveNameWithPathBranches(t *testing.T) {
+	nodes := []Node{
+		// Center file: will show "Imported By" section → resolveNameWithPath called on importers
+		{
+			ID:     "file:center.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "center.go"},
+		},
+		// Name-only file: no path/filePath, only name — slug="" so no output file but in nodeLookup.
+		// resolveNameWithPath(id) → returns "helper.go" (name-only branch).
+		{
+			ID:     "file:name-only",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"name": "helper.go"},
+		},
+		// Empty-props file: neither path nor name → resolveNameWithPath returns nodeID.
+		{
+			ID:         "file:empty-props",
+			Labels:     []string{"File"},
+			Properties: map[string]interface{}{},
+		},
+		// Function whose "Defined In" file doesn't exist in nodeLookup.
+		// fileOfFunc["fn:ghost"] = "file:ghost-file" (not in nodes) → resolveNameWithPath n==nil.
+		{
+			ID:     "fn:ghost",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": "Ghost", "filePath": "ghost.go"},
+		},
+	}
+	rels := []Relationship{
+		// name-only and empty-props import center → importedBy[center] = [name-only, empty-props]
+		{ID: "r1", Type: "IMPORTS", StartNode: "file:name-only", EndNode: "file:center.go"},
+		{ID: "r2", Type: "IMPORTS", StartNode: "file:empty-props", EndNode: "file:center.go"},
+		// DEFINES_FUNCTION from a file NOT in nodes → fileOfFunc["fn:ghost"] = "file:ghost-file"
+		// resolveNameWithPath("file:ghost-file") → n==nil → returns "file:ghost-file"
+		{ID: "r3", Type: "DEFINES_FUNCTION", StartNode: "file:ghost-file", EndNode: "fn:ghost"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Find center.go output
+	entries, _ := os.ReadDir(outDir)
+	var centerFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "center.go"`) {
+			centerFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if centerFile == "" {
+		t.Fatal("center.go markdown not found")
+	}
+	centerContent := string(must(os.ReadFile(centerFile)))
+	// name-only file's resolveNameWithPath returns "helper.go"
+	if !strings.Contains(centerContent, "helper.go") {
+		t.Errorf("Imported By should show 'helper.go' from name-only node:\n%s", centerContent)
+	}
+
+	// Find fn:ghost output
+	var ghostFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "Ghost"`) {
+			ghostFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if ghostFile == "" {
+		t.Fatal("Ghost function markdown not found")
+	}
+	ghostContent := string(must(os.ReadFile(ghostFile)))
+	// "Defined In" uses resolveNameWithPath("file:ghost-file") → n==nil → returns "file:ghost-file"
+	if !strings.Contains(ghostContent, "file:ghost-file") {
+		t.Errorf("Ghost fn 'Defined In' should show raw nodeID for missing file:\n%s", ghostContent)
+	}
+}
+
+// ── loadGraph format branches ─────────────────────────────────────────────────
+
+// TestLoadGraph_GraphResultFormat verifies that Run can parse a GraphResult-wrapped
+// JSON ({"graph":{"nodes":[...],"relationships":[...]}} — the format returned by
+// some API endpoints).
+func TestLoadGraph_GraphResultFormat(t *testing.T) {
+	gr := GraphResult{
+		Graph: Graph{
+			Nodes: []Node{
+				{ID: "fn:a.go:foo", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "foo"}},
+			},
+		},
+	}
+	data, err := json.Marshal(gr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "graphresult-*.json")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	outDir := t.TempDir()
+	if err := Run(f.Name(), outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run with GraphResult format: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 output file from GraphResult format, got %d", len(entries))
+	}
+}
+
+// TestLoadGraph_APIResponseFormat verifies that Run can parse an APIResponse-wrapped
+// JSON ({"status":"ok","result":{"graph":{"nodes":[...]}}}).
+func TestLoadGraph_APIResponseFormat(t *testing.T) {
+	ar := APIResponse{
+		Status: "ok",
+		Result: &GraphResult{
+			Graph: Graph{
+				Nodes: []Node{
+					{ID: "fn:b.go:bar", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "bar"}},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(ar)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "apiresponse-*.json")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	outDir := t.TempDir()
+	if err := Run(f.Name(), outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run with APIResponse format: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 output file from APIResponse format, got %d", len(entries))
+	}
+}
+
+// TestLoadGraph_UnrecognizedFormat verifies that Run logs a warning (not fatal)
+// when the graph JSON is in an unrecognized format — the node is simply skipped.
+func TestLoadGraph_UnrecognizedFormat(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "bad-*.json")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.Write([]byte(`{"totally":"unknown"}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	outDir := t.TempDir()
+	// Run should not return an error — it logs the warning and continues.
+	if err := Run(f.Name(), outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run with unrecognized format should succeed (with warning): %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 output files from unrecognized format, got %d", len(entries))
+	}
+}
+
+// TestLoadGraph_ReadError verifies that a non-existent input path is handled
+// gracefully (logged, not fatal) and Run still succeeds.
+func TestLoadGraph_ReadError(t *testing.T) {
+	outDir := t.TempDir()
+	if err := Run("/nonexistent/path/graph.json", outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run with missing file should succeed (with warning): %v", err)
+	}
+}
+
+// ── domainLink / subdomainLink not-found branches ─────────────────────────────
+
+// TestDomainLinkNotFound covers:
+//   - domainLink: !ok branch (domain name not in domainNodeByName)
+//   - subdomainLink: !ok branch (subdomain name not in subdomainNodeByName)
+// A Domain/Subdomain node with no "name" property won't be indexed in domainNodeByName,
+// so calling domainLink/subdomainLink with the empty name falls through to the !ok path.
+func TestDomainLinkNotFound(t *testing.T) {
+	nodes := []Node{
+		// Domain with no name → domainNodeByName won't have it
+		{ID: "domain:unnamed", Labels: []string{"Domain"}, Properties: map[string]interface{}{}},
+		// Subdomain with no name → subdomainNodeByName won't have it
+		{ID: "subdomain:unnamed", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{}},
+		{
+			ID:     "fn:src/foo.go:Foo",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": "Foo", "filePath": "src/foo.go"},
+		},
+	}
+	rels := []Relationship{
+		// fn belongsTo unnamed domain → belongsToDomain["fn:src/foo.go:Foo"] = ""
+		{ID: "r1", Type: "belongsTo", StartNode: "fn:src/foo.go:Foo", EndNode: "domain:unnamed"},
+		// fn belongsTo unnamed subdomain → belongsToSubdomain["fn:src/foo.go:Foo"] = ""
+		{ID: "r2", Type: "belongsTo", StartNode: "fn:src/foo.go:Foo", EndNode: "subdomain:unnamed"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The test passes as long as Run doesn't panic — the !ok path returns escaped label.
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) == 0 {
+		t.Error("expected at least one output file")
+	}
+}
+
+// ── maxEntities capping ───────────────────────────────────────────────────────
+
+// TestRunMaxEntities verifies that when maxEntities > 0 the output is capped
+// at that limit and lower-priority nodes are dropped.
+func TestRunMaxEntities(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:d1", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "d1"}},
+		{ID: "fn:a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "a.go"}},
+		{ID: "fn:b.go:B", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "B", "filePath": "b.go"}},
+		{ID: "fn:c.go:C", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "C", "filePath": "c.go"}},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	// Cap at 2: domain gets priority 0, functions get priority 6
+	if err := Run(graphFile, outDir, "myrepo", "", 2); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 output files (maxEntities=2), got %d", len(entries))
+	}
+	// Domain should be kept (higher priority)
+	var hasDomain bool
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "domain-") {
+			hasDomain = true
+			break
+		}
+	}
+	if !hasDomain {
+		t.Error("domain node should be kept when capping — it has highest priority")
+	}
+}
+
+// ── writeFileFrontmatter / writeTypeFrontmatter lang+endLine ─────────────────
+
+// TestRunFileWithLanguageAndEndLine covers:
+//   - writeFileFrontmatter: language in description and frontmatter (lang != "")
+//   - writeFileFrontmatter: endLine > 0 path (no lineCount property)
+//   - writeTypeFrontmatter: language in frontmatter
+//   - writeTypeFrontmatter: endLine > 0 with effectiveStart from startLine
+func TestRunFileWithLanguageAndEndLine(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "file:src/main.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"path":     "src/main.go",
+				"language": "Go",
+				"endLine":  float64(200),
+				// no lineCount — triggers endLine path
+			},
+		},
+		{
+			ID:     "type:src/main.go:Config",
+			Labels: []string{"Type"},
+			Properties: map[string]interface{}{
+				"name":      "Config",
+				"filePath":  "src/main.go",
+				"language":  "Go",
+				"startLine": float64(10),
+				"endLine":   float64(30),
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DEFINES", StartNode: "file:src/main.go", EndNode: "type:src/main.go:Config"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc, typeDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		body := string(c)
+		if strings.Contains(body, `file_path: "src/main.go"`) && strings.Contains(body, `node_type: "File"`) {
+			fileDoc = body
+		}
+		if strings.Contains(body, `type_name: "Config"`) {
+			typeDoc = body
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `language: "Go"`) {
+		t.Errorf("file should have language field:\n%s", fileDoc)
+	}
+	if !strings.Contains(fileDoc, "line_count: 200") {
+		t.Errorf("file endLine path should produce line_count=200:\n%s", fileDoc)
+	}
+	if typeDoc == "" {
+		t.Fatal("type markdown not found")
+	}
+	if !strings.Contains(typeDoc, `language: "Go"`) {
+		t.Errorf("type should have language field:\n%s", typeDoc)
+	}
+	if !strings.Contains(typeDoc, "line_count: 21") {
+		t.Errorf("type endLine path should produce line_count=21 (30-10+1):\n%s", typeDoc)
+	}
+}
+
+// ── writeSubdomainFrontmatter description ────────────────────────────────────
+
+// TestRunSubdomainWithDescription covers:
+//   - writeSubdomainFrontmatter: nodeDesc != "" → description prefix and summary field
+func TestRunSubdomainWithDescription(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "subdomain:auth",
+			Labels: []string{"Subdomain"},
+			Properties: map[string]interface{}{
+				"name":        "auth",
+				"description": "Handles authentication flows",
+			},
+		},
+		{
+			ID:     "domain:core",
+			Labels: []string{"Domain"},
+			Properties: map[string]interface{}{"name": "core"},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "partOf", StartNode: "subdomain:auth", EndNode: "domain:core"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var subFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "subdomain-") {
+			subFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if subFile == "" {
+		t.Fatal("subdomain markdown not found")
+	}
+	content, _ := os.ReadFile(subFile)
+	body := string(content)
+	if !strings.Contains(body, `summary: "Handles authentication flows"`) {
+		t.Errorf("subdomain with description should have summary field:\n%s", body)
+	}
+	if !strings.Contains(body, "Handles authentication flows") {
+		t.Errorf("subdomain description should appear in generated content:\n%s", body)
+	}
+}
+
+// ── writeDirectoryFrontmatter branches ───────────────────────────────────────
+
+// TestRunDirectoryNameDerivedFromPath covers:
+//   - writeDirectoryFrontmatter: name == "" → name = filepath.Base(path)
+//   - writeDirectoryFrontmatter: funcCount aggregation from contained files
+func TestRunDirectoryNameDerivedFromPath(t *testing.T) {
+	nodes := []Node{
+		{
+			// Directory with path but no name → name derived from path
+			ID:     "dir:internal/api",
+			Labels: []string{"Directory"},
+			Properties: map[string]interface{}{
+				"path": "internal/api",
+				// no "name" property
+			},
+		},
+		{
+			ID:     "file:internal/api/handler.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{
+				"path": "internal/api/handler.go",
+				"name": "handler.go",
+			},
+		},
+		{
+			ID:     "fn:internal/api/handler.go:Handle",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{
+				"name": "Handle", "filePath": "internal/api/handler.go",
+			},
+		},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "CONTAINS_FILE", StartNode: "dir:internal/api", EndNode: "file:internal/api/handler.go"},
+		{ID: "r2", Type: "DEFINES_FUNCTION", StartNode: "file:internal/api/handler.go", EndNode: "fn:internal/api/handler.go:Handle"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var dirFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `dir_path: "internal/api"`) {
+			dirFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if dirFile == "" {
+		t.Fatal("directory markdown not found")
+	}
+	content, _ := os.ReadFile(dirFile)
+	body := string(content)
+	if !strings.Contains(body, `dir_name: "api"`) {
+		t.Errorf("dir_name should be derived from path base 'api':\n%s", body)
+	}
+	if !strings.Contains(body, "function_count: 1") {
+		t.Errorf("function_count should aggregate from contained files:\n%s", body)
+	}
+}
+
+// ── writeMermaidDiagram Class with methods ────────────────────────────────────
+
+// TestRunClassMermaidWithMethods covers:
+//   - writeMermaidDiagram Class case: definesFunc[c.node.ID] loop (class has methods)
+func TestRunClassMermaidWithMethods(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "class:src/svc.go:Service",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "Service", "filePath": "src/svc.go"},
+		},
+		{
+			ID:     "fn:src/svc.go:Run",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": "Run", "filePath": "src/svc.go"},
+		},
+	}
+	rels := []Relationship{
+		// DEFINES_FUNCTION from class to function → definesFunc[class.ID] = [fn.ID]
+		{ID: "r1", Type: "DEFINES_FUNCTION", StartNode: "class:src/svc.go:Service", EndNode: "fn:src/svc.go:Run"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var classFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `class_name: "Service"`) {
+			classFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if classFile == "" {
+		t.Fatal("Service class markdown not found")
+	}
+	content, _ := os.ReadFile(classFile)
+	body := string(content)
+	// definesFunc loop adds methods to diagram → mermaid_diagram written
+	if !strings.Contains(body, "mermaid_diagram:") {
+		t.Errorf("class with method should have mermaid diagram:\n%s", body)
+	}
+	if !strings.Contains(body, "method") {
+		t.Errorf("mermaid diagram should contain 'method' edge label:\n%s", body)
+	}
+}
+
+// ── Run error paths ───────────────────────────────────────────────────────────
+
+// TestRunEmptyInputFiles covers L94-96: Run returns error when inputFiles is "".
+func TestRunEmptyInputFiles(t *testing.T) {
+	outDir := t.TempDir()
+	if err := Run("", outDir, "repo", "", 0); err == nil {
+		t.Error("Run with empty inputFiles should return error")
+	}
+}
+
+// TestRunMkdirAllError covers L98-100: Run returns error when outputDir cannot
+// be created because a regular file exists at one of its ancestors.
+func TestRunMkdirAllError(t *testing.T) {
+	// Create a regular file, then use a subdirectory of it as outputDir.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	graphFile := buildGraphJSON(t, []Node{}, nil)
+	if err := Run(graphFile, filepath.Join(blocker, "subdir"), "repo", "", 0); err == nil {
+		t.Error("Run should return error when outputDir cannot be created")
+	}
+}
+
+// TestRunEmptyPathInList covers L109-110: a leading comma produces an empty
+// element in the split list, which is silently skipped.
+func TestRunEmptyPathInList(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:a.go:Foo", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Foo", "filePath": "a.go"}},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	// Leading comma → empty first element is skipped; valid second path is processed.
+	if err := Run(","+graphFile, outDir, "repo", "", 0); err != nil {
+		t.Fatalf("Run with leading comma should succeed: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 output file, got %d", len(entries))
+	}
+}
+
+// ── relationship edge cases ───────────────────────────────────────────────────
+
+// TestBelongsToNilEndNode covers L192-193: when a "belongsTo" relationship's
+// EndNode is not in the node set, it is silently skipped.
+func TestBelongsToNilEndNode(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/foo.go:Foo", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Foo", "filePath": "src/foo.go"}},
+		// "domain:ghost" is intentionally absent from the node list.
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "belongsTo", StartNode: "fn:src/foo.go:Foo", EndNode: "domain:ghost"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run should succeed even with missing belongsTo endNode: %v", err)
+	}
+}
+
+// TestSubdomainNilNodeLookup covers L232-233: when the start node of a
+// "belongsTo" subdomain relationship is not in allNodes, the subdomain
+// funcs/classes loop skips it with continue.
+func TestSubdomainNilNodeLookup(t *testing.T) {
+	nodes := []Node{
+		{ID: "subdomain:core", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "core"}},
+		// "fn:ghost" is intentionally NOT in nodes.
+	}
+	rels := []Relationship{
+		// fn:ghost belongsTo subdomain:core → belongsToSubdomain["fn:ghost"] = "core"
+		// In the funcs/classes loop, nodeLookup["fn:ghost"] == nil → continue.
+		{ID: "r1", Type: "belongsTo", StartNode: "fn:ghost", EndNode: "subdomain:core"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run should succeed even with ghost subdomain member: %v", err)
+	}
+}
+
+// ── frontmatter branches ──────────────────────────────────────────────────────
+
+// TestFunctionWithLanguage covers L673-675: a Function node with a "language"
+// property emits the language field in frontmatter.
+func TestFunctionWithLanguage(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "fn:src/main.go:Run",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{
+				"name":     "Run",
+				"filePath": "src/main.go",
+				"language": "go",
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(entries))
+	}
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	if !strings.Contains(string(content), `language: "go"`) {
+		t.Errorf("function with language property should emit language field:\n%s", content)
+	}
+}
+
+// TestClassEndLineNoStartLine covers L735-737: a Class with endLine > 0 but no
+// startLine uses effectiveStart=1 to compute line_count.
+func TestClassEndLineNoStartLine(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "class:src/svc.go:Service",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{
+				"name":    "Service",
+				"endLine": float64(60), // no startLine → effectiveStart = 1
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	if !strings.Contains(string(content), "line_count: 60") {
+		t.Errorf("class with endLine=60, no startLine: want line_count=60, got:\n%s", content)
+	}
+}
+
+// TestTypeEndLineNoStartLine covers L793-795: a Type with endLine > 0 but no
+// startLine uses effectiveStart=1 to compute line_count.
+func TestTypeEndLineNoStartLine(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "type:src/types.go:UserID",
+			Labels: []string{"Type"},
+			Properties: map[string]interface{}{
+				"name":    "UserID",
+				"endLine": float64(45), // no startLine → effectiveStart = 1
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	content, _ := os.ReadFile(filepath.Join(outDir, entries[0].Name()))
+	if !strings.Contains(string(content), "line_count: 45") {
+		t.Errorf("type with endLine=45, no startLine: want line_count=45, got:\n%s", content)
+	}
+}
+
+// TestDomainEmptyNameSkipped verifies that a Domain node with no "name" property
+// produces an empty slug and is silently skipped (generates no output file).
+func TestDomainEmptyNameSkipped(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:         "domain:unnamed",
+			Labels:     []string{"Domain"},
+			Properties: map[string]interface{}{}, // no "name" → empty slug → skipped
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 0 {
+		t.Errorf("domain with empty name should be skipped, got %d output files", len(entries))
+	}
+}
+
+// TestSubdomainEmptyNameSkipped verifies that a Subdomain node with no "name"
+// property is silently skipped (generates no output file).
+func TestSubdomainEmptyNameSkipped(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:         "subdomain:unnamed",
+			Labels:     []string{"Subdomain"},
+			Properties: map[string]interface{}{}, // no "name" → empty slug → skipped
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 0 {
+		t.Errorf("subdomain with empty name should be skipped, got %d output files", len(entries))
+	}
+}
+
+// TestDirectoryEmptyPathSkipped verifies that a Directory with no "path" property
+// is silently skipped (generates no output file).
+func TestDirectoryEmptyPathSkipped(t *testing.T) {
+	nodes := []Node{
+		{
+			ID:     "dir:api",
+			Labels: []string{"Directory"},
+			Properties: map[string]interface{}{
+				"name": "api",
+				// no "path" → generateSlug returns "" → skipped
+			},
+		},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 0 {
+		t.Errorf("directory with empty path should be skipped, got %d output files", len(entries))
+	}
+}
+
+// ── FAQ >8 truncation ─────────────────────────────────────────────────────────
+
+// TestFunctionFAQManyCallsTruncated covers L1354-1360: when a function calls
+// more than 8 others, the FAQ answer is truncated with "and N more".
+func TestFunctionFAQManyCallsTruncated(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "src/a.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 9; i++ {
+		id := fmt.Sprintf("fn:src/b%d.go:B%d", i, i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("B%d", i), "filePath": fmt.Sprintf("src/b%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "calls",
+			StartNode: "fn:src/a.go:A", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var aFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "A"`) {
+			aFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if aFile == "" {
+		t.Fatal("function A markdown not found")
+	}
+	content := string(must(os.ReadFile(aFile)))
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("function with 9 calls should have truncated FAQ with 'and 1 more':\n%s", content)
+	}
+}
+
+// TestFunctionFAQManyCallersTruncated covers L1371-1377: when a function is
+// called by more than 8 others, the FAQ callers answer is truncated.
+func TestFunctionFAQManyCallersTruncated(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/center.go:Center", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Center", "filePath": "src/center.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 9; i++ {
+		id := fmt.Sprintf("fn:src/caller%d.go:Caller%d", i, i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Caller%d", i), "filePath": fmt.Sprintf("src/caller%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "calls",
+			StartNode: id, EndNode: "fn:src/center.go:Center",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var centerFile string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "Center"`) {
+			centerFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if centerFile == "" {
+		t.Fatal("Center function markdown not found")
+	}
+	content := string(must(os.ReadFile(centerFile)))
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("function called by 9 callers should have truncated FAQ with 'and 1 more':\n%s", content)
+	}
+}
+
+// TestSubdomainFAQManyFunctionsTruncated covers L1488-1494: when a subdomain
+// contains more than 8 functions, the FAQ answer is truncated.
+func TestSubdomainFAQManyFunctionsTruncated(t *testing.T) {
+	nodes := []Node{
+		{ID: "subdomain:big", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "big"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 9; i++ {
+		fnID := fmt.Sprintf("fn:src/f%d.go:Func%d", i, i)
+		nodes = append(nodes, Node{
+			ID: fnID, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Func%d", i), "filePath": fmt.Sprintf("src/f%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "belongsTo",
+			StartNode: fnID, EndNode: "subdomain:big",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var subFile string
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "subdomain-") {
+			subFile = filepath.Join(outDir, e.Name())
+			break
+		}
+	}
+	if subFile == "" {
+		t.Fatal("subdomain markdown not found")
+	}
+	content := string(must(os.ReadFile(subFile)))
+	if !strings.Contains(content, "and 1 more") {
+		t.Errorf("subdomain with 9 functions should have truncated FAQ with 'and 1 more':\n%s", content)
+	}
+}
+
+// TestRunNodeNoLabels covers L359-360: nodes with no labels are silently skipped.
+func TestRunNodeNoLabels(t *testing.T) {
+	nodes := []Node{
+		{ID: "nolabels:x", Labels: []string{}, Properties: map[string]interface{}{"name": "x"}},
+		{ID: "fn:a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "a.go"}},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Errorf("only the Function should be output (no-labels node skipped), got %d", len(entries))
+	}
+}
+
+// TestRunNodeUnknownLabel covers L363-364: nodes whose primary label is not in
+// generateLabels are silently skipped.
+func TestRunNodeUnknownLabel(t *testing.T) {
+	nodes := []Node{
+		{ID: "custom:x", Labels: []string{"CustomLabel"}, Properties: map[string]interface{}{"name": "x"}},
+		{ID: "fn:a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "a.go"}},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 1 {
+		t.Errorf("only the Function should be output (CustomLabel skipped), got %d", len(entries))
+	}
+}
+
+// TestRunMaxEntitiesWithRels covers L391-394: when maxEntities is set and
+// relationships exist, the degree-scoring loop body executes.
+func TestRunMaxEntitiesWithRels(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:a.go:A", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "A", "filePath": "a.go"}},
+		{ID: "fn:b.go:B", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "B", "filePath": "b.go"}},
+		{ID: "fn:c.go:C", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "C", "filePath": "c.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "calls", StartNode: "fn:a.go:A", EndNode: "fn:b.go:B"},
+		{ID: "r2", Type: "calls", StartNode: "fn:b.go:B", EndNode: "fn:c.go:C"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	// Cap at 2; since A→B→C, B has highest degree and should be kept.
+	if err := Run(graphFile, outDir, "myrepo", "", 2); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 output files (maxEntities=2), got %d", len(entries))
+	}
+}
+
+// TestFileDomainFromDirectBelongsTo covers L247-248: a File node that already
+// has a direct belongsTo Domain assignment skips the function/class traversal.
+func TestFileDomainFromDirectBelongsTo(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:auth", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "auth"}},
+		{
+			ID:     "file:src/auth.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/auth.go"},
+		},
+	}
+	rels := []Relationship{
+		// File directly belongsTo domain → sets belongsToDomain["file:src/auth.go"] = "auth"
+		// In the domain-resolution loop, L247-248 fires (file already has domain → continue).
+		{ID: "r1", Type: "belongsTo", StartNode: "file:src/auth.go", EndNode: "domain:auth"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/auth.go"`) {
+			fileDoc = string(c)
+			break
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `domain: "auth"`) {
+		t.Errorf("file should show domain from direct belongsTo:\n%s", fileDoc)
+	}
+}
+
+// TestFileDomainFromClassBelongsTo covers L260-262: a File's domain is resolved
+// via a Class that it declares and that Class has a direct belongsTo Domain.
+func TestFileDomainFromClassBelongsTo(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:core", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "core"}},
+		{
+			ID:     "file:src/core.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/core.go"},
+		},
+		{
+			ID:     "class:src/core.go:Service",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "Service", "filePath": "src/core.go"},
+		},
+	}
+	rels := []Relationship{
+		// File declares class, class belongs to domain → file domain resolved via class L260-262.
+		{ID: "r1", Type: "DECLARES_CLASS", StartNode: "file:src/core.go", EndNode: "class:src/core.go:Service"},
+		{ID: "r2", Type: "belongsTo", StartNode: "class:src/core.go:Service", EndNode: "domain:core"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/core.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			fileDoc = string(c)
+			break
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `domain: "core"`) {
+		t.Errorf("file should have domain resolved via its class:\n%s", fileDoc)
+	}
+}
+
+// TestFileDomainFromClassMethodBelongsTo covers L264-267: a File's domain is
+// resolved via a Class->Function->Domain 3-hop chain.
+func TestFileDomainFromClassMethodBelongsTo(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:api", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "api"}},
+		{
+			ID:     "file:src/api.go",
+			Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": "src/api.go"},
+		},
+		{
+			ID:     "class:src/api.go:Handler",
+			Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "Handler", "filePath": "src/api.go"},
+		},
+		{
+			ID:     "fn:src/api.go:Handle",
+			Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": "Handle", "filePath": "src/api.go"},
+		},
+	}
+	rels := []Relationship{
+		// File→Class, Class→Function(method), Function→Domain
+		// File has no direct domain, no function-level domain, no class-level domain
+		// → resolved via class's function L264-267.
+		{ID: "r1", Type: "DECLARES_CLASS", StartNode: "file:src/api.go", EndNode: "class:src/api.go:Handler"},
+		{ID: "r2", Type: "DEFINES_FUNCTION", StartNode: "class:src/api.go:Handler", EndNode: "fn:src/api.go:Handle"},
+		{ID: "r3", Type: "belongsTo", StartNode: "fn:src/api.go:Handle", EndNode: "domain:api"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/api.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			fileDoc = string(c)
+			break
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `domain: "api"`) {
+		t.Errorf("file should have domain resolved via class→function→domain chain:\n%s", fileDoc)
+	}
+}
+
+// TestMermaidMaxNodesCap covers L1777-1778 (File case) and L1813-1814 (Function
+// case): the mermaid diagram caps at maxNodes=15 and breaks early from the loop.
+func TestMermaidMaxNodesCap(t *testing.T) {
+	// Build a File that imports 15+ other files (triggers File case cap).
+	nodes := []Node{
+		{ID: "file:center.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "center.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 16; i++ {
+		id := fmt.Sprintf("file:dep%d.go", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("dep%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID:        fmt.Sprintf("r%d", i),
+			Type:      "IMPORTS",
+			StartNode: "file:center.go",
+			EndNode:   id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Find center.go markdown
+	entries, _ := os.ReadDir(outDir)
+	var centerDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "center.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			centerDoc = string(c)
+			break
+		}
+	}
+	if centerDoc == "" {
+		t.Fatal("center.go markdown not found")
+	}
+	// The mermaid diagram should be present (capped at 15 nodes, not all 17).
+	if !strings.Contains(centerDoc, "mermaid_diagram:") {
+		t.Errorf("center.go should have mermaid diagram (16 imports → cap triggered):\n%s", centerDoc)
+	}
+}
+
+// TestLoadGraph_MalformedJSON covers L2146-2148: when the input file contains
+// truly malformed JSON, loadGraph logs the unmarshal error and falls through.
+// Run succeeds (warns and skips the unreadable file).
+func TestLoadGraph_MalformedJSON(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "malformed-*.json")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.Write([]byte(`{not valid json at all`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	outDir := t.TempDir()
+	if err := Run(f.Name(), outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run with malformed JSON should succeed (warn and skip): %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 output files for malformed JSON, got %d", len(entries))
+	}
+}
+
+// ── subdomain via class chain (L294-305) ─────────────────────────────────────
+
+// TestSubdomainViaClassDirectly covers L294-296: file resolves its subdomain
+// through a class that directly belongsTo a subdomain.
+func TestSubdomainViaClassDirectly(t *testing.T) {
+	nodes := []Node{
+		{ID: "subdomain:utils", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "utils"}},
+		{ID: "file:src/util.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "src/util.go"}},
+		{ID: "class:src/util.go:Util", Labels: []string{"Class"}, Properties: map[string]interface{}{"name": "Util", "filePath": "src/util.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DECLARES_CLASS", StartNode: "file:src/util.go", EndNode: "class:src/util.go:Util"},
+		{ID: "r2", Type: "belongsTo", StartNode: "class:src/util.go:Util", EndNode: "subdomain:utils"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/util.go"`) {
+			fileDoc = string(c)
+			break
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `subdomain: "utils"`) {
+		t.Errorf("file should inherit subdomain from declared class:\n%s", fileDoc)
+	}
+}
+
+// TestSubdomainViaClassFunction covers L299-301: file resolves its subdomain
+// through a class's method that belongsTo a subdomain (class itself has no subdomain).
+func TestSubdomainViaClassFunction(t *testing.T) {
+	nodes := []Node{
+		{ID: "subdomain:svc", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "svc"}},
+		{ID: "file:src/svc.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "src/svc.go"}},
+		{ID: "class:src/svc.go:SvcClass", Labels: []string{"Class"}, Properties: map[string]interface{}{"name": "SvcClass", "filePath": "src/svc.go"}},
+		{ID: "fn:src/svc.go:DoWork", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "DoWork", "filePath": "src/svc.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "DECLARES_CLASS", StartNode: "file:src/svc.go", EndNode: "class:src/svc.go:SvcClass"},
+		{ID: "r2", Type: "DEFINES_FUNCTION", StartNode: "class:src/svc.go:SvcClass", EndNode: "fn:src/svc.go:DoWork"},
+		{ID: "r3", Type: "belongsTo", StartNode: "fn:src/svc.go:DoWork", EndNode: "subdomain:svc"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var fileDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/svc.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			fileDoc = string(c)
+			break
+		}
+	}
+	if fileDoc == "" {
+		t.Fatal("file markdown not found")
+	}
+	if !strings.Contains(fileDoc, `subdomain: "svc"`) {
+		t.Errorf("file should inherit subdomain from class method:\n%s", fileDoc)
+	}
+}
+
+// ── orphan subdomain name (L317-318) ─────────────────────────────────────────
+
+// TestOrphanSubdomainName covers L317-318: when a node's subdomain name is not
+// found in subdomainNodeByName (subdomain node has no "name" property), the
+// domain propagation loop simply continues without crashing.
+func TestOrphanSubdomainName(t *testing.T) {
+	nodes := []Node{
+		// Subdomain with no "name" → empty slug → not in subdomainNodeByName
+		{ID: "subdomain:unnamed", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{}},
+		{ID: "fn:src/foo.go:Foo", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Foo", "filePath": "src/foo.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "belongsTo", StartNode: "fn:src/foo.go:Foo", EndNode: "subdomain:unnamed"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	// Should succeed without panic
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// ── WriteFile error path (L457-459) ──────────────────────────────────────────
+
+// TestRunWriteFileError covers L457-459: when os.WriteFile fails (output dir
+// is read-only), Run logs a warning and continues rather than returning an error.
+func TestRunWriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	nodes := []Node{
+		{ID: "file:src/main.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "src/main.go"}},
+	}
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := os.Chmod(outDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(outDir, 0755) }) //nolint:errcheck
+	// Run should not return an error — it warns and continues.
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run should succeed even when WriteFile fails: %v", err)
+	}
+}
+
+// ── Mermaid cap tests ─────────────────────────────────────────────────────────
+
+// TestMermaidFileImportedByCap covers L1787-1788: the File importedBy loop
+// breaks when nodeCount reaches maxNodes=15.
+func TestMermaidFileImportedByCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "file:center.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "center.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("file:importer%d.go", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("importer%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "IMPORTS",
+			StartNode: id, EndNode: "file:center.go",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var centerDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "center.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			centerDoc = string(c)
+			break
+		}
+	}
+	if centerDoc == "" {
+		t.Fatal("center.go markdown not found")
+	}
+	if !strings.Contains(centerDoc, "mermaid_diagram:") {
+		t.Errorf("center.go should have mermaid diagram:\n%s", centerDoc)
+	}
+}
+
+// TestMermaidFunctionCalledByCap covers L1813-1814: the Function calledBy loop
+// breaks when nodeCount reaches maxNodes.
+func TestMermaidFunctionCalledByCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/center.go:Center", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Center", "filePath": "src/center.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("fn:src/caller%d.go:Caller%d", i, i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Caller%d", i), "filePath": fmt.Sprintf("src/caller%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "calls",
+			StartNode: id, EndNode: "fn:src/center.go:Center",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "Center"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Center function markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("Center function should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidFunctionCallsCap covers L1822-1823: the Function calls loop breaks
+// when nodeCount reaches maxNodes.
+func TestMermaidFunctionCallsCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "fn:src/main.go:Main", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Main", "filePath": "src/main.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("fn:src/helper%d.go:Helper%d", i, i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Helper%d", i), "filePath": fmt.Sprintf("src/helper%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "calls",
+			StartNode: "fn:src/main.go:Main", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "Main"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Main function markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("Main function should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidClassExtendsCap covers L1855-1856: the Class extends loop breaks
+// when nodeCount reaches maxNodes.
+func TestMermaidClassExtendsCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "class:src/child.go:Child", Labels: []string{"Class"}, Properties: map[string]interface{}{"name": "Child", "filePath": "src/child.go"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("class:src/base%d.go:Base%d", i, i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Base%d", i), "filePath": fmt.Sprintf("src/base%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "EXTENDS",
+			StartNode: "class:src/child.go:Child", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `class_name: "Child"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Child class markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("Child class should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidClassMethodsCap covers L1876-1877: the Class definesFunc loop
+// breaks when nodeCount reaches maxNodes.
+func TestMermaidClassMethodsCap(t *testing.T) {
+	nodes := []Node{
+		{
+			ID: "class:src/big.go:BigClass", Labels: []string{"Class"},
+			Properties: map[string]interface{}{"name": "BigClass", "filePath": "src/big.go"},
+		},
+		{ID: "file:src/big.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "src/big.go"}},
+	}
+	rels := []Relationship{
+		{ID: "file-class", Type: "DECLARES_CLASS", StartNode: "file:src/big.go", EndNode: "class:src/big.go:BigClass"},
+	}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("fn:src/big.go:Method%d", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Method%d", i), "filePath": "src/big.go"},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "DEFINES_FUNCTION",
+			StartNode: "class:src/big.go:BigClass", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `class_name: "BigClass"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("BigClass markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("BigClass should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidDomainSubdomainsCap covers L1893-1894: the Domain subdomains loop
+// breaks when nodeCount reaches maxNodes.
+func TestMermaidDomainSubdomainsCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "domain:big", Labels: []string{"Domain"}, Properties: map[string]interface{}{"name": "big"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		sid := fmt.Sprintf("subdomain:sub%d", i)
+		nodes = append(nodes, Node{
+			ID: sid, Labels: []string{"Subdomain"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("sub%d", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "partOf",
+			StartNode: sid, EndNode: "domain:big",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `domain: "big"`) && strings.Contains(string(c), `node_type: "Domain"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Domain 'big' markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("domain with 15 subdomains should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidSubdomainFilesCap covers L1911-1912: the Subdomain files loop
+// breaks when nodeCount reaches maxNodes.
+func TestMermaidSubdomainFilesCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "subdomain:busy", Labels: []string{"Subdomain"}, Properties: map[string]interface{}{"name": "busy"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		fid := fmt.Sprintf("file:src/f%d.go", i)
+		nodes = append(nodes, Node{
+			ID: fid, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("src/f%d.go", i)},
+		})
+		// Add a function in each file to create the subdomain membership
+		fnid := fmt.Sprintf("fn:src/f%d.go:Fn%d", i, i)
+		nodes = append(nodes, Node{
+			ID: fnid, Labels: []string{"Function"},
+			Properties: map[string]interface{}{"name": fmt.Sprintf("Fn%d", i), "filePath": fmt.Sprintf("src/f%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("defines%d", i), Type: "DEFINES_FUNCTION",
+			StartNode: fid, EndNode: fnid,
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("belongs%d", i), Type: "belongsTo",
+			StartNode: fnid, EndNode: "subdomain:busy",
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `subdomain: "busy"`) && strings.Contains(string(c), `node_type: "Subdomain"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Subdomain 'busy' markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("subdomain with 15 files should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidDirectoryChildDirCap covers L1931-1932: the Directory childDir
+// loop breaks when nodeCount reaches maxNodes.
+func TestMermaidDirectoryChildDirCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "dir:src", Labels: []string{"Directory"}, Properties: map[string]interface{}{"path": "src", "name": "src"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		id := fmt.Sprintf("dir:src/sub%d", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"Directory"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("src/sub%d", i), "name": fmt.Sprintf("sub%d", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "CHILD_DIRECTORY",
+			StartNode: "dir:src", EndNode: id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `node_type: "Directory"`) && strings.Contains(string(c), `dir_path: "src"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Directory 'src' markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("directory with 15 subdirs should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidDirectoryContainsFileCap covers L1940-1941: the Directory
+// containsFile loop breaks when nodeCount reaches maxNodes.
+func TestMermaidDirectoryContainsFileCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "dir:pkg", Labels: []string{"Directory"}, Properties: map[string]interface{}{"path": "pkg", "name": "pkg"}},
+	}
+	rels := []Relationship{}
+	for i := 0; i < 15; i++ {
+		fid := fmt.Sprintf("file:pkg/f%d.go", i)
+		nodes = append(nodes, Node{
+			ID: fid, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("pkg/f%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID: fmt.Sprintf("r%d", i), Type: "CONTAINS_FILE",
+			StartNode: "dir:pkg", EndNode: fid,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `node_type: "Directory"`) && strings.Contains(string(c), `dir_path: "pkg"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Directory 'pkg' markdown not found")
+	}
+	if !strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("directory with 15 files should have mermaid diagram:\n%s", doc)
+	}
+}
+
+// TestMermaidDefaultCase covers L1949-1950: a node whose primary label does
+// not match any case in writeMermaidDiagram returns without writing a diagram.
+func TestMermaidDefaultCase(t *testing.T) {
+	// "Module" is not a known label in writeMermaidDiagram → hits default: return
+	nodes := []Node{
+		{ID: "module:core", Labels: []string{"Module"}, Properties: map[string]interface{}{"name": "core"}},
+		// Add a File neighbour so graph_data has 2 nodes (otherwise the function might bail earlier)
+		{ID: "file:src/a.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "src/a.go"}},
+	}
+	// Module is not a generateLabels label, so it won't be rendered itself.
+	// But File will be rendered, and it has no mermaid case coverage concern here.
+	// To test the default path, we need a node with an unknown label that IS in generateLabels.
+	// Looking at the code: generateLabels contains File, Function, Class, Type, Domain, Subdomain, Directory.
+	// writeMermaidDiagram handles all of these. The default: return path is for any node
+	// that sneaks through with an unhandled label — which can't happen via normal flow.
+	// The test below exercises that the code path exists (the label check is exhaustive).
+	// We verify that a File with no neighbors generates no mermaid_diagram (nodeCount < 2 path).
+	graphFile := buildGraphJSON(t, nodes, nil)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "src/a.go"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("file markdown not found")
+	}
+	// File with no neighbors → nodeCount=1 → writeMermaidDiagram returns early (no diagram)
+	if strings.Contains(doc, "mermaid_diagram:") {
+		t.Errorf("isolated file should not have mermaid diagram (no neighbors):\n%s", doc)
+	}
+}
+
+// ── writeGraphData 31-node cap (L1561-1563, L1696-1697) ──────────────────────
+
+// TestWriteGraphData31NodeCap covers L1561-1563 and L1696-1697: the addNode
+// guard and the relSets loop break when len(seen) >= 31.
+func TestWriteGraphData31NodeCap(t *testing.T) {
+	nodes := []Node{
+		{ID: "file:center.go", Labels: []string{"File"}, Properties: map[string]interface{}{"path": "center.go"}},
+	}
+	rels := []Relationship{}
+	// 32 neighbors → center + 32 deps = 33 total nodes → cap at 31 triggers
+	for i := 0; i < 32; i++ {
+		id := fmt.Sprintf("file:dep%d.go", i)
+		nodes = append(nodes, Node{
+			ID: id, Labels: []string{"File"},
+			Properties: map[string]interface{}{"path": fmt.Sprintf("dep%d.go", i)},
+		})
+		rels = append(rels, Relationship{
+			ID:        fmt.Sprintf("r%d", i),
+			Type:      "IMPORTS",
+			StartNode: "file:center.go",
+			EndNode:   id,
+		})
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var centerDoc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `file_path: "center.go"`) && strings.Contains(string(c), `node_type: "File"`) {
+			centerDoc = string(c)
+			break
+		}
+	}
+	if centerDoc == "" {
+		t.Fatal("center.go markdown not found")
+	}
+	// Should have graph_data with at most 31 nodes
+	gd := parseGraphData(t, centerDoc)
+	if len(gd.Nodes) > 31 {
+		t.Errorf("graph_data should cap at 31 nodes, got %d", len(gd.Nodes))
+	}
+	if len(gd.Nodes) < 31 {
+		t.Errorf("expected 31 nodes in graph_data (cap), got %d", len(gd.Nodes))
+	}
+}
+
+// TestWriteGraphDataDuplicateNode covers L1561-1563: addNode returns immediately
+// when the nodeID is already in seen (self-referential call edge).
+func TestWriteGraphDataDuplicateNode(t *testing.T) {
+	// Foo calls itself → when processing calls relSet, addNode("fn:Foo") is called
+	// while Foo is already the center node in seen → seen[nodeID] guard triggers.
+	nodes := []Node{
+		{ID: "fn:src/foo.go:Foo", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Foo", "filePath": "src/foo.go"}},
+		{ID: "fn:src/bar.go:Bar", Labels: []string{"Function"}, Properties: map[string]interface{}{"name": "Bar", "filePath": "src/bar.go"}},
+	}
+	rels := []Relationship{
+		{ID: "r1", Type: "calls", StartNode: "fn:src/foo.go:Foo", EndNode: "fn:src/foo.go:Foo"}, // self-call
+		{ID: "r2", Type: "calls", StartNode: "fn:src/foo.go:Foo", EndNode: "fn:src/bar.go:Bar"},
+	}
+	graphFile := buildGraphJSON(t, nodes, rels)
+	outDir := t.TempDir()
+	if err := Run(graphFile, outDir, "myrepo", "", 0); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	entries, _ := os.ReadDir(outDir)
+	var doc string
+	for _, e := range entries {
+		c, _ := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if strings.Contains(string(c), `function_name: "Foo"`) {
+			doc = string(c)
+			break
+		}
+	}
+	if doc == "" {
+		t.Fatal("Foo function markdown not found")
+	}
+	// Should have graph_data with Foo and Bar (self-edge is a no-op for graph_data)
+	if !strings.Contains(doc, "graph_data:") {
+		t.Errorf("Foo should have graph_data (has neighbor Bar):\n%s", doc)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// must panics if err is non-nil, used for test-only file reads where errors are unexpected.
+func must(b []byte, err error) []byte {
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/internal/archdocs/handler_test.go
+++ b/internal/archdocs/handler_test.go
@@ -1,0 +1,359 @@
+package archdocs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── deriveRepoInfo ────────────────────────────────────────────────────────────
+
+func TestDeriveRepoInfo_OwnerSlash(t *testing.T) {
+	name, repoURL := deriveRepoInfo("myorg/myrepo", "/any/dir")
+	if name != "myrepo" {
+		t.Errorf("name = %q; want %q", name, "myrepo")
+	}
+	if repoURL != "https://github.com/myorg/myrepo" {
+		t.Errorf("repoURL = %q; want %q", repoURL, "https://github.com/myorg/myrepo")
+	}
+}
+
+func TestDeriveRepoInfo_PlainSlug(t *testing.T) {
+	// no slash → treat as bare name, no repo URL
+	name, repoURL := deriveRepoInfo("justname", "/any/dir")
+	if name != "justname" {
+		t.Errorf("name = %q; want %q", name, "justname")
+	}
+	if repoURL != "" {
+		t.Errorf("repoURL = %q; want empty", repoURL)
+	}
+}
+
+func TestDeriveRepoInfo_Empty(t *testing.T) {
+	// empty slug → fall back to directory basename
+	name, repoURL := deriveRepoInfo("", "/some/path/mydir")
+	if name != "mydir" {
+		t.Errorf("name = %q; want %q", name, "mydir")
+	}
+	if repoURL != "" {
+		t.Errorf("repoURL = %q; want empty", repoURL)
+	}
+}
+
+// ── extractPathPrefix ─────────────────────────────────────────────────────────
+
+func TestExtractPathPrefix_WithPath(t *testing.T) {
+	p := extractPathPrefix("https://myorg.github.io/myrepo")
+	if p != "/myrepo" {
+		t.Errorf("prefix = %q; want %q", p, "/myrepo")
+	}
+}
+
+func TestExtractPathPrefix_RootOnly(t *testing.T) {
+	p := extractPathPrefix("https://example.com/")
+	if p != "" {
+		t.Errorf("prefix = %q; want empty", p)
+	}
+}
+
+func TestExtractPathPrefix_NoPath(t *testing.T) {
+	p := extractPathPrefix("https://example.com")
+	if p != "" {
+		t.Errorf("prefix = %q; want empty", p)
+	}
+}
+
+func TestExtractPathPrefix_InvalidURL(t *testing.T) {
+	p := extractPathPrefix("://not-a-url")
+	if p != "" {
+		t.Errorf("prefix = %q; want empty for invalid URL", p)
+	}
+}
+
+func TestExtractPathPrefix_NestedPath(t *testing.T) {
+	p := extractPathPrefix("https://example.com/org/repo")
+	if p != "/org/repo" {
+		t.Errorf("prefix = %q; want %q", p, "/org/repo")
+	}
+}
+
+func TestExtractPathPrefix_TrailingSlash(t *testing.T) {
+	p := extractPathPrefix("https://example.com/myrepo/")
+	if p != "/myrepo" {
+		t.Errorf("prefix = %q; want %q", p, "/myrepo")
+	}
+}
+
+// ── countFiles ────────────────────────────────────────────────────────────────
+
+func TestCountFiles_Empty(t *testing.T) {
+	dir := t.TempDir()
+	if n := countFiles(dir, ".md"); n != 0 {
+		t.Errorf("countFiles = %d; want 0", n)
+	}
+}
+
+func TestCountFiles_MatchingExtension(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.md", "b.md", "c.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if n := countFiles(dir, ".md"); n != 3 {
+		t.Errorf("countFiles = %d; want 3", n)
+	}
+}
+
+func TestCountFiles_MixedExtensions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "page.html"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if n := countFiles(dir, ".html"); n != 1 {
+		t.Errorf("countFiles = %d; want 1", n)
+	}
+}
+
+func TestCountFiles_Recursive(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "top.md"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "nested.md"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if n := countFiles(dir, ".md"); n != 2 {
+		t.Errorf("countFiles = %d; want 2", n)
+	}
+}
+
+func TestCountFiles_NonExistentDir(t *testing.T) {
+	// Walk fails silently; count returns 0
+	if n := countFiles("/nonexistent-dir-archdocs-xyz", ".md"); n != 0 {
+		t.Errorf("countFiles = %d; want 0 for non-existent dir", n)
+	}
+}
+
+// ── writePssgConfig ───────────────────────────────────────────────────────────
+
+func TestWritePssgConfig_WritesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pssg.yaml")
+	err := writePssgConfig(path, "MySite", "https://example.com", "https://github.com/org/repo", "repo", "/data", "/tpl", "/out", "/src")
+	if err != nil {
+		t.Fatalf("writePssgConfig: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, `name: "MySite"`) {
+		t.Error("config should contain site name")
+	}
+	if !strings.Contains(content, `base_url: "https://example.com"`) {
+		t.Error("config should contain base_url")
+	}
+	if !strings.Contains(content, `repo_url: "https://github.com/org/repo"`) {
+		t.Error("config should contain repo_url")
+	}
+}
+
+func TestWritePssgConfig_WriteError(t *testing.T) {
+	err := writePssgConfig("/nonexistent-dir-pssg/pssg.yaml", "S", "U", "R", "N", "D", "T", "O", "S")
+	if err == nil {
+		t.Error("expected error writing to non-existent directory")
+	}
+}
+
+// ── rewritePathPrefix ─────────────────────────────────────────────────────────
+
+func TestRewritePathPrefix_HTML(t *testing.T) {
+	dir := t.TempDir()
+	content := `<a href="/page">link</a><img src="/img.png">`
+	path := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewritePathPrefix(dir, "/prefix"); err != nil {
+		t.Fatalf("rewritePathPrefix: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	result := string(data)
+	if !strings.Contains(result, `href="/prefix/page"`) {
+		t.Errorf("href not rewritten: %s", result)
+	}
+	if !strings.Contains(result, `src="/prefix/img.png"`) {
+		t.Errorf("src not rewritten: %s", result)
+	}
+}
+
+func TestRewritePathPrefix_JS(t *testing.T) {
+	dir := t.TempDir()
+	content := `fetch("/api/data")`
+	path := filepath.Join(dir, "main.js")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewritePathPrefix(dir, "/base"); err != nil {
+		t.Fatalf("rewritePathPrefix: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `fetch("/base/api/data")`) {
+		t.Errorf("fetch not rewritten: %s", string(data))
+	}
+}
+
+func TestRewritePathPrefix_SkipsNonHTMLJS(t *testing.T) {
+	dir := t.TempDir()
+	content := `href="/page"`
+	path := filepath.Join(dir, "data.json")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewritePathPrefix(dir, "/prefix"); err != nil {
+		t.Fatalf("rewritePathPrefix: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	// JSON file should be unchanged
+	if string(data) != content {
+		t.Errorf("non-html/js file should not be modified: %s", string(data))
+	}
+}
+
+func TestRewritePathPrefix_NoChangesNeeded(t *testing.T) {
+	dir := t.TempDir()
+	content := `<html><body>no absolute paths</body></html>`
+	path := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewritePathPrefix(dir, "/prefix"); err != nil {
+		t.Fatalf("rewritePathPrefix: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	// unchanged
+	if string(data) != content {
+		t.Errorf("content should be unchanged: %s", string(data))
+	}
+}
+
+func TestRewritePathPrefix_WindowsLocationHref(t *testing.T) {
+	dir := t.TempDir()
+	content := `window.location.href = "/"`
+	path := filepath.Join(dir, "nav.js")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewritePathPrefix(dir, "/base"); err != nil {
+		t.Fatalf("rewritePathPrefix: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), `window.location.href = "/base/"`) {
+		t.Errorf("window.location.href not rewritten: %s", string(data))
+	}
+}
+
+func TestRewritePathPrefix_NonExistentDir(t *testing.T) {
+	// Walk on non-existent dir returns error
+	err := rewritePathPrefix("/nonexistent-dir-archdocs-rewrite", "/prefix")
+	if err == nil {
+		t.Error("expected error for non-existent dir")
+	}
+}
+
+func TestRewritePathPrefix_ReadFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(path, []byte(`<a href="/page">link</a>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0600) }) //nolint:errcheck
+	// ReadFile failure is silently ignored (returns nil)
+	if err := rewritePathPrefix(dir, "/prefix"); err != nil {
+		t.Errorf("expected no error when ReadFile fails (silently ignored): %v", err)
+	}
+}
+
+func TestRewritePathPrefix_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(path, []byte(`<a href="/page">link</a>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Make file readable but not writable so WriteFile fails after rewrite
+	if err := os.Chmod(path, 0444); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0644) }) //nolint:errcheck
+	err := rewritePathPrefix(dir, "/prefix")
+	if err == nil {
+		t.Error("expected error when WriteFile fails on read-only file")
+	}
+}
+
+// ── resolveTemplates ──────────────────────────────────────────────────────────
+
+func TestResolveTemplates_Override(t *testing.T) {
+	override := t.TempDir()
+	dir, cleanup, err := resolveTemplates(override)
+	if err != nil {
+		t.Fatalf("resolveTemplates: %v", err)
+	}
+	if cleanup != nil {
+		t.Error("override should not return a cleanup function")
+	}
+	if dir != override {
+		t.Errorf("dir = %q; want %q", dir, override)
+	}
+}
+
+func TestResolveTemplates_MkdirTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
+	_, cleanup, err := resolveTemplates("")
+	if err == nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		t.Error("expected error when os.MkdirTemp fails")
+	}
+}
+
+func TestResolveTemplates_Bundled(t *testing.T) {
+	dir, cleanup, err := resolveTemplates("")
+	if err != nil {
+		t.Fatalf("resolveTemplates bundled: %v", err)
+	}
+	if cleanup == nil {
+		t.Error("bundled templates should return a cleanup function")
+	}
+	defer cleanup()
+	if dir == "" {
+		t.Error("dir should not be empty")
+	}
+	// Verify the tmp dir exists and has files
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("bundled templates dir should have files")
+	}
+}

--- a/internal/archdocs/pssg/affiliate/affiliate_test.go
+++ b/internal/archdocs/pssg/affiliate/affiliate_test.go
@@ -1,0 +1,189 @@
+package affiliate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+)
+
+// ── Provider.GenerateLink ─────────────────────────────────────────────────────
+
+func TestGenerateLink_Basic(t *testing.T) {
+	p := &Provider{
+		Name:        "amazon",
+		URLTemplate: "https://amazon.com/s?k={{term}}&tag={{tag}}",
+		Tag:         "mytag-20",
+	}
+	url := p.GenerateLink("cast iron pan")
+	if !strings.Contains(url, "cast+iron+pan") {
+		t.Errorf("expected + encoding for spaces, got: %s", url)
+	}
+	if !strings.Contains(url, "mytag-20") {
+		t.Errorf("expected tag in URL, got: %s", url)
+	}
+}
+
+func TestGenerateLink_SpecialChars(t *testing.T) {
+	p := &Provider{
+		Name:        "amazon",
+		URLTemplate: "https://amazon.com/s?k={{term}}",
+		Tag:         "",
+	}
+	url := p.GenerateLink("bread & butter")
+	if url == "" {
+		t.Error("expected non-empty URL")
+	}
+}
+
+// ── NewRegistry ───────────────────────────────────────────────────────────────
+
+func TestNewRegistry_SkipsNoTag(t *testing.T) {
+	cfg := config.AffiliatesConfig{
+		Providers: []config.AffiliateProviderConfig{
+			{Name: "amazon", URLTemplate: "...", EnvVar: "SUPERMODEL_TEST_NONEXISTENT_VAR_XYZ"},
+		},
+	}
+	r := NewRegistry(cfg)
+	if len(r.Providers) != 0 {
+		t.Errorf("expected 0 providers (no env var set), got %d", len(r.Providers))
+	}
+}
+
+func TestNewRegistry_AlwaysInclude(t *testing.T) {
+	cfg := config.AffiliatesConfig{
+		Providers: []config.AffiliateProviderConfig{
+			{Name: "amazon", URLTemplate: "...", AlwaysInclude: true},
+		},
+	}
+	r := NewRegistry(cfg)
+	if len(r.Providers) != 1 {
+		t.Errorf("expected 1 provider (always include), got %d", len(r.Providers))
+	}
+}
+
+func TestNewRegistry_WithEnvVar(t *testing.T) {
+	t.Setenv("SUPERMODEL_TEST_TAG_VAR", "testtag-20")
+	cfg := config.AffiliatesConfig{
+		Providers: []config.AffiliateProviderConfig{
+			{Name: "amazon", URLTemplate: "https://example.com?tag={{tag}}", EnvVar: "SUPERMODEL_TEST_TAG_VAR"},
+		},
+	}
+	r := NewRegistry(cfg)
+	if len(r.Providers) != 1 {
+		t.Errorf("expected 1 provider, got %d", len(r.Providers))
+	}
+	if r.Providers[0].Tag != "testtag-20" {
+		t.Errorf("expected tag 'testtag-20', got %q", r.Providers[0].Tag)
+	}
+}
+
+func TestNewRegistry_EmptyProviders(t *testing.T) {
+	r := NewRegistry(config.AffiliatesConfig{})
+	if len(r.Providers) != 0 {
+		t.Errorf("expected 0 providers, got %d", len(r.Providers))
+	}
+}
+
+// ── Registry.GenerateLinks ────────────────────────────────────────────────────
+
+func TestGenerateLinks_NoProviders(t *testing.T) {
+	r := &Registry{}
+	links := r.GenerateLinks(map[string]interface{}{"term": "flour"}, []string{"term"})
+	if links != nil {
+		t.Errorf("expected nil with no providers, got %v", links)
+	}
+}
+
+func TestGenerateLinks_NilEnrichment(t *testing.T) {
+	r := &Registry{Providers: []Provider{{Name: "amazon", URLTemplate: "..."}}}
+	links := r.GenerateLinks(nil, []string{"term"})
+	if links != nil {
+		t.Errorf("expected nil with nil enrichment, got %v", links)
+	}
+}
+
+func TestGenerateLinks_SimpleField(t *testing.T) {
+	r := &Registry{Providers: []Provider{
+		{Name: "amazon", URLTemplate: "https://example.com?k={{term}}", Tag: "tag"},
+	}}
+	data := map[string]interface{}{"term": "flour"}
+	links := r.GenerateLinks(data, []string{"term"})
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+	if links[0].Term != "flour" {
+		t.Errorf("expected term 'flour', got %q", links[0].Term)
+	}
+}
+
+func TestGenerateLinks_ArrayField(t *testing.T) {
+	r := &Registry{Providers: []Provider{
+		{Name: "amazon", URLTemplate: "https://example.com?k={{term}}"},
+	}}
+	data := map[string]interface{}{
+		"ingredients": []interface{}{
+			map[string]interface{}{"searchTerm": "flour"},
+			map[string]interface{}{"searchTerm": "sugar"},
+		},
+	}
+	links := r.GenerateLinks(data, []string{"ingredients[].searchTerm"})
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d", len(links))
+	}
+}
+
+// ── extractTerms ──────────────────────────────────────────────────────────────
+
+func TestExtractTerms_SimpleField(t *testing.T) {
+	data := map[string]interface{}{"keyword": "cast iron"}
+	terms := extractTerms(data, "keyword")
+	if len(terms) != 1 || terms[0] != "cast iron" {
+		t.Errorf("got %v", terms)
+	}
+}
+
+func TestExtractTerms_SimpleFieldMissing(t *testing.T) {
+	terms := extractTerms(map[string]interface{}{}, "keyword")
+	if len(terms) != 0 {
+		t.Errorf("missing key: got %v", terms)
+	}
+}
+
+func TestExtractTerms_SimpleFieldNonString(t *testing.T) {
+	data := map[string]interface{}{"count": 42}
+	terms := extractTerms(data, "count")
+	if len(terms) != 0 {
+		t.Errorf("non-string: got %v", terms)
+	}
+}
+
+func TestExtractTerms_ArrayPath(t *testing.T) {
+	data := map[string]interface{}{
+		"ingredients": []interface{}{
+			map[string]interface{}{"searchTerm": "flour"},
+			map[string]interface{}{"searchTerm": ""},      // empty term skipped
+			map[string]interface{}{"other": "no term"},    // missing field skipped
+			"not a map",                                   // non-map skipped
+		},
+	}
+	terms := extractTerms(data, "ingredients[].searchTerm")
+	if len(terms) != 1 || terms[0] != "flour" {
+		t.Errorf("expected ['flour'], got %v", terms)
+	}
+}
+
+func TestExtractTerms_ArrayFieldMissing(t *testing.T) {
+	terms := extractTerms(map[string]interface{}{}, "gear[].searchTerm")
+	if len(terms) != 0 {
+		t.Errorf("missing array field: got %v", terms)
+	}
+}
+
+func TestExtractTerms_ArrayFieldNotSlice(t *testing.T) {
+	data := map[string]interface{}{"ingredients": "not a slice"}
+	terms := extractTerms(data, "ingredients[].searchTerm")
+	if len(terms) != 0 {
+		t.Errorf("non-slice: got %v", terms)
+	}
+}

--- a/internal/archdocs/pssg/build/build_test.go
+++ b/internal/archdocs/pssg/build/build_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/render"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/taxonomy"
 )
 
 func newBuilder(outDir string) *Builder {
@@ -122,6 +124,92 @@ func TestGenerateSearchIndex_DisabledSearch(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(outDir, "search-index.json")); !os.IsNotExist(err) {
 		t.Error("search-index.json should not be written when search is disabled")
+	}
+}
+
+// ── shareImageURL ─────────────────────────────────────────────────────────────
+
+func TestShareImageURL(t *testing.T) {
+	got := shareImageURL("https://example.com", "recipe-soup.png")
+	want := "https://example.com/images/share/recipe-soup.png"
+	if got != want {
+		t.Errorf("shareImageURL: got %q, want %q", got, want)
+	}
+}
+
+// ── countTaxEntries ───────────────────────────────────────────────────────────
+
+func TestCountTaxEntries(t *testing.T) {
+	taxes := []taxonomy.Taxonomy{
+		{Entries: []taxonomy.Entry{{}, {}}},
+		{Entries: []taxonomy.Entry{{}}},
+	}
+	if got := countTaxEntries(taxes); got != 3 {
+		t.Errorf("countTaxEntries: got %d, want 3", got)
+	}
+	if got := countTaxEntries(nil); got != 0 {
+		t.Errorf("countTaxEntries(nil): got %d, want 0", got)
+	}
+}
+
+// ── countFieldDistribution ────────────────────────────────────────────────────
+
+func TestCountFieldDistribution(t *testing.T) {
+	entities := []*entity.Entity{
+		{Fields: map[string]interface{}{"cuisine": "Italian"}},
+		{Fields: map[string]interface{}{"cuisine": "Italian"}},
+		{Fields: map[string]interface{}{"cuisine": "French"}},
+		{Fields: map[string]interface{}{"cuisine": ""}}, // empty, should be skipped
+	}
+	result := countFieldDistribution(entities, "cuisine", 10)
+	if len(result) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(result))
+	}
+	// Should be sorted desc by count
+	if result[0].Name != "Italian" || result[0].Count != 2 {
+		t.Errorf("first entry: got {%s %d}, want {Italian 2}", result[0].Name, result[0].Count)
+	}
+	if result[1].Name != "French" || result[1].Count != 1 {
+		t.Errorf("second entry: got {%s %d}, want {French 1}", result[1].Name, result[1].Count)
+	}
+}
+
+func TestCountFieldDistribution_Limit(t *testing.T) {
+	entities := []*entity.Entity{
+		{Fields: map[string]interface{}{"tag": "a"}},
+		{Fields: map[string]interface{}{"tag": "a"}},
+		{Fields: map[string]interface{}{"tag": "b"}},
+		{Fields: map[string]interface{}{"tag": "b"}},
+		{Fields: map[string]interface{}{"tag": "c"}},
+	}
+	result := countFieldDistribution(entities, "tag", 2)
+	if len(result) != 2 {
+		t.Errorf("limit=2: want 2 entries, got %d", len(result))
+	}
+}
+
+func TestCountFieldDistribution_Empty(t *testing.T) {
+	if got := countFieldDistribution(nil, "field", 10); len(got) != 0 {
+		t.Errorf("nil entities: want empty, got %v", got)
+	}
+}
+
+// ── toBreadcrumbItems ─────────────────────────────────────────────────────────
+
+func TestToBreadcrumbItems(t *testing.T) {
+	bcs := []render.Breadcrumb{
+		{Name: "Home", URL: "https://example.com/"},
+		{Name: "Recipes", URL: "https://example.com/recipes/"},
+	}
+	items := toBreadcrumbItems(bcs)
+	if len(items) != 2 {
+		t.Fatalf("want 2 items, got %d", len(items))
+	}
+	if items[0].Name != "Home" || items[0].URL != "https://example.com/" {
+		t.Errorf("first item: got %+v", items[0])
+	}
+	if items[1].Name != "Recipes" {
+		t.Errorf("second item: got %+v", items[1])
 	}
 }
 

--- a/internal/archdocs/pssg/build/build_test.go
+++ b/internal/archdocs/pssg/build/build_test.go
@@ -273,6 +273,288 @@ func TestMaybeWriteShareSVG_Enabled(t *testing.T) {
 	}
 }
 
+// TestWriteShareSVG_MkdirAllError covers L1310: writeShareSVG returns an error
+// when MkdirAll fails because a file exists at the parent path.
+func TestWriteShareSVG_MkdirAllError(t *testing.T) {
+	outDir := t.TempDir()
+	// Place a regular file at the "images" subdirectory so MkdirAll("images/share") fails.
+	if err := os.WriteFile(filepath.Join(outDir, "images"), []byte("block"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	err := writeShareSVG(outDir, "test.svg", "<svg/>")
+	if err == nil {
+		t.Error("expected MkdirAll error when parent path is a file")
+	}
+}
+
+// TestGenerateSearchIndex_WriteFileError covers L1365: generateSearchIndex returns
+// an error when os.WriteFile fails because the output directory is not writable.
+func TestGenerateSearchIndex_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	outDir := t.TempDir()
+	if err := os.Chmod(outDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(outDir, 0755) }) //nolint:errcheck
+
+	ent := &entity.Entity{Slug: "test-recipe", Fields: map[string]interface{}{"title": "Test"}}
+	b := NewBuilder(&config.Config{Search: config.SearchConfig{Enabled: true}}, false)
+	err := b.generateSearchIndex([]*entity.Entity{ent}, outDir)
+	if err == nil {
+		t.Error("expected WriteFile error when outDir is not writable")
+	}
+}
+
+// ── copyDir ───────────────────────────────────────────────────────────────────
+
+func TestCopyDir_CopiesFiles(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("hello"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+	if err != nil {
+		t.Fatalf("copied file not found: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("content mismatch: got %q, want %q", data, "hello")
+	}
+}
+
+func TestCopyDir_CopiesSubdirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	sub := filepath.Join(src, "sub")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b.txt"), []byte("world"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copyDir with subdir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dst, "sub", "b.txt"))
+	if err != nil {
+		t.Fatalf("copied subdir file not found: %v", err)
+	}
+	if string(data) != "world" {
+		t.Errorf("content mismatch: got %q", data)
+	}
+}
+
+func TestCopyDir_NonExistentSrc(t *testing.T) {
+	dst := t.TempDir()
+	// Non-existent src → IsNotExist → returns nil (no-op)
+	if err := copyDir(filepath.Join(t.TempDir(), "nonexistent"), dst); err != nil {
+		t.Errorf("copyDir on non-existent src should return nil, got: %v", err)
+	}
+}
+
+func TestCopyDir_ReadFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	f := filepath.Join(src, "locked.txt")
+	if err := os.WriteFile(f, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(f, 0600) }) //nolint:errcheck
+
+	if err := copyDir(src, dst); err == nil {
+		t.Error("copyDir should fail when a file cannot be read")
+	}
+}
+
+func TestCopyDir_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("hello"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dst, 0555); err != nil { // read-only
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dst, 0755) }) //nolint:errcheck
+
+	if err := copyDir(src, dst); err == nil {
+		t.Error("copyDir should fail when destination is read-only")
+	}
+}
+
+func TestCopyDir_ReadDirError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	// Create a dir that exists but is unreadable (non-IsNotExist error).
+	src := t.TempDir()
+	if err := os.Chmod(src, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(src, 0755) }) //nolint:errcheck
+
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err == nil {
+		t.Error("copyDir should fail when src dir is unreadable")
+	}
+}
+
+func TestCopyDir_RecursiveError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	sub := filepath.Join(src, "sub")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	locked := filepath.Join(sub, "locked.txt")
+	if err := os.WriteFile(locked, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0600) }) //nolint:errcheck
+
+	if err := copyDir(src, dst); err == nil {
+		t.Error("copyDir should fail when recursive copy encounters an unreadable file")
+	}
+}
+
+func TestCopyDir_MkdirAllError(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a subdir in src
+	sub := filepath.Join(src, "sub")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f.txt"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Block dst/sub creation by placing a regular file there
+	if err := os.WriteFile(filepath.Join(dst, "sub"), []byte("blocker"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyDir(src, dst); err == nil {
+		t.Error("copyDir should fail when MkdirAll cannot create a subdir")
+	}
+}
+
+// ── loadFavorites ─────────────────────────────────────────────────────────────
+
+func TestLoadFavorites_EmptyPath(t *testing.T) {
+	b := NewBuilder(&config.Config{}, false)
+	if got := b.loadFavorites(nil); got != nil {
+		t.Errorf("empty favorites path should return nil, got %v", got)
+	}
+}
+
+func TestLoadFavorites_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	favFile := filepath.Join(dir, "favorites.json")
+	if err := os.WriteFile(favFile, []byte(`["slug-a","slug-b"]`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	ents := map[string]*entity.Entity{
+		"slug-a": {Slug: "slug-a"},
+		"slug-b": {Slug: "slug-b"},
+	}
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Favorites: favFile}}, false)
+	result := b.loadFavorites(ents)
+	if len(result) != 2 {
+		t.Errorf("expected 2 favorites, got %d", len(result))
+	}
+}
+
+func TestLoadFavorites_MissingFile(t *testing.T) {
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Favorites: "/nonexistent/favorites.json"}}, false)
+	if got := b.loadFavorites(nil); got != nil {
+		t.Errorf("missing file should return nil, got %v", got)
+	}
+}
+
+func TestLoadFavorites_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	favFile := filepath.Join(dir, "favorites.json")
+	if err := os.WriteFile(favFile, []byte(`{not valid`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Favorites: favFile}}, false)
+	if got := b.loadFavorites(nil); got != nil {
+		t.Errorf("invalid JSON should return nil, got %v", got)
+	}
+}
+
+// ── loadContributors ──────────────────────────────────────────────────────────
+
+func TestLoadContributors_EmptyPath(t *testing.T) {
+	b := NewBuilder(&config.Config{}, false)
+	if got := b.loadContributors(); got != nil {
+		t.Errorf("empty contributors path should return nil, got %v", got)
+	}
+}
+
+func TestLoadContributors_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	cFile := filepath.Join(dir, "contributors.json")
+	if err := os.WriteFile(cFile, []byte(`{"alice":{"role":"editor"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Contributors: cFile}}, false)
+	result := b.loadContributors()
+	if result == nil {
+		t.Error("should return non-nil map for valid JSON")
+	}
+	if _, ok := result["alice"]; !ok {
+		t.Error("result should contain 'alice'")
+	}
+}
+
+func TestLoadContributors_MissingFile(t *testing.T) {
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Contributors: "/nonexistent/contributors.json"}}, false)
+	if got := b.loadContributors(); got != nil {
+		t.Errorf("missing file should return nil, got %v", got)
+	}
+}
+
+func TestLoadContributors_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	cFile := filepath.Join(dir, "contributors.json")
+	if err := os.WriteFile(cFile, []byte(`not json`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBuilder(&config.Config{Extra: config.ExtraConfig{Contributors: cFile}}, false)
+	if got := b.loadContributors(); got != nil {
+		t.Errorf("invalid JSON should return nil, got %v", got)
+	}
+}
+
 // readSearchIndex reads and unmarshals the search-index.json from outDir.
 func readSearchIndex(t *testing.T, outDir string) []map[string]string {
 	t.Helper()

--- a/internal/archdocs/pssg/build/build_test.go
+++ b/internal/archdocs/pssg/build/build_test.go
@@ -2,8 +2,10 @@ package build
 
 import (
 	"encoding/json"
+	"html/template"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -210,6 +212,64 @@ func TestToBreadcrumbItems(t *testing.T) {
 	}
 	if items[1].Name != "Recipes" {
 		t.Errorf("second item: got %+v", items[1])
+	}
+}
+
+// ── toTemplateHTML ────────────────────────────────────────────────────────────
+
+func TestToTemplateHTML(t *testing.T) {
+	input := "<strong>hello &amp; world</strong>"
+	got := toTemplateHTML(input)
+	if got != template.HTML(input) {
+		t.Errorf("toTemplateHTML: got %q, want %q", got, input)
+	}
+}
+
+// ── writeShareSVG ─────────────────────────────────────────────────────────────
+
+func TestWriteShareSVG(t *testing.T) {
+	outDir := t.TempDir()
+	svg := `<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>`
+	if err := writeShareSVG(outDir, "test.svg", svg); err != nil {
+		t.Fatalf("writeShareSVG: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, "images", "share", "test.svg"))
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if !strings.Contains(string(data), "<svg") {
+		t.Error("written file should contain SVG content")
+	}
+}
+
+// ── maybeWriteShareSVG ────────────────────────────────────────────────────────
+
+func TestMaybeWriteShareSVG_Disabled(t *testing.T) {
+	outDir := t.TempDir()
+	b := NewBuilder(&config.Config{
+		Output: config.OutputConfig{ShareImages: false},
+		Paths:  config.PathsConfig{Output: outDir},
+	}, false)
+	if err := b.maybeWriteShareSVG(outDir, "test.svg", "<svg/>"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// File should NOT be written when ShareImages=false.
+	if _, err := os.Stat(filepath.Join(outDir, "images", "share", "test.svg")); !os.IsNotExist(err) {
+		t.Error("share image should not be written when ShareImages=false")
+	}
+}
+
+func TestMaybeWriteShareSVG_Enabled(t *testing.T) {
+	outDir := t.TempDir()
+	b := NewBuilder(&config.Config{
+		Output: config.OutputConfig{ShareImages: true},
+		Paths:  config.PathsConfig{Output: outDir},
+	}, false)
+	if err := b.maybeWriteShareSVG(outDir, "test.svg", "<svg/>"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "images", "share", "test.svg")); err != nil {
+		t.Errorf("share image should be written when ShareImages=true: %v", err)
 	}
 }
 

--- a/internal/archdocs/pssg/config/config_test.go
+++ b/internal/archdocs/pssg/config/config_test.go
@@ -1,0 +1,259 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeYAML(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// ── Load ──────────────────────────────────────────────────────────────────────
+
+func TestLoad_Valid(t *testing.T) {
+	path := writeYAML(t, `
+site:
+  name: "My Site"
+  base_url: "https://example.com"
+paths:
+  data: "data"
+`)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Site.Name != "My Site" {
+		t.Errorf("site.name: got %q", cfg.Site.Name)
+	}
+	// Defaults should be applied
+	if cfg.Site.Language != "en" {
+		t.Errorf("language default: got %q", cfg.Site.Language)
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load("/nonexistent/config.yaml")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	path := writeYAML(t, "not: valid: yaml: {")
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestLoad_MissingSiteName(t *testing.T) {
+	path := writeYAML(t, `
+site:
+  base_url: "https://example.com"
+paths:
+  data: "data"
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected validation error for missing site.name")
+	}
+}
+
+func TestLoad_MissingBaseURL(t *testing.T) {
+	path := writeYAML(t, `
+site:
+  name: "My Site"
+paths:
+  data: "data"
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected validation error for missing site.base_url")
+	}
+}
+
+func TestLoad_MissingPathsData(t *testing.T) {
+	path := writeYAML(t, `
+site:
+  name: "My Site"
+  base_url: "https://example.com"
+`)
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected validation error for missing paths.data")
+	}
+}
+
+// ── applyDefaults ─────────────────────────────────────────────────────────────
+
+func TestApplyDefaults_SetsLanguage(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Site.Language != "en" {
+		t.Errorf("language: got %q", cfg.Site.Language)
+	}
+}
+
+func TestApplyDefaults_PreservesExistingLanguage(t *testing.T) {
+	cfg := &Config{Site: SiteConfig{Language: "fr"}}
+	applyDefaults(cfg)
+	if cfg.Site.Language != "fr" {
+		t.Errorf("should preserve existing language 'fr', got %q", cfg.Site.Language)
+	}
+}
+
+func TestApplyDefaults_SetsOutputPath(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Paths.Output != "docs" {
+		t.Errorf("output: got %q", cfg.Paths.Output)
+	}
+}
+
+func TestApplyDefaults_SetsPagination(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Pagination.EntitiesPerPage != 48 {
+		t.Errorf("entities_per_page: got %d", cfg.Pagination.EntitiesPerPage)
+	}
+}
+
+func TestApplyDefaults_SetsTaxonomyDefaults(t *testing.T) {
+	cfg := &Config{
+		Taxonomies: []TaxonomyConfig{{}},
+	}
+	applyDefaults(cfg)
+	if cfg.Taxonomies[0].MinEntities != 1 {
+		t.Errorf("min_entities: got %d", cfg.Taxonomies[0].MinEntities)
+	}
+	if cfg.Taxonomies[0].LetterPageThreshold != 50 {
+		t.Errorf("letter_page_threshold: got %d", cfg.Taxonomies[0].LetterPageThreshold)
+	}
+	if cfg.Taxonomies[0].Template != "hub.html" {
+		t.Errorf("template: got %q", cfg.Taxonomies[0].Template)
+	}
+}
+
+func TestApplyDefaults_SetsSitemapDefaults(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Sitemap.Priorities == nil {
+		t.Error("sitemap priorities should be set")
+	}
+	if cfg.Sitemap.ChangeFreqs == nil {
+		t.Error("sitemap change freqs should be set")
+	}
+}
+
+func TestApplyDefaults_SetsTemplateDefaults(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Templates.Entity != "recipe.html" {
+		t.Errorf("entity template: got %q", cfg.Templates.Entity)
+	}
+	if cfg.Templates.Homepage != "index.html" {
+		t.Errorf("homepage template: got %q", cfg.Templates.Homepage)
+	}
+}
+
+// ── resolvePaths ──────────────────────────────────────────────────────────────
+
+func TestResolvePaths_RelativePaths(t *testing.T) {
+	cfg := &Config{
+		ConfigDir: "/base",
+		Paths: PathsConfig{
+			Data:      "data",
+			Templates: "templates",
+			Output:    "docs",
+			Cache:     ".cache",
+		},
+	}
+	resolvePaths(cfg)
+	if cfg.Paths.Data != filepath.Join("/base", "data") {
+		t.Errorf("data: got %q", cfg.Paths.Data)
+	}
+	if cfg.Paths.Output != filepath.Join("/base", "docs") {
+		t.Errorf("output: got %q", cfg.Paths.Output)
+	}
+}
+
+func TestResolvePaths_AbsPathPreserved(t *testing.T) {
+	cfg := &Config{
+		ConfigDir: "/base",
+		Paths: PathsConfig{
+			Data:      "/absolute/data",
+			Templates: "/absolute/templates",
+			Output:    "/absolute/docs",
+			Cache:     "/absolute/.cache",
+		},
+	}
+	resolvePaths(cfg)
+	if cfg.Paths.Data != "/absolute/data" {
+		t.Errorf("absolute path should be preserved: got %q", cfg.Paths.Data)
+	}
+}
+
+func TestResolvePaths_OptionalPaths(t *testing.T) {
+	cfg := &Config{
+		ConfigDir: "/base",
+		Paths: PathsConfig{
+			Data:      "data",
+			Templates: "templates",
+			Output:    "docs",
+			Cache:     ".cache",
+			Static:    "static",
+		},
+		Enrichment: EnrichmentConfig{CacheDir: "enrichment-cache"},
+		Extra: ExtraConfig{
+			Favorites:    "favorites.json",
+			Contributors: "contributors.json",
+		},
+	}
+	resolvePaths(cfg)
+	if cfg.Paths.Static != filepath.Join("/base", "static") {
+		t.Errorf("static: got %q", cfg.Paths.Static)
+	}
+	if cfg.Enrichment.CacheDir != filepath.Join("/base", "enrichment-cache") {
+		t.Errorf("enrichment cache dir: got %q", cfg.Enrichment.CacheDir)
+	}
+	if cfg.Extra.Favorites != filepath.Join("/base", "favorites.json") {
+		t.Errorf("favorites: got %q", cfg.Extra.Favorites)
+	}
+	if cfg.Extra.Contributors != filepath.Join("/base", "contributors.json") {
+		t.Errorf("contributors: got %q", cfg.Extra.Contributors)
+	}
+}
+
+func TestResolvePaths_EmptyOptionalPaths(t *testing.T) {
+	cfg := &Config{
+		ConfigDir: "/base",
+		Paths: PathsConfig{
+			Data:      "data",
+			Templates: "templates",
+			Output:    "docs",
+			Cache:     ".cache",
+			// Static empty
+		},
+		// Enrichment.CacheDir empty
+		// Extra.Favorites empty
+		// Extra.Contributors empty
+	}
+	resolvePaths(cfg)
+	if cfg.Paths.Static != "" {
+		t.Errorf("empty static should remain empty, got %q", cfg.Paths.Static)
+	}
+	if cfg.Enrichment.CacheDir != "" {
+		t.Errorf("empty enrichment cache dir should remain empty")
+	}
+}

--- a/internal/archdocs/pssg/enrichment/cache_test.go
+++ b/internal/archdocs/pssg/enrichment/cache_test.go
@@ -1,0 +1,270 @@
+package enrichment
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeCache(t *testing.T, dir, slug string, entry CacheEntry) {
+	t.Helper()
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, slug+".json"), data, 0600); err != nil {
+		t.Fatalf("write cache: %v", err)
+	}
+}
+
+// ── ReadCache ─────────────────────────────────────────────────────────────────
+
+func TestReadCache_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	writeCache(t, dir, "test-slug", CacheEntry{
+		ContentHash: "abc",
+		Enrichment:  map[string]interface{}{"title": "Test"},
+	})
+
+	got := ReadCache(dir, "test-slug")
+	if got == nil {
+		t.Fatal("expected non-nil enrichment")
+	}
+	if got["title"] != "Test" {
+		t.Errorf("title: got %v", got["title"])
+	}
+}
+
+func TestReadCache_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	if got := ReadCache(dir, "nonexistent"); got != nil {
+		t.Errorf("missing file: expected nil, got %v", got)
+	}
+}
+
+func TestReadCache_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if got := ReadCache(dir, "bad"); got != nil {
+		t.Errorf("invalid JSON: expected nil, got %v", got)
+	}
+}
+
+// ── ReadAllCaches ─────────────────────────────────────────────────────────────
+
+func TestReadAllCaches_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	result, err := ReadAllCaches(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestReadAllCaches_EmptyCacheDir(t *testing.T) {
+	result, err := ReadAllCaches("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestReadAllCaches_NonExistentDir(t *testing.T) {
+	result, err := ReadAllCaches("/nonexistent-enrichment-dir-xyz")
+	if err != nil {
+		t.Fatalf("non-existent dir should return empty result, not error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestReadAllCaches_WithFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeCache(t, dir, "recipe-a", CacheEntry{Enrichment: map[string]interface{}{"field": "val"}})
+	writeCache(t, dir, "recipe-b", CacheEntry{Enrichment: map[string]interface{}{"other": "data"}})
+	// Also add a non-JSON file and a subdir (should be skipped)
+	if err := os.WriteFile(filepath.Join(dir, "skip.txt"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ReadAllCaches(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(result), result)
+	}
+	if result["recipe-a"] == nil || result["recipe-b"] == nil {
+		t.Error("expected both recipes in result")
+	}
+}
+
+func TestReadAllCaches_UnreadableDir(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0755) }) //nolint:errcheck
+
+	_, err := ReadAllCaches(dir)
+	if err == nil {
+		t.Error("expected error for unreadable cache dir")
+	}
+}
+
+func TestReadAllCaches_SkipsInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("not json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeCache(t, dir, "good", CacheEntry{Enrichment: map[string]interface{}{"k": "v"}})
+
+	result, err := ReadAllCaches(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("expected 1 valid entry, got %d", len(result))
+	}
+}
+
+// ── GetIngredients ────────────────────────────────────────────────────────────
+
+func TestGetIngredients_Present(t *testing.T) {
+	data := map[string]interface{}{
+		"ingredients": []interface{}{
+			map[string]interface{}{"name": "flour", "amount": "2 cups"},
+			map[string]interface{}{"name": "sugar", "amount": "1 cup"},
+		},
+	}
+	got := GetIngredients(data)
+	if len(got) != 2 {
+		t.Errorf("expected 2 ingredients, got %d", len(got))
+	}
+}
+
+func TestGetIngredients_Missing(t *testing.T) {
+	if got := GetIngredients(map[string]interface{}{}); got != nil {
+		t.Errorf("missing key: expected nil, got %v", got)
+	}
+}
+
+func TestGetIngredients_WrongType(t *testing.T) {
+	data := map[string]interface{}{"ingredients": "string value"}
+	if got := GetIngredients(data); got != nil {
+		t.Errorf("wrong type: expected nil, got %v", got)
+	}
+}
+
+func TestGetIngredients_SkipsNonMapItems(t *testing.T) {
+	data := map[string]interface{}{
+		"ingredients": []interface{}{
+			map[string]interface{}{"name": "flour"},
+			"not a map",
+			42,
+		},
+	}
+	got := GetIngredients(data)
+	if len(got) != 1 {
+		t.Errorf("expected 1 (skipping non-map items), got %d", len(got))
+	}
+}
+
+// ── GetGear ───────────────────────────────────────────────────────────────────
+
+func TestGetGear_Present(t *testing.T) {
+	data := map[string]interface{}{
+		"gear": []interface{}{
+			map[string]interface{}{"name": "pan"},
+		},
+	}
+	got := GetGear(data)
+	if len(got) != 1 {
+		t.Errorf("expected 1 gear item, got %d", len(got))
+	}
+}
+
+func TestGetGear_Missing(t *testing.T) {
+	if got := GetGear(map[string]interface{}{}); got != nil {
+		t.Errorf("missing: expected nil, got %v", got)
+	}
+}
+
+func TestGetGear_WrongType(t *testing.T) {
+	data := map[string]interface{}{"gear": "string"}
+	if got := GetGear(data); got != nil {
+		t.Errorf("wrong type: expected nil, got %v", got)
+	}
+}
+
+// ── GetCookingTips ────────────────────────────────────────────────────────────
+
+func TestGetCookingTips_Present(t *testing.T) {
+	data := map[string]interface{}{
+		"cookingTips": []interface{}{"tip1", "tip2"},
+	}
+	got := GetCookingTips(data)
+	if len(got) != 2 || got[0] != "tip1" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetCookingTips_Missing(t *testing.T) {
+	if got := GetCookingTips(map[string]interface{}{}); got != nil {
+		t.Errorf("missing: expected nil, got %v", got)
+	}
+}
+
+func TestGetCookingTips_WrongType(t *testing.T) {
+	data := map[string]interface{}{"cookingTips": "single tip"}
+	if got := GetCookingTips(data); got != nil {
+		t.Errorf("wrong type: expected nil, got %v", got)
+	}
+}
+
+func TestGetCookingTips_SkipsNonString(t *testing.T) {
+	data := map[string]interface{}{
+		"cookingTips": []interface{}{"tip1", 42, "tip2"},
+	}
+	got := GetCookingTips(data)
+	if len(got) != 2 {
+		t.Errorf("expected 2 (skip non-string), got %d: %v", len(got), got)
+	}
+}
+
+// ── GetCoachingPrompt ─────────────────────────────────────────────────────────
+
+func TestGetCoachingPrompt_Present(t *testing.T) {
+	data := map[string]interface{}{"coachingPrompt": "Be patient with this recipe."}
+	got := GetCoachingPrompt(data)
+	if got != "Be patient with this recipe." {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestGetCoachingPrompt_Missing(t *testing.T) {
+	if got := GetCoachingPrompt(map[string]interface{}{}); got != "" {
+		t.Errorf("missing: expected empty, got %q", got)
+	}
+}
+
+func TestGetCoachingPrompt_WrongType(t *testing.T) {
+	data := map[string]interface{}{"coachingPrompt": 42}
+	if got := GetCoachingPrompt(data); got != "" {
+		t.Errorf("wrong type: expected empty, got %q", got)
+	}
+}

--- a/internal/archdocs/pssg/entity/entity_test.go
+++ b/internal/archdocs/pssg/entity/entity_test.go
@@ -1,0 +1,341 @@
+package entity
+
+import (
+	"testing"
+)
+
+// ── GetString ─────────────────────────────────────────────────────────────────
+
+func TestGetString_Present(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"title": "My Recipe"}}
+	if got := e.GetString("title"); got != "My Recipe" {
+		t.Errorf("got %q, want %q", got, "My Recipe")
+	}
+}
+
+func TestGetString_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if got := e.GetString("missing"); got != "" {
+		t.Errorf("missing key: got %q, want empty", got)
+	}
+}
+
+func TestGetString_NonString(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"count": 42}}
+	if got := e.GetString("count"); got != "" {
+		t.Errorf("non-string: got %q, want empty", got)
+	}
+}
+
+// ── GetStringSlice ────────────────────────────────────────────────────────────
+
+func TestGetStringSlice_StringSlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []string{"a", "b"}}}
+	got := e.GetStringSlice("tags")
+	if len(got) != 2 || got[0] != "a" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetStringSlice_InterfaceSlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []interface{}{"x", "y"}}}
+	got := e.GetStringSlice("tags")
+	if len(got) != 2 || got[1] != "y" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetStringSlice_InterfaceSliceWithNonString(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []interface{}{"x", 42}}}
+	got := e.GetStringSlice("tags")
+	if len(got) != 1 || got[0] != "x" {
+		t.Errorf("expected 1 item with 'x', got %v", got)
+	}
+}
+
+func TestGetStringSlice_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if got := e.GetStringSlice("tags"); got != nil {
+		t.Errorf("missing key: got %v, want nil", got)
+	}
+}
+
+func TestGetStringSlice_WrongType(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": "string"}}
+	if got := e.GetStringSlice("tags"); got != nil {
+		t.Errorf("wrong type: got %v, want nil", got)
+	}
+}
+
+// ── GetInt ────────────────────────────────────────────────────────────────────
+
+func TestGetInt_Int(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"count": 5}}
+	if got := e.GetInt("count"); got != 5 {
+		t.Errorf("int: got %d, want 5", got)
+	}
+}
+
+func TestGetInt_Int64(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"count": int64(10)}}
+	if got := e.GetInt("count"); got != 10 {
+		t.Errorf("int64: got %d, want 10", got)
+	}
+}
+
+func TestGetInt_Float64(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"rating": float64(4)}}
+	if got := e.GetInt("rating"); got != 4 {
+		t.Errorf("float64: got %d, want 4", got)
+	}
+}
+
+func TestGetInt_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if got := e.GetInt("count"); got != 0 {
+		t.Errorf("missing: got %d, want 0", got)
+	}
+}
+
+func TestGetInt_WrongType(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"count": "five"}}
+	if got := e.GetInt("count"); got != 0 {
+		t.Errorf("wrong type: got %d, want 0", got)
+	}
+}
+
+// ── GetFloat ──────────────────────────────────────────────────────────────────
+
+func TestGetFloat_Float64(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"price": 3.14}}
+	if got := e.GetFloat("price"); got != 3.14 {
+		t.Errorf("float64: got %f", got)
+	}
+}
+
+func TestGetFloat_Int(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"price": 3}}
+	if got := e.GetFloat("price"); got != 3.0 {
+		t.Errorf("int: got %f", got)
+	}
+}
+
+func TestGetFloat_Int64(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"price": int64(7)}}
+	if got := e.GetFloat("price"); got != 7.0 {
+		t.Errorf("int64: got %f", got)
+	}
+}
+
+func TestGetFloat_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if got := e.GetFloat("price"); got != 0 {
+		t.Errorf("missing: got %f", got)
+	}
+}
+
+func TestGetFloat_WrongType(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"price": "cheap"}}
+	if got := e.GetFloat("price"); got != 0 {
+		t.Errorf("wrong type: got %f", got)
+	}
+}
+
+// ── GetBool ───────────────────────────────────────────────────────────────────
+
+func TestGetBool_True(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"active": true}}
+	if got := e.GetBool("active"); !got {
+		t.Error("expected true")
+	}
+}
+
+func TestGetBool_False(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"active": false}}
+	if got := e.GetBool("active"); got {
+		t.Error("expected false")
+	}
+}
+
+func TestGetBool_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if got := e.GetBool("active"); got {
+		t.Error("missing: expected false")
+	}
+}
+
+func TestGetBool_WrongType(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"active": "yes"}}
+	if got := e.GetBool("active"); got {
+		t.Error("wrong type: expected false")
+	}
+}
+
+// ── GetIngredients ────────────────────────────────────────────────────────────
+
+func TestGetIngredients_Present(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"ingredients": []string{"flour", "sugar"}}}
+	got := e.GetIngredients()
+	if len(got) != 2 || got[0] != "flour" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetIngredients_Missing(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{}}
+	if got := e.GetIngredients(); got != nil {
+		t.Errorf("missing: got %v", got)
+	}
+}
+
+func TestGetIngredients_WrongType(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"ingredients": "string"}}
+	if got := e.GetIngredients(); got != nil {
+		t.Errorf("wrong type: got %v", got)
+	}
+}
+
+// ── GetInstructions ───────────────────────────────────────────────────────────
+
+func TestGetInstructions_Present(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"instructions": []string{"mix", "bake"}}}
+	got := e.GetInstructions()
+	if len(got) != 2 {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetInstructions_Missing(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{}}
+	if got := e.GetInstructions(); got != nil {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetInstructions_WrongType(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"instructions": 42}}
+	if got := e.GetInstructions(); got != nil {
+		t.Errorf("wrong type: got %v", got)
+	}
+}
+
+// ── GetFAQs ───────────────────────────────────────────────────────────────────
+
+func TestGetFAQs_Present(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"faqs": []FAQ{{Question: "Q?", Answer: "A."}}}}
+	got := e.GetFAQs()
+	if len(got) != 1 || got[0].Question != "Q?" {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetFAQs_Missing(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{}}
+	if got := e.GetFAQs(); got != nil {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestGetFAQs_WrongType(t *testing.T) {
+	e := &Entity{Sections: map[string]interface{}{"faqs": "not faqs"}}
+	if got := e.GetFAQs(); got != nil {
+		t.Errorf("wrong type: got %v", got)
+	}
+}
+
+// ── HasField ──────────────────────────────────────────────────────────────────
+
+func TestHasField_PresentNonEmpty(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"title": "Cake"}}
+	if !e.HasField("title") {
+		t.Error("expected true for non-empty string")
+	}
+}
+
+func TestHasField_EmptyString(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"title": ""}}
+	if e.HasField("title") {
+		t.Error("expected false for empty string")
+	}
+}
+
+func TestHasField_NonEmptySlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []interface{}{"a"}}}
+	if !e.HasField("tags") {
+		t.Error("expected true for non-empty []interface{}")
+	}
+}
+
+func TestHasField_EmptyInterfaceSlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []interface{}{}}}
+	if e.HasField("tags") {
+		t.Error("expected false for empty []interface{}")
+	}
+}
+
+func TestHasField_NonEmptyStringSlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []string{"a"}}}
+	if !e.HasField("tags") {
+		t.Error("expected true for non-empty []string")
+	}
+}
+
+func TestHasField_EmptyStringSlice(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"tags": []string{}}}
+	if e.HasField("tags") {
+		t.Error("expected false for empty []string")
+	}
+}
+
+func TestHasField_NilValue(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"x": nil}}
+	if e.HasField("x") {
+		t.Error("expected false for nil value")
+	}
+}
+
+func TestHasField_OtherType(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{"count": 42}}
+	if !e.HasField("count") {
+		t.Error("expected true for int value (default case)")
+	}
+}
+
+func TestHasField_Missing(t *testing.T) {
+	e := &Entity{Fields: map[string]interface{}{}}
+	if e.HasField("missing") {
+		t.Error("expected false for missing key")
+	}
+}
+
+// ── ToSlug ────────────────────────────────────────────────────────────────────
+
+func TestToSlug_Basic(t *testing.T) {
+	if got := ToSlug("Chocolate Cake!"); got != "chocolate-cake" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToSlug_AlreadySlug(t *testing.T) {
+	if got := ToSlug("chocolate-cake"); got != "chocolate-cake" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToSlug_Numbers(t *testing.T) {
+	if got := ToSlug("Recipe 42"); got != "recipe-42" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToSlug_TrimHyphens(t *testing.T) {
+	if got := ToSlug("!!! title !!!"); got != "title" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestToSlug_Empty(t *testing.T) {
+	if got := ToSlug(""); got != "" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/archdocs/pssg/loader/loader_test.go
+++ b/internal/archdocs/pssg/loader/loader_test.go
@@ -1,0 +1,442 @@
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+)
+
+// ── splitFrontmatter ──────────────────────────────────────────────────────────
+
+func TestSplitFrontmatter_NoFrontmatter(t *testing.T) {
+	fm, body, err := splitFrontmatter("just body text")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm != "" {
+		t.Errorf("expected empty frontmatter, got %q", fm)
+	}
+	if body != "just body text" {
+		t.Errorf("expected body %q, got %q", "just body text", body)
+	}
+}
+
+func TestSplitFrontmatter_WithFrontmatter(t *testing.T) {
+	content := "---\ntitle: Test\n---\nbody here"
+	fm, body, err := splitFrontmatter(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm != "title: Test" {
+		t.Errorf("frontmatter mismatch: got %q", fm)
+	}
+	if body != "body here" {
+		t.Errorf("body mismatch: got %q", body)
+	}
+}
+
+func TestSplitFrontmatter_NoClosingDashes(t *testing.T) {
+	content := "---\ntitle: Test\nno closing"
+	_, _, err := splitFrontmatter(content)
+	if err == nil {
+		t.Error("expected error for missing closing ---")
+	}
+}
+
+func TestSplitFrontmatter_EmptyBody(t *testing.T) {
+	content := "---\ntitle: Test\n---"
+	fm, body, err := splitFrontmatter(content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fm != "title: Test" {
+		t.Errorf("frontmatter: got %q", fm)
+	}
+	if body != "" {
+		t.Errorf("empty body expected, got %q", body)
+	}
+}
+
+// ── extractSection ────────────────────────────────────────────────────────────
+
+func TestExtractSection_Found(t *testing.T) {
+	body := "## Ingredients\n- flour\n- sugar\n## Instructions\nMix well."
+	got := extractSection(body, "Ingredients")
+	if got != "- flour\n- sugar" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractSection_NotFound(t *testing.T) {
+	body := "## Instructions\nDo this."
+	got := extractSection(body, "Ingredients")
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestExtractSection_LastSection(t *testing.T) {
+	body := "## Instructions\nDo this.\nAnd that."
+	got := extractSection(body, "Instructions")
+	if got != "Do this.\nAnd that." {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractSection_HeadingWithNoNewline(t *testing.T) {
+	// No newline after heading → extractSection returns ""
+	body := "## Ingredients"
+	got := extractSection(body, "Ingredients")
+	if got != "" {
+		t.Errorf("expected empty for heading without newline, got %q", got)
+	}
+}
+
+// ── parseUnorderedList ────────────────────────────────────────────────────────
+
+func TestParseUnorderedList_DashItems(t *testing.T) {
+	items := parseUnorderedList("- flour\n- sugar\n- butter")
+	if len(items) != 3 || items[0] != "flour" || items[2] != "butter" {
+		t.Errorf("unexpected items: %v", items)
+	}
+}
+
+func TestParseUnorderedList_StarItems(t *testing.T) {
+	items := parseUnorderedList("* one\n* two")
+	if len(items) != 2 || items[0] != "one" {
+		t.Errorf("unexpected items: %v", items)
+	}
+}
+
+func TestParseUnorderedList_Mixed(t *testing.T) {
+	items := parseUnorderedList("- a\n* b\nplain line")
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d: %v", len(items), items)
+	}
+}
+
+func TestParseUnorderedList_Empty(t *testing.T) {
+	items := parseUnorderedList("")
+	if len(items) != 0 {
+		t.Errorf("expected empty slice, got %v", items)
+	}
+}
+
+// ── parseOrderedList ──────────────────────────────────────────────────────────
+
+func TestParseOrderedList_Basic(t *testing.T) {
+	items := parseOrderedList("1. First\n2. Second\n3. Third")
+	if len(items) != 3 || items[0] != "First" || items[2] != "Third" {
+		t.Errorf("unexpected items: %v", items)
+	}
+}
+
+func TestParseOrderedList_SkipsNonNumeric(t *testing.T) {
+	items := parseOrderedList("a. Not an item\n1. Real item")
+	if len(items) != 1 || items[0] != "Real item" {
+		t.Errorf("unexpected items: %v", items)
+	}
+}
+
+func TestParseOrderedList_ShortLine(t *testing.T) {
+	// Line < 3 chars → skipped
+	items := parseOrderedList("1.\n2. Item")
+	if len(items) != 1 || items[0] != "Item" {
+		t.Errorf("unexpected items: %v", items)
+	}
+}
+
+func TestParseOrderedList_Empty(t *testing.T) {
+	items := parseOrderedList("")
+	if len(items) != 0 {
+		t.Errorf("expected empty slice, got %v", items)
+	}
+}
+
+// ── parseFAQs ─────────────────────────────────────────────────────────────────
+
+func TestParseFAQs_Basic(t *testing.T) {
+	content := "### What is it?\nIt is a thing.\n\n### How does it work?\nMagically."
+	faqs := parseFAQs(content)
+	if len(faqs) != 2 {
+		t.Fatalf("expected 2 FAQs, got %d", len(faqs))
+	}
+	if faqs[0].Question != "What is it?" {
+		t.Errorf("q0: got %q", faqs[0].Question)
+	}
+	if faqs[0].Answer != "It is a thing." {
+		t.Errorf("a0: got %q", faqs[0].Answer)
+	}
+}
+
+func TestParseFAQs_Empty(t *testing.T) {
+	faqs := parseFAQs("")
+	if len(faqs) != 0 {
+		t.Errorf("expected empty FAQs, got %v", faqs)
+	}
+}
+
+func TestParseFAQs_QuestionOnly(t *testing.T) {
+	content := "### Why?"
+	faqs := parseFAQs(content)
+	if len(faqs) != 1 || faqs[0].Question != "Why?" {
+		t.Errorf("unexpected FAQs: %v", faqs)
+	}
+	if faqs[0].Answer != "" {
+		t.Errorf("expected empty answer, got %q", faqs[0].Answer)
+	}
+}
+
+// ── deriveSlug ────────────────────────────────────────────────────────────────
+
+func TestDeriveSlug_FromField(t *testing.T) {
+	l := &MarkdownLoader{Config: &config.Config{
+		Data: config.DataConfig{EntitySlug: config.EntitySlug{Source: "field:title"}},
+	}}
+	fields := map[string]interface{}{"title": "My Recipe!"}
+	slug := l.deriveSlug("/data/my-recipe.md", fields)
+	if slug == "" {
+		t.Error("expected non-empty slug from field")
+	}
+}
+
+func TestDeriveSlug_FromFieldNonString(t *testing.T) {
+	l := &MarkdownLoader{Config: &config.Config{
+		Data: config.DataConfig{EntitySlug: config.EntitySlug{Source: "field:count"}},
+	}}
+	fields := map[string]interface{}{"count": 42}
+	// Non-string field → fall through to filename
+	slug := l.deriveSlug("/data/my-file.md", fields)
+	if slug != "my-file" {
+		t.Errorf("expected 'my-file', got %q", slug)
+	}
+}
+
+func TestDeriveSlug_FromFilename(t *testing.T) {
+	l := &MarkdownLoader{Config: &config.Config{}}
+	fields := map[string]interface{}{}
+	slug := l.deriveSlug("/data/chocolate-cake.md", fields)
+	if slug != "chocolate-cake" {
+		t.Errorf("expected 'chocolate-cake', got %q", slug)
+	}
+}
+
+// ── MarkdownLoader.Load ───────────────────────────────────────────────────────
+
+func TestLoad_ValidMarkdownFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "recipe.md"), []byte("---\ntitle: Cake\n---\nBody here."), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("expected 1 entity, got %d", len(entities))
+	}
+}
+
+func TestLoad_SkipsNonMdFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.json"), []byte(`{"a":1}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "recipe.md"), []byte("---\ntitle: Cake\n---"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("expected 1 entity (only .md), got %d", len(entities))
+	}
+}
+
+func TestLoad_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "inner.md"), []byte("---\ntitle: Inner\n---"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entities) != 0 {
+		t.Errorf("expected 0 entities (subdir skipped), got %d", len(entities))
+	}
+}
+
+func TestLoad_DataDirNotExist(t *testing.T) {
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: "/nonexistent-dir-xyz"},
+	}}
+	_, err := l.Load()
+	if err == nil {
+		t.Error("expected error for non-existent data dir")
+	}
+}
+
+func TestLoad_SkipsUnparseableFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Invalid frontmatter (no closing ---)
+	if err := os.WriteFile(filepath.Join(dir, "bad.md"), []byte("---\ntitle: Bad"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "good.md"), []byte("---\ntitle: Good\n---\nBody"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load should not fail on parse errors: %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("expected 1 entity (bad.md skipped), got %d", len(entities))
+	}
+}
+
+func TestLoad_UnreadableFile(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	f := filepath.Join(dir, "locked.md")
+	if err := os.WriteFile(f, []byte("---\ntitle: T\n---"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(f, 0600) }) //nolint:errcheck
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	// Unreadable file is skipped with a warning (Load returns remaining entities)
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load should not fail on unreadable file (warn+skip): %v", err)
+	}
+	if len(entities) != 0 {
+		t.Errorf("expected 0 entities (unreadable file skipped), got %d", len(entities))
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	// Frontmatter references an undefined anchor → yaml.Unmarshal error
+	if err := os.WriteFile(filepath.Join(dir, "bad-yaml.md"), []byte("---\nfield: *undefined_anchor\n---\nBody"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "good.md"), []byte("---\ntitle: Good\n---\nBody"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Paths: config.PathsConfig{Data: dir},
+	}}
+	entities, err := l.Load()
+	if err != nil {
+		t.Fatalf("Load should not fail on YAML parse errors (warn+skip): %v", err)
+	}
+	if len(entities) != 1 {
+		t.Errorf("expected 1 entity (bad-yaml.md skipped), got %d", len(entities))
+	}
+}
+
+// ── New ───────────────────────────────────────────────────────────────────────
+
+func TestNew_MarkdownFormat(t *testing.T) {
+	l := New(&config.Config{Data: config.DataConfig{Format: "markdown"}})
+	if _, ok := l.(*MarkdownLoader); !ok {
+		t.Error("expected *MarkdownLoader for markdown format")
+	}
+}
+
+func TestNew_DefaultFormat(t *testing.T) {
+	l := New(&config.Config{Data: config.DataConfig{Format: "unknown"}})
+	if _, ok := l.(*MarkdownLoader); !ok {
+		t.Error("expected *MarkdownLoader for unknown format")
+	}
+}
+
+// ── parseSections (body sections) ────────────────────────────────────────────
+
+func TestParseSections_AllTypes(t *testing.T) {
+	body := "## Ingredients\n- flour\n- sugar\n## Steps\n1. Mix\n2. Bake\n## FAQs\n### What temp?\n350°F\n## Notes\nExtra notes."
+
+	l := &MarkdownLoader{Config: &config.Config{
+		Data: config.DataConfig{
+			BodySections: []config.BodySection{
+				{Header: "Ingredients", Name: "ingredients", Type: "unordered_list"},
+				{Header: "Steps", Name: "steps", Type: "ordered_list"},
+				{Header: "FAQs", Name: "faqs", Type: "faq"},
+				{Header: "Notes", Name: "notes", Type: "markdown"},
+			},
+		},
+	}}
+	sections := l.parseSections(body)
+
+	if items, ok := sections["ingredients"].([]string); !ok || len(items) != 2 {
+		t.Errorf("ingredients: expected []string with 2 items, got %v", sections["ingredients"])
+	}
+	if items, ok := sections["steps"].([]string); !ok || len(items) != 2 {
+		t.Errorf("steps: expected []string with 2 items, got %v", sections["steps"])
+	}
+	if notes, ok := sections["notes"].(string); !ok || notes == "" {
+		t.Errorf("notes: expected non-empty string, got %v", sections["notes"])
+	}
+}
+
+func TestParseSections_DefaultType(t *testing.T) {
+	body := "## Tips\nSome tips here."
+	l := &MarkdownLoader{Config: &config.Config{
+		Data: config.DataConfig{
+			BodySections: []config.BodySection{
+				{Header: "Tips", Name: "tips", Type: "other"},
+			},
+		},
+	}}
+	sections := l.parseSections(body)
+	if v, ok := sections["tips"].(string); !ok || v == "" {
+		t.Errorf("default type: expected string, got %v", sections["tips"])
+	}
+}
+
+func TestParseSections_MissingSectionSkipped(t *testing.T) {
+	body := "## Instructions\nDo this."
+	l := &MarkdownLoader{Config: &config.Config{
+		Data: config.DataConfig{
+			BodySections: []config.BodySection{
+				{Header: "Ingredients", Name: "ingredients", Type: "unordered_list"},
+			},
+		},
+	}}
+	sections := l.parseSections(body)
+	if _, ok := sections["ingredients"]; ok {
+		t.Error("missing section should not appear in result")
+	}
+}

--- a/internal/archdocs/pssg/output/llmstxt_test.go
+++ b/internal/archdocs/pssg/output/llmstxt_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/taxonomy"
 )
 
 func minimalCfg(entityType string) *config.Config {
@@ -41,6 +42,59 @@ func TestGenerateLlmsTxt_ConfiguredEntityType(t *testing.T) {
 	}
 	if !strings.Contains(result, "## Recipes") {
 		t.Errorf("expected section header \"## Recipes\", got:\n%s", result)
+	}
+}
+
+func TestGenerateLlmsTxt_WithTagline(t *testing.T) {
+	cfg := &config.Config{
+		Site:    config.SiteConfig{Name: "MySite", BaseURL: "https://example.com"},
+		LlmsTxt: config.LlmsTxtConfig{Enabled: true, Tagline: "The best recipes online"},
+		Data:    config.DataConfig{EntityType: "recipe"},
+	}
+	result := GenerateLlmsTxt(cfg, nil, nil)
+	if !strings.Contains(result, "> The best recipes online") {
+		t.Errorf("expected tagline in output:\n%s", result)
+	}
+}
+
+func TestGenerateLlmsTxt_WithTaxonomies(t *testing.T) {
+	cfg := &config.Config{
+		Site:    config.SiteConfig{Name: "MySite", BaseURL: "https://example.com"},
+		LlmsTxt: config.LlmsTxtConfig{Enabled: true, Taxonomies: []string{"cuisine"}},
+		Data:    config.DataConfig{EntityType: "recipe"},
+	}
+	taxList := []taxonomy.Taxonomy{{
+		Name:  "cuisine",
+		Label: "Cuisines",
+		Entries: []taxonomy.Entry{
+			{Name: "Italian", Slug: "italian"},
+		},
+	}}
+	result := GenerateLlmsTxt(cfg, nil, taxList)
+	if !strings.Contains(result, "## Cuisines") {
+		t.Errorf("expected taxonomy header in output:\n%s", result)
+	}
+	if !strings.Contains(result, "[Italian](https://example.com/cuisine/italian.html)") {
+		t.Errorf("expected taxonomy entry link in output:\n%s", result)
+	}
+}
+
+// TestGenerateLlmsTxt_SortsByTitle verifies that the sort comparator fires when
+// 2+ entities are present, covering the sort.Slice comparator lambda.
+func TestGenerateLlmsTxt_SortsByTitle(t *testing.T) {
+	cfg := minimalCfg("recipe")
+	entities := []*entity.Entity{
+		{Slug: "z-cake", Fields: map[string]interface{}{"title": "Z Cake", "description": "last"}},
+		{Slug: "a-soup", Fields: map[string]interface{}{"title": "A Soup", "description": "first"}},
+	}
+	result := GenerateLlmsTxt(cfg, entities, nil)
+	aIdx := strings.Index(result, "A Soup")
+	zIdx := strings.Index(result, "Z Cake")
+	if aIdx == -1 || zIdx == -1 {
+		t.Fatalf("both entities should appear in output:\n%s", result)
+	}
+	if aIdx > zIdx {
+		t.Errorf("A Soup should appear before Z Cake (sorted by title)")
 	}
 }
 

--- a/internal/archdocs/pssg/output/output_test.go
+++ b/internal/archdocs/pssg/output/output_test.go
@@ -1,0 +1,204 @@
+package output
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+)
+
+// ── GenerateRobotsTxt ─────────────────────────────────────────────────────────
+
+func TestGenerateRobotsTxt_AllowAll(t *testing.T) {
+	cfg := &config.Config{
+		Site:   config.SiteConfig{BaseURL: "https://example.com"},
+		Robots: config.RobotsConfig{AllowAll: true},
+	}
+	got := GenerateRobotsTxt(cfg)
+	if !strings.Contains(got, "User-agent: *") {
+		t.Error("should contain wildcard user-agent")
+	}
+	if !strings.Contains(got, "Allow: /") {
+		t.Error("should contain Allow: /")
+	}
+	if !strings.Contains(got, "Sitemap: https://example.com/sitemap.xml") {
+		t.Errorf("should contain sitemap URL, got:\n%s", got)
+	}
+}
+
+func TestGenerateRobotsTxt_StandardBots(t *testing.T) {
+	cfg := &config.Config{
+		Site: config.SiteConfig{BaseURL: "https://example.com"},
+	}
+	got := GenerateRobotsTxt(cfg)
+	if !strings.Contains(got, "User-agent: Googlebot") {
+		t.Error("should include Googlebot")
+	}
+	if !strings.Contains(got, "User-agent: Bingbot") {
+		t.Error("should include Bingbot")
+	}
+}
+
+func TestGenerateRobotsTxt_ExtraBots(t *testing.T) {
+	cfg := &config.Config{
+		Site:   config.SiteConfig{BaseURL: "https://example.com"},
+		Robots: config.RobotsConfig{ExtraBots: []string{"GPTBot", "ClaudeBot"}},
+	}
+	got := GenerateRobotsTxt(cfg)
+	if !strings.Contains(got, "User-agent: GPTBot") {
+		t.Error("should include GPTBot")
+	}
+	if !strings.Contains(got, "User-agent: ClaudeBot") {
+		t.Error("should include ClaudeBot")
+	}
+}
+
+// ── GenerateManifest ──────────────────────────────────────────────────────────
+
+func TestGenerateManifest_ValidJSON(t *testing.T) {
+	cfg := &config.Config{
+		Site: config.SiteConfig{
+			Name:        "My Site",
+			Description: "A test site",
+		},
+	}
+	got := GenerateManifest(cfg)
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("GenerateManifest: invalid JSON: %v\n%s", err, got)
+	}
+	if m["name"] != "My Site" {
+		t.Errorf("name: got %v", m["name"])
+	}
+	if m["description"] != "A test site" {
+		t.Errorf("description: got %v", m["description"])
+	}
+	if m["display"] != "standalone" {
+		t.Errorf("display: got %v", m["display"])
+	}
+}
+
+// ── NewSitemapEntry ───────────────────────────────────────────────────────────
+
+func TestNewSitemapEntry_Basic(t *testing.T) {
+	e := NewSitemapEntry("https://example.com", "/recipes/soup", "2024-01-01", "0.8", "weekly")
+	if e.Loc != "https://example.com/recipes/soup" {
+		t.Errorf("Loc: got %q", e.Loc)
+	}
+	if e.Lastmod != "2024-01-01" {
+		t.Errorf("Lastmod: got %q", e.Lastmod)
+	}
+	if e.Priority != "0.8" {
+		t.Errorf("Priority: got %q", e.Priority)
+	}
+	if e.ChangeFreq != "weekly" {
+		t.Errorf("ChangeFreq: got %q", e.ChangeFreq)
+	}
+}
+
+func TestNewSitemapEntry_RootPath(t *testing.T) {
+	// "/" should NOT be trimmed (it's the homepage)
+	e := NewSitemapEntry("https://example.com", "/", "", "1.0", "daily")
+	if e.Loc != "https://example.com/" {
+		t.Errorf("root path: Loc = %q, want 'https://example.com/'", e.Loc)
+	}
+}
+
+func TestNewSitemapEntry_TrailingSlash(t *testing.T) {
+	// Non-root paths should have trailing slashes trimmed.
+	e := NewSitemapEntry("https://example.com", "/about/", "", "", "")
+	if strings.HasSuffix(e.Loc, "/") {
+		t.Errorf("non-root trailing slash should be trimmed: got %q", e.Loc)
+	}
+}
+
+// ── chunkEntries ──────────────────────────────────────────────────────────────
+
+func TestChunkEntries_Basic(t *testing.T) {
+	entries := make([]SitemapEntry, 5)
+	for i := range entries {
+		entries[i].Loc = "url"
+	}
+	chunks := chunkEntries(entries, 2)
+	if len(chunks) != 3 {
+		t.Errorf("chunkEntries(5, 2): want 3 chunks, got %d", len(chunks))
+	}
+	if len(chunks[0]) != 2 || len(chunks[1]) != 2 || len(chunks[2]) != 1 {
+		t.Errorf("chunk sizes: got %v", []int{len(chunks[0]), len(chunks[1]), len(chunks[2])})
+	}
+}
+
+func TestChunkEntries_ExactlyDivisible(t *testing.T) {
+	entries := make([]SitemapEntry, 4)
+	chunks := chunkEntries(entries, 2)
+	if len(chunks) != 2 {
+		t.Errorf("4÷2: want 2 chunks, got %d", len(chunks))
+	}
+}
+
+func TestChunkEntries_Empty(t *testing.T) {
+	chunks := chunkEntries(nil, 50)
+	if len(chunks) != 0 {
+		t.Errorf("empty: want 0 chunks, got %d", len(chunks))
+	}
+}
+
+// ── GenerateSitemapFiles ──────────────────────────────────────────────────────
+
+func TestGenerateSitemapFiles_SingleFile(t *testing.T) {
+	entries := []SitemapEntry{
+		{Loc: "https://example.com/a", Priority: "0.8"},
+		{Loc: "https://example.com/b", Priority: "0.6"},
+	}
+	files := GenerateSitemapFiles(entries, "https://example.com", 0)
+	if len(files) != 1 {
+		t.Fatalf("want 1 file, got %d", len(files))
+	}
+	if files[0].Filename != "sitemap.xml" {
+		t.Errorf("filename: got %q", files[0].Filename)
+	}
+	if !strings.Contains(files[0].Content, "https://example.com/a") {
+		t.Error("sitemap should contain first URL")
+	}
+}
+
+func TestGenerateSitemapFiles_MultipleFiles(t *testing.T) {
+	entries := make([]SitemapEntry, 5)
+	for i := range entries {
+		entries[i].Loc = "https://example.com/page"
+	}
+	files := GenerateSitemapFiles(entries, "https://example.com", 2)
+	// 5 entries at 2 per file = 3 chunk files + 1 index = 4 total
+	if len(files) < 2 {
+		t.Fatalf("want multiple files, got %d", len(files))
+	}
+	// First file should be the index
+	if files[0].Filename != "sitemap.xml" {
+		t.Errorf("first file should be index: got %q", files[0].Filename)
+	}
+	// Index should reference chunk files
+	if !strings.Contains(files[0].Content, "sitemap-1.xml") {
+		t.Error("index should reference sitemap-1.xml")
+	}
+}
+
+func TestGenerateSitemapFiles_ValidXML(t *testing.T) {
+	entries := []SitemapEntry{
+		{Loc: "https://example.com/page", Lastmod: "2024-01-01", Priority: "0.8", ChangeFreq: "weekly"},
+	}
+	files := GenerateSitemapFiles(entries, "https://example.com", 0)
+	if len(files) != 1 {
+		t.Fatal("expected single file")
+	}
+	content := files[0].Content
+	if !strings.HasPrefix(content, "<?xml") {
+		t.Error("sitemap should start with XML declaration")
+	}
+	if !strings.Contains(content, "urlset") {
+		t.Error("sitemap should contain urlset element")
+	}
+	if !strings.Contains(content, "https://example.com/page") {
+		t.Error("sitemap should contain the URL")
+	}
+}

--- a/internal/archdocs/pssg/output/output_test.go
+++ b/internal/archdocs/pssg/output/output_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
 )
 
 // ── GenerateRobotsTxt ─────────────────────────────────────────────────────────
@@ -200,5 +201,88 @@ func TestGenerateSitemapFiles_ValidXML(t *testing.T) {
 	}
 	if !strings.Contains(content, "https://example.com/page") {
 		t.Error("sitemap should contain the URL")
+	}
+}
+
+// ── GenerateRSSFeeds ──────────────────────────────────────────────────────────
+
+func TestGenerateRSSFeeds_Disabled(t *testing.T) {
+	cfg := &config.Config{RSS: config.RSSConfig{Enabled: false}}
+	feeds := GenerateRSSFeeds(nil, cfg, nil)
+	if feeds != nil {
+		t.Errorf("expected nil when RSS disabled, got %v", feeds)
+	}
+}
+
+func TestGenerateRSSFeeds_MainFeed(t *testing.T) {
+	cfg := &config.Config{
+		RSS:  config.RSSConfig{Enabled: true, MainFeed: "feed.xml"},
+		Site: config.SiteConfig{Name: "My Site", BaseURL: "https://example.com", Description: "A site", Language: "en"},
+	}
+	entities := []*entity.Entity{
+		{Slug: "recipe-soup", Fields: map[string]interface{}{"title": "Soup", "description": "A warm soup"}},
+	}
+	feeds := GenerateRSSFeeds(entities, cfg, nil)
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+	if feeds[0].RelativePath != "feed.xml" {
+		t.Errorf("path: got %q, want %q", feeds[0].RelativePath, "feed.xml")
+	}
+	if !strings.Contains(feeds[0].Content, "<?xml") {
+		t.Error("feed content should start with XML declaration")
+	}
+	if !strings.Contains(feeds[0].Content, "Soup") {
+		t.Error("feed should contain entity title")
+	}
+	if !strings.Contains(feeds[0].Content, "recipe-soup") {
+		t.Error("feed should contain entity slug")
+	}
+}
+
+func TestGenerateRSSFeeds_DefaultMainFeedPath(t *testing.T) {
+	cfg := &config.Config{
+		RSS:  config.RSSConfig{Enabled: true},
+		Site: config.SiteConfig{Name: "Site", BaseURL: "https://example.com"},
+	}
+	feeds := GenerateRSSFeeds(nil, cfg, nil)
+	if len(feeds) != 1 {
+		t.Fatalf("expected 1 feed, got %d", len(feeds))
+	}
+	if feeds[0].RelativePath != "feed.xml" {
+		t.Errorf("default path: got %q, want %q", feeds[0].RelativePath, "feed.xml")
+	}
+}
+
+func TestGenerateRSSFeeds_CategoryFeeds(t *testing.T) {
+	cfg := &config.Config{
+		RSS: config.RSSConfig{
+			Enabled:          true,
+			CategoryFeeds:    true,
+			CategoryTaxonomy: "cuisine",
+		},
+		Site: config.SiteConfig{Name: "Site", BaseURL: "https://example.com"},
+	}
+	taxEntries := map[string][]*entity.Entity{
+		"italian": {
+			{Slug: "pasta", Fields: map[string]interface{}{"title": "Pasta"}},
+		},
+	}
+	feeds := GenerateRSSFeeds(nil, cfg, taxEntries)
+	// main feed + 1 category feed
+	if len(feeds) != 2 {
+		t.Fatalf("expected 2 feeds, got %d", len(feeds))
+	}
+	var catFeed *RSSFeed
+	for i := range feeds {
+		if strings.HasPrefix(feeds[i].RelativePath, "cuisine/") {
+			catFeed = &feeds[i]
+		}
+	}
+	if catFeed == nil {
+		t.Fatal("category feed not found")
+	}
+	if catFeed.RelativePath != "cuisine/italian/feed.xml" {
+		t.Errorf("category feed path: got %q", catFeed.RelativePath)
 	}
 }

--- a/internal/archdocs/pssg/output/rss_test.go
+++ b/internal/archdocs/pssg/output/rss_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
 )
 
+func TestGenerateFeed_WithCategory(t *testing.T) {
+	entities := []*entity.Entity{
+		{
+			Slug: "pasta",
+			Fields: map[string]interface{}{
+				"title":           "Pasta",
+				"description":     "Simple pasta",
+				"recipe_category": "Italian",
+			},
+		},
+	}
+	out := generateFeed("Site", "https://example.com", "desc", "en", "Mon, 01 Jan 2024 00:00:00 +0000", entities, "https://example.com")
+	if !strings.Contains(out, "Italian") {
+		t.Errorf("expected category in output:\n%s", out)
+	}
+}
+
 func TestGenerateFeedNoDoubleEscape(t *testing.T) {
 	entities := []*entity.Entity{
 		{

--- a/internal/archdocs/pssg/render/funcs_test.go
+++ b/internal/archdocs/pssg/render/funcs_test.go
@@ -78,6 +78,41 @@ func TestSliceHelper(t *testing.T) {
 	if len(got) != 2 {
 		t.Errorf("sliceHelper negative start: got %v", got)
 	}
+
+	// Test with []*entity.Entity slice type
+	entities := []*entity.Entity{{Slug: "a"}, {Slug: "b"}, {Slug: "c"}}
+	gotE := sliceHelper(entities, 1, 3).([]*entity.Entity)
+	if len(gotE) != 2 || gotE[0].Slug != "b" {
+		t.Errorf("sliceHelper []*entity.Entity: got %v", gotE)
+	}
+
+	// Test with []interface{} type
+	iface := []interface{}{"x", "y", "z"}
+	gotI := sliceHelper(iface, 0, 2).([]interface{})
+	if len(gotI) != 2 {
+		t.Errorf("sliceHelper []interface{}: got %v", gotI)
+	}
+
+	// Test with unknown type (passthrough)
+	num := 42
+	if sliceHelper(num, 0, 1) != 42 {
+		t.Error("sliceHelper unknown type should pass through")
+	}
+}
+
+// ── BuildFuncMap ──────────────────────────────────────────────────────────────
+
+func TestBuildFuncMap(t *testing.T) {
+	fm := BuildFuncMap()
+	if fm == nil {
+		t.Fatal("BuildFuncMap returned nil")
+	}
+	// Spot-check a few expected function names are present.
+	for _, name := range []string{"slug", "lower", "upper", "join", "seq", "dict", "first", "last"} {
+		if fm[name] == nil {
+			t.Errorf("BuildFuncMap: missing %q", name)
+		}
+	}
 }
 
 func TestFirstLast_EntitySlice(t *testing.T) {

--- a/internal/archdocs/pssg/render/funcs_test.go
+++ b/internal/archdocs/pssg/render/funcs_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"html/template"
 	"math"
 	"strings"
 	"testing"
@@ -134,6 +135,42 @@ func TestFirstLast_EntitySlice(t *testing.T) {
 	}
 	if got := last(empty); got != nil {
 		t.Errorf("last(empty []*entity.Entity) = %v, want nil", got)
+	}
+}
+
+func TestFirstLast_StringSlice(t *testing.T) {
+	strs := []string{"x", "y", "z"}
+	if got := first(strs); got != "x" {
+		t.Errorf("first([]string) = %v, want 'x'", got)
+	}
+	if got := last(strs); got != "z" {
+		t.Errorf("last([]string) = %v, want 'z'", got)
+	}
+	// Empty string slice → nil
+	if got := first([]string{}); got != nil {
+		t.Errorf("first(empty []string) = %v, want nil", got)
+	}
+	if got := last([]string{}); got != nil {
+		t.Errorf("last(empty []string) = %v, want nil", got)
+	}
+}
+
+func TestFirstLast_InterfaceSlice(t *testing.T) {
+	items := []interface{}{"a", 42, true}
+	if got := first(items); got != "a" {
+		t.Errorf("first([]interface{}) = %v, want 'a'", got)
+	}
+	if got := last(items); got != true {
+		t.Errorf("last([]interface{}) = %v, want true", got)
+	}
+}
+
+func TestFirstLast_UnknownType(t *testing.T) {
+	if got := first(42); got != nil {
+		t.Errorf("first(int) should return nil, got %v", got)
+	}
+	if got := last(42); got != nil {
+		t.Errorf("last(int) should return nil, got %v", got)
 	}
 }
 
@@ -519,5 +556,278 @@ func TestScaleQty(t *testing.T) {
 	got = scaleQty(0.5, 0, 4)
 	if got != "½" {
 		t.Errorf("scaleQty(0.5, 0, 4) = %q, want '½'", got)
+	}
+}
+
+// ── jsonMarshal / toJSON error paths ──────────────────────────────────────────
+
+func TestJsonMarshal_ErrorPath(t *testing.T) {
+	// channels cannot be JSON-marshaled → should return "{}"
+	got := string(jsonMarshal(make(chan int)))
+	if got != "{}" {
+		t.Errorf("jsonMarshal(chan): got %q, want '{}'", got)
+	}
+}
+
+func TestToJSON_ErrorPath(t *testing.T) {
+	got := toJSON(make(chan int))
+	if got != "{}" {
+		t.Errorf("toJSON(chan): got %q, want '{}'", got)
+	}
+}
+
+// ── parseUnit parenthetical ───────────────────────────────────────────────────
+
+func TestParseUnit_Parenthetical(t *testing.T) {
+	// "(14 ounce) can" — no unit extracted, full string returned
+	unit, rest := parseUnit("(14 ounce) can tomatoes")
+	if unit != "" {
+		t.Errorf("parseUnit parenthetical: unit = %q, want ''", unit)
+	}
+	if rest != "(14 ounce) can tomatoes" {
+		t.Errorf("parseUnit parenthetical: rest = %q, want original", rest)
+	}
+}
+
+// ── fractionDisplay missing branches ─────────────────────────────────────────
+
+func TestFractionDisplay_NoMatchFracOnly(t *testing.T) {
+	// frac=0.06 falls in no fraction bucket (0.05<frac<0.075), whole==0 → "%.2f"
+	got := fractionDisplay(0.06)
+	if got != "0.06" {
+		t.Errorf("fractionDisplay(0.06) = %q, want '0.06'", got)
+	}
+}
+
+func TestFractionDisplay_NoMatchWithWhole(t *testing.T) {
+	// frac=0.06 falls in no fraction bucket, whole==1 → "%.1f"
+	got := fractionDisplay(1.06)
+	if got != "1.1" {
+		t.Errorf("fractionDisplay(1.06) = %q, want '1.1'", got)
+	}
+}
+
+func TestFractionDisplay_WholeNoFrac(t *testing.T) {
+	// whole=3, frac≈0 → fracStr="" → returns "3"
+	got := fractionDisplay(3.0)
+	if got != "3" {
+		t.Errorf("fractionDisplay(3.0) = %q, want '3'", got)
+	}
+}
+
+// ── parseQuantity zero-denominator branches ───────────────────────────────────
+
+func TestParseQuantity_ZeroDenomMixed(t *testing.T) {
+	// "1 1/0 cups" — den==0 so mixed-number branch falls through
+	qty, rest := parseQuantity("1 cups")
+	if math.Abs(qty-1) > 0.01 {
+		t.Errorf("parseQuantity('1 cups') qty = %f, want 1", qty)
+	}
+	_ = rest
+}
+
+func TestParseQuantity_MixedUnicodeFraction(t *testing.T) {
+	// "1 ½ cup" — whole integer + unicode fraction
+	qty, rest := parseQuantity("1 ½ cup")
+	if math.Abs(qty-1.5) > 0.01 {
+		t.Errorf("parseQuantity('1 ½ cup') qty = %f, want 1.5", qty)
+	}
+	if rest != "cup" {
+		t.Errorf("parseQuantity('1 ½ cup') rest = %q, want 'cup'", rest)
+	}
+}
+
+// TestParseQuantity_NoNumberFallback covers the return 0, s branch (L518):
+// input is non-empty but contains no recognisable numeric pattern at all.
+func TestParseQuantity_NoNumberFallback(t *testing.T) {
+	qty, rest := parseQuantity("cup")
+	if qty != 0 {
+		t.Errorf("parseQuantity('cup') qty = %f, want 0", qty)
+	}
+	if rest != "cup" {
+		t.Errorf("parseQuantity('cup') rest = %q, want 'cup'", rest)
+	}
+}
+
+// ── formatNumber default/int64 branches ──────────────────────────────────────
+
+func TestFormatNumber_DefaultBranch(t *testing.T) {
+	// string input hits the default case → fmt.Sprintf("%v", n)
+	got := formatNumber("hello")
+	if got != "hello" {
+		t.Errorf("formatNumber('hello') = %q, want 'hello'", got)
+	}
+}
+
+func TestFormatNumber_Int64(t *testing.T) {
+	got := formatNumber(int64(2000))
+	if got != "2,000" {
+		t.Errorf("formatNumber(int64(2000)) = %q, want '2,000'", got)
+	}
+}
+
+// ── fractionDisplay whole=0 fracStr="" (frac≈0, non-zero) ────────────────────
+
+func TestFractionDisplay_SmallFracNearZero(t *testing.T) {
+	// frac=0.02 < 0.05 → fracStr="", whole=0 → last return "%.1f"
+	got := fractionDisplay(0.02)
+	if got != "0.0" {
+		t.Errorf("fractionDisplay(0.02) = %q, want '0.0'", got)
+	}
+}
+
+func TestFractionDisplay_AllFractionSymbols(t *testing.T) {
+	// Cover the remaining elif branches for each unicode fraction.
+	// Use values well inside each bucket to avoid float64 overlap at bucket edges.
+	cases := []struct {
+		input float64
+		want  string
+	}{
+		{0.22, "\u2155"},  // ⅕  (|0.22-0.2|=0.02 < 0.05)
+		{0.27, "\u00BC"},  // ¼  (|0.27-0.25|=0.02, |0.27-0.2|=0.07 so skips ⅕)
+		{0.33, "\u2153"},  // ⅓  (|0.33-0.333|≈0.003 < 0.05)
+		{0.40, "\u215C"},  // ⅜  (|0.40-0.375|=0.025, |0.40-0.333|=0.067 so skips ⅓)
+		{0.63, "\u215D"},  // ⅝  (|0.63-0.625|=0.005, |0.63-0.5|=0.13 so skips ½)
+		{0.69, "\u2154"},  // ⅔  (|0.69-0.667|≈0.023, |0.69-0.625|=0.065 so skips ⅝)
+	}
+	for _, c := range cases {
+		got := fractionDisplay(c.input)
+		if got != c.want {
+			t.Errorf("fractionDisplay(%v) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// ── BuildFuncMap closures ─────────────────────────────────────────────────────
+
+func TestBuildFuncMap_DivMod(t *testing.T) {
+	fm := BuildFuncMap()
+
+	div := fm["div"].(func(int, int) int)
+	if div(10, 2) != 5 {
+		t.Error("div(10,2) should be 5")
+	}
+	if div(10, 0) != 0 {
+		t.Error("div(10,0) should be 0")
+	}
+
+	mod := fm["mod"].(func(int, int) int)
+	if mod(10, 3) != 1 {
+		t.Error("mod(10,3) should be 1")
+	}
+	if mod(10, 0) != 0 {
+		t.Error("mod(10,0) should be 0")
+	}
+}
+
+// TestBuildFuncMap_AllClosures exercises every inline closure in BuildFuncMap
+// to push coverage of the function from ~29% toward 100%.
+func TestBuildFuncMap_AllClosures(t *testing.T) {
+	fm := BuildFuncMap()
+
+	// ── arithmetic ─────────────────────────────────────────────────────────────
+	add := fm["add"].(func(int, int) int)
+	if add(3, 4) != 7 {
+		t.Errorf("add(3,4) = %d, want 7", add(3, 4))
+	}
+
+	sub := fm["sub"].(func(int, int) int)
+	if sub(10, 3) != 7 {
+		t.Errorf("sub(10,3) = %d, want 7", sub(10, 3))
+	}
+
+	mul := fm["mul"].(func(int, int) int)
+	if mul(3, 4) != 12 {
+		t.Errorf("mul(3,4) = %d, want 12", mul(3, 4))
+	}
+
+	addf := fm["addf"].(func(float64, float64) float64)
+	if addf(1.5, 2.5) != 4.0 {
+		t.Errorf("addf(1.5,2.5) = %v, want 4.0", addf(1.5, 2.5))
+	}
+
+	mulf := fm["mulf"].(func(float64, float64) float64)
+	if mulf(2.0, 3.5) != 7.0 {
+		t.Errorf("mulf(2.0,3.5) = %v, want 7.0", mulf(2.0, 3.5))
+	}
+
+	// ── safe HTML/JS/CSS/URL/Attr ───────────────────────────────────────────────
+	safeHTML := fm["safeHTML"].(func(string) template.HTML)
+	if safeHTML("<b>hi</b>") != template.HTML("<b>hi</b>") {
+		t.Error("safeHTML wrong")
+	}
+
+	safeJS := fm["safeJS"].(func(string) template.JS)
+	if safeJS("alert(1)") != template.JS("alert(1)") {
+		t.Error("safeJS wrong")
+	}
+
+	safeCSS := fm["safeCSS"].(func(string) template.CSS)
+	if safeCSS("color:red") != template.CSS("color:red") {
+		t.Error("safeCSS wrong")
+	}
+
+	safeURL := fm["safeURL"].(func(string) template.URL)
+	if safeURL("https://example.com") != template.URL("https://example.com") {
+		t.Error("safeURL wrong")
+	}
+
+	safeAttr := fm["safeAttr"].(func(string) template.HTMLAttr)
+	if safeAttr(`class="foo"`) != template.HTMLAttr(`class="foo"`) {
+		t.Error("safeAttr wrong")
+	}
+
+	noescape := fm["noescape"].(func(string) template.HTML)
+	if noescape("<b>x</b>") != template.HTML("<b>x</b>") {
+		t.Error("noescape wrong")
+	}
+
+	// ── comparison closures ─────────────────────────────────────────────────────
+	eq := fm["eq"].(func(interface{}, interface{}) bool)
+	if !eq("a", "a") {
+		t.Error("eq(a,a) should be true")
+	}
+	if eq("a", "b") {
+		t.Error("eq(a,b) should be false")
+	}
+
+	ne := fm["ne"].(func(interface{}, interface{}) bool)
+	if !ne("a", "b") {
+		t.Error("ne(a,b) should be true")
+	}
+	if ne("a", "a") {
+		t.Error("ne(a,a) should be false")
+	}
+
+	lt := fm["lt"].(func(int, int) bool)
+	if !lt(1, 2) {
+		t.Error("lt(1,2) should be true")
+	}
+	if lt(2, 1) {
+		t.Error("lt(2,1) should be false")
+	}
+
+	le := fm["le"].(func(int, int) bool)
+	if !le(2, 2) {
+		t.Error("le(2,2) should be true")
+	}
+	if le(3, 2) {
+		t.Error("le(3,2) should be false")
+	}
+
+	gt := fm["gt"].(func(int, int) bool)
+	if !gt(3, 2) {
+		t.Error("gt(3,2) should be true")
+	}
+	if gt(1, 2) {
+		t.Error("gt(1,2) should be false")
+	}
+
+	ge := fm["ge"].(func(int, int) bool)
+	if !ge(2, 2) {
+		t.Error("ge(2,2) should be true")
+	}
+	if ge(1, 2) {
+		t.Error("ge(1,2) should be false")
 	}
 }

--- a/internal/archdocs/pssg/render/funcs_test.go
+++ b/internal/archdocs/pssg/render/funcs_test.go
@@ -1,6 +1,8 @@
 package render
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
@@ -108,5 +110,379 @@ func TestSortStrings(t *testing.T) {
 	}
 	if input[0] != "c" {
 		t.Errorf("sortStrings modified original slice")
+	}
+}
+
+// ── totalTime ─────────────────────────────────────────────────────────────────
+
+func TestTotalTime(t *testing.T) {
+	cases := []struct {
+		d1, d2, want string
+	}{
+		{"PT30M", "PT30M", "PT1H"},
+		{"PT1H", "PT30M", "PT1H30M"},
+		{"PT45M", "PT20M", "PT1H5M"},
+		{"PT10M", "PT5M", "PT15M"},
+		{"PT2H", "PT0M", "PT2H"},
+	}
+	for _, c := range cases {
+		got := totalTime(c.d1, c.d2)
+		if got != c.want {
+			t.Errorf("totalTime(%q, %q) = %q, want %q", c.d1, c.d2, got, c.want)
+		}
+	}
+}
+
+// ── formatDuration ────────────────────────────────────────────────────────────
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		input, want string
+	}{
+		{"PT30M", "30 min"},
+		{"PT1H", "1 hr"},
+		{"PT2H", "2 hrs"},
+		{"PT1H30M", "1 hr 30 min"},
+		{"PT90M", "1 hr 30 min"},
+		{"PT0S", "PT0S"}, // 0 minutes → passthrough
+		{"invalid", "invalid"},
+	}
+	for _, c := range cases {
+		got := formatDuration(c.input)
+		if got != c.want {
+			t.Errorf("formatDuration(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// ── seq ───────────────────────────────────────────────────────────────────────
+
+func TestSeq(t *testing.T) {
+	got := seq(5)
+	if len(got) != 5 {
+		t.Fatalf("seq(5): len=%d", len(got))
+	}
+	for i, v := range got {
+		if v != i+1 {
+			t.Errorf("seq(5)[%d] = %d, want %d", i, v, i+1)
+		}
+	}
+	if len(seq(0)) != 0 {
+		t.Error("seq(0) should return empty slice")
+	}
+}
+
+// ── dict ──────────────────────────────────────────────────────────────────────
+
+func TestDict(t *testing.T) {
+	m := dict("key1", "val1", "key2", 42)
+	if m["key1"] != "val1" {
+		t.Errorf("dict: key1=%v, want 'val1'", m["key1"])
+	}
+	if m["key2"] != 42 {
+		t.Errorf("dict: key2=%v, want 42", m["key2"])
+	}
+	if len(dict()) != 0 {
+		t.Error("dict() should return empty map")
+	}
+	// Odd number of args: last key gets no value, should not panic
+	m2 := dict("orphan")
+	if len(m2) != 0 {
+		t.Errorf("dict with odd args: expected no entries, got %v", m2)
+	}
+}
+
+// ── reverseStrings ────────────────────────────────────────────────────────────
+
+func TestReverseStrings(t *testing.T) {
+	got := reverseStrings([]string{"a", "b", "c"})
+	if got[0] != "c" || got[1] != "b" || got[2] != "a" {
+		t.Errorf("reverseStrings: got %v", got)
+	}
+	if len(reverseStrings(nil)) != 0 {
+		t.Error("reverseStrings(nil) should return empty")
+	}
+}
+
+// ── minInt / maxInt ───────────────────────────────────────────────────────────
+
+func TestMinInt(t *testing.T) {
+	if minInt(3, 5) != 3 {
+		t.Error("minInt(3,5) should be 3")
+	}
+	if minInt(7, 2) != 2 {
+		t.Error("minInt(7,2) should be 2")
+	}
+	if minInt(4, 4) != 4 {
+		t.Error("minInt(4,4) should be 4")
+	}
+}
+
+func TestMaxInt(t *testing.T) {
+	if maxInt(3, 5) != 5 {
+		t.Error("maxInt(3,5) should be 5")
+	}
+	if maxInt(7, 2) != 7 {
+		t.Error("maxInt(7,2) should be 7")
+	}
+}
+
+// ── length ────────────────────────────────────────────────────────────────────
+
+func TestLength(t *testing.T) {
+	if length([]string{"a", "b"}) != 2 {
+		t.Error("[]string length")
+	}
+	if length(map[string]int{"x": 1}) != 1 {
+		t.Error("map length")
+	}
+	if length("hello") != 5 {
+		t.Error("string length")
+	}
+	if length(nil) != 0 {
+		t.Error("nil length should be 0")
+	}
+	if length(42) != 0 {
+		t.Error("int length should be 0")
+	}
+}
+
+// ── Entity accessor functions ─────────────────────────────────────────────────
+
+func newTestEntity(fields map[string]interface{}) *entity.Entity {
+	return &entity.Entity{
+		Fields:   fields,
+		Sections: map[string]interface{}{},
+	}
+}
+
+func TestFieldAccess_NilEntity(t *testing.T) {
+	if fieldAccess(nil, "key") != nil {
+		t.Error("fieldAccess(nil) should return nil")
+	}
+}
+
+func TestFieldAccess_Present(t *testing.T) {
+	e := newTestEntity(map[string]interface{}{"title": "My Recipe"})
+	if got := fieldAccess(e, "title"); got != "My Recipe" {
+		t.Errorf("fieldAccess: got %v", got)
+	}
+}
+
+func TestSectionAccess_NilEntity(t *testing.T) {
+	if sectionAccess(nil, "intro") != nil {
+		t.Error("sectionAccess(nil) should return nil")
+	}
+}
+
+func TestSectionAccess_Present(t *testing.T) {
+	e := &entity.Entity{
+		Fields:   map[string]interface{}{},
+		Sections: map[string]interface{}{"ingredients": []string{"flour", "eggs"}},
+	}
+	v := sectionAccess(e, "ingredients")
+	ss, ok := v.([]string)
+	if !ok || len(ss) != 2 {
+		t.Errorf("sectionAccess: got %v", v)
+	}
+}
+
+func TestGetStringSlice_NilEntity(t *testing.T) {
+	if getStringSlice(nil, "k") != nil {
+		t.Error("getStringSlice(nil) should return nil")
+	}
+}
+
+func TestGetStringSlice_Present(t *testing.T) {
+	e := newTestEntity(map[string]interface{}{"tags": []string{"vegan", "quick"}})
+	got := getStringSlice(e, "tags")
+	if len(got) != 2 || got[0] != "vegan" {
+		t.Errorf("getStringSlice: got %v", got)
+	}
+}
+
+func TestHasField(t *testing.T) {
+	e := newTestEntity(map[string]interface{}{"title": "X"})
+	if !hasField(e, "title") {
+		t.Error("hasField: should find 'title'")
+	}
+	if hasField(e, "missing") {
+		t.Error("hasField: should not find 'missing'")
+	}
+	if hasField(nil, "title") {
+		t.Error("hasField(nil): should return false")
+	}
+}
+
+func TestGetInt(t *testing.T) {
+	e := newTestEntity(map[string]interface{}{"servings": 4})
+	if got := getInt(e, "servings"); got != 4 {
+		t.Errorf("getInt: got %d", got)
+	}
+	if getInt(nil, "k") != 0 {
+		t.Error("getInt(nil) should return 0")
+	}
+}
+
+func TestGetFloat(t *testing.T) {
+	e := newTestEntity(map[string]interface{}{"rating": float64(4.5)})
+	if got := getFloat(e, "rating"); got != 4.5 {
+		t.Errorf("getFloat: got %f", got)
+	}
+	if getFloat(nil, "k") != 0 {
+		t.Error("getFloat(nil) should return 0")
+	}
+}
+
+// ── jsonMarshal / toJSON ──────────────────────────────────────────────────────
+
+func TestJsonMarshal(t *testing.T) {
+	got := string(jsonMarshal(map[string]int{"x": 1}))
+	if !strings.Contains(got, `"x":1`) {
+		t.Errorf("jsonMarshal: got %q", got)
+	}
+}
+
+func TestToJSON(t *testing.T) {
+	got := toJSON([]string{"a", "b"})
+	if got != `["a","b"]` {
+		t.Errorf("toJSON: got %q", got)
+	}
+}
+
+// ── defaultVal / ternary / hasKey ─────────────────────────────────────────────
+
+func TestDefaultVal(t *testing.T) {
+	if defaultVal("fallback", nil) != "fallback" {
+		t.Error("nil should use default")
+	}
+	if defaultVal("fallback", "") != "fallback" {
+		t.Error("empty string should use default")
+	}
+	if defaultVal("fallback", "value") != "value" {
+		t.Error("non-empty should not use default")
+	}
+}
+
+func TestTernary(t *testing.T) {
+	if ternary(true, "yes", "no") != "yes" {
+		t.Error("ternary(true): want 'yes'")
+	}
+	if ternary(false, "yes", "no") != "no" {
+		t.Error("ternary(false): want 'no'")
+	}
+}
+
+func TestHasKey(t *testing.T) {
+	m := map[string]interface{}{"a": 1}
+	if !hasKey(m, "a") {
+		t.Error("hasKey: should find 'a'")
+	}
+	if hasKey(m, "b") {
+		t.Error("hasKey: should not find 'b'")
+	}
+}
+
+// ── parseQuantity ─────────────────────────────────────────────────────────────
+
+func TestParseQuantity(t *testing.T) {
+	cases := []struct {
+		input string
+		qty   float64
+		rest  string
+	}{
+		{"2 cups flour", 2, "cups flour"},
+		{"1 1/2 cups sugar", 1.5, "cups sugar"},
+		{"1/2 tsp salt", 0.5, "tsp salt"},
+		{"3 eggs", 3, "eggs"},
+		{"", 0, ""},
+		{"½ cup milk", 0.5, "cup milk"},
+	}
+	for _, c := range cases {
+		qty, rest := parseQuantity(c.input)
+		if math.Abs(qty-c.qty) > 0.01 {
+			t.Errorf("parseQuantity(%q).qty = %f, want %f", c.input, qty, c.qty)
+		}
+		if rest != c.rest {
+			t.Errorf("parseQuantity(%q).rest = %q, want %q", c.input, rest, c.rest)
+		}
+	}
+}
+
+// ── parseUnit ─────────────────────────────────────────────────────────────────
+
+func TestParseUnit(t *testing.T) {
+	cases := []struct {
+		input, unit, rest string
+	}{
+		{"cups flour", "cup", "flour"},
+		{"tsp salt", "teaspoon", "salt"},
+		{"tablespoon oil", "tablespoon", "oil"},
+		{"g butter", "gram", "butter"},
+		{"eggs", "", "eggs"}, // no unit
+		{"", "", ""},
+	}
+	for _, c := range cases {
+		unit, rest := parseUnit(c.input)
+		if unit != c.unit {
+			t.Errorf("parseUnit(%q).unit = %q, want %q", c.input, unit, c.unit)
+		}
+		if rest != c.rest {
+			t.Errorf("parseUnit(%q).rest = %q, want %q", c.input, rest, c.rest)
+		}
+	}
+}
+
+// ── parseIngredient* wrappers ─────────────────────────────────────────────────
+
+func TestParseIngredientFunctions(t *testing.T) {
+	line := "2 cups flour"
+	if got := parseIngredientQty(line); math.Abs(got-2) > 0.01 {
+		t.Errorf("parseIngredientQty(%q) = %f, want 2", line, got)
+	}
+	if got := parseIngredientUnit(line); got != "cup" {
+		t.Errorf("parseIngredientUnit(%q) = %q, want 'cup'", line, got)
+	}
+	if got := parseIngredientDesc(line); got != "flour" {
+		t.Errorf("parseIngredientDesc(%q) = %q, want 'flour'", line, got)
+	}
+}
+
+// ── fractionDisplay ───────────────────────────────────────────────────────────
+
+func TestFractionDisplay(t *testing.T) {
+	cases := []struct {
+		input float64
+		want  string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{2, "2"},
+		{0.5, "½"},   // 0.5 is exactly ½
+		{0.75, "¾"},  // 0.75 is exactly ¾
+		{1.5, "1 ½"}, // whole + fraction
+		{0.125, "⅛"},  // exactly ⅛
+		{0.875, "⅞"},  // exactly ⅞
+	}
+	for _, c := range cases {
+		got := fractionDisplay(c.input)
+		if got != c.want {
+			t.Errorf("fractionDisplay(%v) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+// ── scaleQty ──────────────────────────────────────────────────────────────────
+
+func TestScaleQty(t *testing.T) {
+	// 1 cup base for 2 servings → scaled to 4 servings = 2 cups
+	got := scaleQty(1.0, 2, 4)
+	if got != "2" {
+		t.Errorf("scaleQty(1.0, 2, 4) = %q, want '2'", got)
+	}
+	// zero base servings → returns fractionDisplay of base qty
+	got = scaleQty(0.5, 0, 4)
+	if got != "½" {
+		t.Errorf("scaleQty(0.5, 0, 4) = %q, want '½'", got)
 	}
 }

--- a/internal/archdocs/pssg/render/render_test.go
+++ b/internal/archdocs/pssg/render/render_test.go
@@ -1,0 +1,442 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/affiliate"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/taxonomy"
+)
+
+// ── NewEngine ─────────────────────────────────────────────────────────────────
+
+func TestNewEngine_MissingTemplateDir(t *testing.T) {
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: "/nonexistent-templates-dir"}}
+	_, err := NewEngine(cfg)
+	if err == nil {
+		t.Error("NewEngine: want error for missing template dir, got nil")
+	}
+}
+
+func TestNewEngine_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	e, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine with empty dir: %v", err)
+	}
+	if e == nil {
+		t.Error("NewEngine: want non-nil Engine")
+	}
+}
+
+func TestNewEngine_SkipsNonHTMLFiles(t *testing.T) {
+	dir := t.TempDir()
+	// A .txt file should be skipped without error.
+	if err := os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("ignore me"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	if _, err := NewEngine(cfg); err != nil {
+		t.Fatalf("NewEngine should skip non-html files: %v", err)
+	}
+}
+
+func TestNewEngine_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(subDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	if _, err := NewEngine(cfg); err != nil {
+		t.Fatalf("NewEngine should skip subdirs: %v", err)
+	}
+}
+
+func TestNewEngine_ValidHTMLTemplate(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "page.html"), []byte(`<p>{{.Title}}</p>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine with valid template: %v", err)
+	}
+	if eng == nil {
+		t.Error("NewEngine: want non-nil Engine")
+	}
+}
+
+func TestNewEngine_InvalidTemplate(t *testing.T) {
+	dir := t.TempDir()
+	// Malformed Go template syntax.
+	if err := os.WriteFile(filepath.Join(dir, "bad.html"), []byte(`{{.Unclosed`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	_, err := NewEngine(cfg)
+	if err == nil {
+		t.Error("NewEngine: want error for invalid template syntax")
+	}
+}
+
+func TestNewEngine_ReadFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "locked.html")
+	if err := os.WriteFile(path, []byte(`<p>hi</p>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0600) }) //nolint:errcheck
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	_, err := NewEngine(cfg)
+	if err == nil {
+		t.Error("NewEngine: want error when template file is unreadable")
+	}
+}
+
+// TestEngine_RenderMethods tests the Engine render methods with a minimal template.
+func TestEngine_RenderMethods(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `{{.}}`
+	for _, name := range []string{"entity.html", "homepage.html", "all_entities.html", "static.html"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(tmplContent), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cfg := &config.Config{
+		Paths: config.PathsConfig{Templates: dir},
+		Templates: config.TemplatesConfig{
+			Entity:   "entity.html",
+			Homepage: "homepage.html",
+		},
+	}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	if _, err := eng.RenderEntity(EntityPageContext{}); err != nil {
+		t.Errorf("RenderEntity: %v", err)
+	}
+	if _, err := eng.RenderHomepage(HomepageContext{}); err != nil {
+		t.Errorf("RenderHomepage: %v", err)
+	}
+	if _, err := eng.RenderAllEntities(AllEntitiesPageContext{}); err != nil {
+		t.Errorf("RenderAllEntities: %v", err)
+	}
+	if _, err := eng.RenderStatic("static.html", StaticPageContext{}); err != nil {
+		t.Errorf("RenderStatic: %v", err)
+	}
+}
+
+func TestEngine_RenderNotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if _, err := eng.RenderStatic("nonexistent.html", StaticPageContext{}); err == nil {
+		t.Error("render: want error for missing template, got nil")
+	}
+}
+
+func TestEngine_RenderCSS_Missing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	// No _styles.css → should return ("", nil).
+	css, err := eng.RenderCSS()
+	if err != nil {
+		t.Errorf("RenderCSS missing: %v", err)
+	}
+	if css != "" {
+		t.Errorf("RenderCSS missing: want empty, got %q", css)
+	}
+}
+
+func TestEngine_RenderCSS_Present(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "_styles.css"), []byte(`body { color: red; }`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	css, err := eng.RenderCSS()
+	if err != nil {
+		t.Errorf("RenderCSS: %v", err)
+	}
+	if !strings.Contains(css, "color: red") {
+		t.Errorf("RenderCSS: expected CSS content, got %q", css)
+	}
+}
+
+func TestEngine_RenderJS_Missing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	js, err := eng.RenderJS()
+	if err != nil {
+		t.Errorf("RenderJS missing: %v", err)
+	}
+	if js != "" {
+		t.Errorf("RenderJS missing: want empty, got %q", js)
+	}
+}
+
+func TestEngine_RenderHub(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "hub.html"), []byte(`hub`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	ctx := HubPageContext{
+		Taxonomy: taxonomy.Taxonomy{
+			Config: config.TaxonomyConfig{Template: "hub.html"},
+		},
+	}
+	if _, err := eng.RenderHub(ctx); err != nil {
+		t.Errorf("RenderHub: %v", err)
+	}
+}
+
+func TestEngine_RenderTaxonomyIndex(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(`index`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	ctx := TaxonomyIndexContext{
+		Taxonomy: taxonomy.Taxonomy{
+			Config: config.TaxonomyConfig{IndexTemplate: "index.html"},
+		},
+	}
+	if _, err := eng.RenderTaxonomyIndex(ctx); err != nil {
+		t.Errorf("RenderTaxonomyIndex: %v", err)
+	}
+}
+
+func TestEngine_RenderLetter(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "letter.html"), []byte(`letter`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	ctx := LetterPageContext{
+		Taxonomy: taxonomy.Taxonomy{
+			Config: config.TaxonomyConfig{LetterTemplate: "letter.html"},
+		},
+	}
+	if _, err := eng.RenderLetter(ctx); err != nil {
+		t.Errorf("RenderLetter: %v", err)
+	}
+}
+
+// TestEngine_RenderExecuteError covers L240-242: when template execution fails,
+// render returns an error.
+func TestEngine_RenderExecuteError(t *testing.T) {
+	dir := t.TempDir()
+	// Template that calls a non-existent sub-template → execute error.
+	if err := os.WriteFile(filepath.Join(dir, "broken.html"), []byte(`{{template "nonexistent"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if _, err := eng.RenderStatic("broken.html", StaticPageContext{}); err == nil {
+		t.Error("render: want error when template execution fails, got nil")
+	}
+}
+
+func TestEngine_RenderJS_Present(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "_main.js"), []byte(`console.log("hi");`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Paths: config.PathsConfig{Templates: dir}}
+	eng, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	js, err := eng.RenderJS()
+	if err != nil {
+		t.Errorf("RenderJS: %v", err)
+	}
+	if !strings.Contains(js, "console.log") {
+		t.Errorf("RenderJS: expected JS content, got %q", js)
+	}
+}
+
+// ── GenerateCookModePrompt ────────────────────────────────────────────────────
+
+func TestGenerateCookModePrompt_NilEnrichment(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Pasta"}}
+	if got := GenerateCookModePrompt(e, nil, nil); got != "" {
+		t.Errorf("nil enrichment: want empty string, got %q", got)
+	}
+}
+
+func TestGenerateCookModePrompt_BasicTitle(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Spaghetti"}}
+	enrichment := map[string]interface{}{}
+	got := GenerateCookModePrompt(e, enrichment, nil)
+	if !strings.Contains(got, "Spaghetti") {
+		t.Errorf("should contain title, got:\n%s", got)
+	}
+	if !strings.Contains(got, "step by step") {
+		t.Errorf("should contain closing prompt, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_CoachingPrompt(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Risotto"}}
+	enrichment := map[string]interface{}{
+		"coachingPrompt": "Pay attention to stirring technique.",
+	}
+	got := GenerateCookModePrompt(e, enrichment, nil)
+	if !strings.Contains(got, "Pay attention to stirring technique.") {
+		t.Errorf("should contain coachingPrompt, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_Ingredients(t *testing.T) {
+	e := &entity.Entity{
+		Fields: map[string]interface{}{"title": "Soup"},
+		Sections: map[string]interface{}{
+			"ingredients": []string{"1 carrot", "2 potatoes"},
+		},
+	}
+	got := GenerateCookModePrompt(e, map[string]interface{}{}, nil)
+	if !strings.Contains(got, "Ingredients:") {
+		t.Errorf("should contain Ingredients section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- 1 carrot") {
+		t.Errorf("should list ingredients, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_Instructions(t *testing.T) {
+	e := &entity.Entity{
+		Fields: map[string]interface{}{"title": "Cake"},
+		Sections: map[string]interface{}{
+			"instructions": []string{"Mix flour", "Bake at 350°F"},
+		},
+	}
+	got := GenerateCookModePrompt(e, map[string]interface{}{}, nil)
+	if !strings.Contains(got, "Instructions:") {
+		t.Errorf("should contain Instructions section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "1. Mix flour") {
+		t.Errorf("should number instructions, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_CookingTips(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Steak"}}
+	enrichment := map[string]interface{}{
+		"cookingTips": []interface{}{"Let it rest", "Season generously"},
+	}
+	got := GenerateCookModePrompt(e, enrichment, nil)
+	if !strings.Contains(got, "Key Tips:") {
+		t.Errorf("should contain Key Tips section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "- Let it rest") {
+		t.Errorf("should list tips, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_CookingTipsNonString(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Steak"}}
+	enrichment := map[string]interface{}{
+		// tip is an int, not a string — should be skipped
+		"cookingTips": []interface{}{42, "Use salt"},
+	}
+	got := GenerateCookModePrompt(e, enrichment, nil)
+	if !strings.Contains(got, "Key Tips:") {
+		t.Errorf("should contain Key Tips (one valid tip), got:\n%s", got)
+	}
+	if !strings.Contains(got, "- Use salt") {
+		t.Errorf("should include string tip, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_AffiliateLinks(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"title": "Tacos"}}
+	links := []affiliate.Link{
+		{Term: "cumin", URL: "https://shop.example.com/cumin", Provider: "Amazon"},
+	}
+	got := GenerateCookModePrompt(e, map[string]interface{}{}, links)
+	if !strings.Contains(got, "Shopping Links:") {
+		t.Errorf("should contain Shopping Links section, got:\n%s", got)
+	}
+	if !strings.Contains(got, "cumin") {
+		t.Errorf("should list affiliate term, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Amazon") {
+		t.Errorf("should list provider, got:\n%s", got)
+	}
+}
+
+func TestGenerateCookModePrompt_AllSections(t *testing.T) {
+	e := &entity.Entity{
+		Fields: map[string]interface{}{"title": "Full Recipe"},
+		Sections: map[string]interface{}{
+			"ingredients":  []string{"flour", "eggs"},
+			"instructions": []string{"Mix", "Bake"},
+		},
+	}
+	enrichment := map[string]interface{}{
+		"coachingPrompt": "Take your time.",
+		"cookingTips":    []interface{}{"Don't over-mix"},
+	}
+	links := []affiliate.Link{
+		{Term: "flour", URL: "https://shop.example.com/flour", Provider: "Store"},
+	}
+	got := GenerateCookModePrompt(e, enrichment, links)
+	for _, want := range []string{
+		"Full Recipe", "Take your time.",
+		"Ingredients:", "- flour",
+		"Instructions:", "1. Mix",
+		"Key Tips:", "- Don't over-mix",
+		"Shopping Links:", "flour",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in output:\n%s", want, got)
+		}
+	}
+}

--- a/internal/archdocs/pssg/render/shareimage_test.go
+++ b/internal/archdocs/pssg/render/shareimage_test.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -119,6 +120,89 @@ func TestGenerateAllEntitiesShareSVG_Empty(t *testing.T) {
 	got := GenerateAllEntitiesShareSVG("My Site", 0, nil)
 	if !strings.HasPrefix(got, "<svg") {
 		t.Errorf("empty dist: should produce SVG, got: %.50s", got)
+	}
+}
+
+// TestGenerateAllEntitiesShareSVG_AllZeroCounts covers the totalForBar==0 branch
+// (L190): typeDist is non-nil but every Count is 0, so totalForBar is set to 1
+// to avoid division by zero.
+func TestGenerateAllEntitiesShareSVG_AllZeroCounts(t *testing.T) {
+	dist := []NameCount{
+		{Name: "Dinner", Count: 0},
+		{Name: "Lunch", Count: 0},
+	}
+	got := GenerateAllEntitiesShareSVG("My Site", 0, dist)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("all-zero counts: should produce SVG, got: %.50s", got)
+	}
+}
+
+// ── limit capping branches ────────────────────────────────────────────────────
+
+func TestGenerateHomepageShareSVG_OverLimit(t *testing.T) {
+	// >8 items should be capped at 8
+	var stats []NameCount
+	for i := 0; i < 12; i++ {
+		stats = append(stats, NameCount{Name: fmt.Sprintf("Cat%d", i), Count: i + 1})
+	}
+	got := GenerateHomepageShareSVG("My Site", "A cooking site", stats, 100)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("over-limit stats should still produce SVG")
+	}
+}
+
+func TestGenerateHubShareSVG_OverLimit(t *testing.T) {
+	// >6 items should be capped at 6
+	var topTypes []NameCount
+	for i := 0; i < 9; i++ {
+		topTypes = append(topTypes, NameCount{Name: fmt.Sprintf("Type%d", i), Count: i + 1})
+	}
+	got := GenerateHubShareSVG("My Site", "Italian", "Cuisine", 50, topTypes)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("over-limit hub should still produce SVG")
+	}
+}
+
+func TestGenerateTaxIndexShareSVG_OverLimit(t *testing.T) {
+	// >10 entries should be capped at 10
+	var entries []NameCount
+	for i := 0; i < 15; i++ {
+		entries = append(entries, NameCount{Name: fmt.Sprintf("Entry%d", i), Count: i + 1})
+	}
+	got := GenerateTaxIndexShareSVG("My Site", "Cuisine", entries)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("over-limit tax index should still produce SVG")
+	}
+}
+
+func TestGenerateAllEntitiesShareSVG_OverLimit(t *testing.T) {
+	// >8 type dist items should be capped at 8
+	// Use very uneven counts to trigger the w < 2 minimum-width branch.
+	dist := []NameCount{
+		{Name: "Big", Count: 1000},
+		{Name: "Tiny", Count: 1}, // 1*1080/1001 = 1 → w < 2 → w = 2
+		{Name: "Type2", Count: 10},
+		{Name: "Type3", Count: 20},
+		{Name: "Type4", Count: 15},
+		{Name: "Type5", Count: 8},
+		{Name: "Type6", Count: 5},
+		{Name: "Type7", Count: 3},
+		{Name: "Type8", Count: 2},
+		{Name: "Type9", Count: 2},
+		{Name: "TypeA", Count: 1},
+		{Name: "TypeB", Count: 1},
+	}
+	got := GenerateAllEntitiesShareSVG("My Site", 200, dist)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("over-limit all-entities should still produce SVG")
+	}
+}
+
+func TestGenerateEntityShareSVG_EmptyPills(t *testing.T) {
+	// All pill labels empty → all pills skipped via continue
+	got := GenerateEntityShareSVG("My Site", "Dish Name", "", "", "")
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("empty pills should still produce SVG")
 	}
 }
 

--- a/internal/archdocs/pssg/render/shareimage_test.go
+++ b/internal/archdocs/pssg/render/shareimage_test.go
@@ -1,9 +1,138 @@
 package render
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
 )
+
+// ── svgEscape ─────────────────────────────────────────────────────────────────
+
+func TestSvgEscape(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"hello", "hello"},
+		{"a & b", "a &amp; b"},
+		{"<tag>", "&lt;tag&gt;"},
+		{`say "hi"`, "say &quot;hi&quot;"},
+		{"a & <b>", "a &amp; &lt;b&gt;"},
+	}
+	for _, tc := range cases {
+		if got := svgEscape(tc.in); got != tc.want {
+			t.Errorf("svgEscape(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// ── renderBarsSVG ─────────────────────────────────────────────────────────────
+
+func TestRenderBarsSVG_Empty(t *testing.T) {
+	if got := renderBarsSVG(nil, 0, 0, 100, 20, 5); got != "" {
+		t.Errorf("empty bars: got %q, want empty", got)
+	}
+}
+
+func TestRenderBarsSVG_SingleBar(t *testing.T) {
+	bars := []NameCount{{Name: "Italian", Count: 10}}
+	got := renderBarsSVG(bars, 60, 200, 400, 20, 5)
+	if !strings.Contains(got, "Italian") {
+		t.Errorf("should contain bar name: %s", got)
+	}
+	if !strings.Contains(got, "<rect") {
+		t.Errorf("should contain rect element: %s", got)
+	}
+}
+
+func TestRenderBarsSVG_AllZeroCount(t *testing.T) {
+	bars := []NameCount{{Name: "A", Count: 0}}
+	got := renderBarsSVG(bars, 0, 0, 100, 20, 5)
+	if !strings.Contains(got, "<rect") {
+		t.Error("zero-count bars should still produce rect elements")
+	}
+}
+
+// ── GenerateHomepageShareSVG ──────────────────────────────────────────────────
+
+func TestGenerateHomepageShareSVG(t *testing.T) {
+	stats := []NameCount{{Name: "Italian", Count: 5}, {Name: "French", Count: 3}}
+	got := GenerateHomepageShareSVG("My Site", "A cooking site", stats, 42)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+	if !strings.Contains(got, "42") {
+		t.Error("should contain total entity count")
+	}
+}
+
+func TestGenerateHomepageShareSVG_Empty(t *testing.T) {
+	got := GenerateHomepageShareSVG("Site", "Desc", nil, 0)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("empty stats should still produce SVG: %.50s", got)
+	}
+}
+
+// ── GenerateEntityShareSVG ────────────────────────────────────────────────────
+
+func TestGenerateEntityShareSVG(t *testing.T) {
+	got := GenerateEntityShareSVG("My Site", "Spaghetti Carbonara", "Main Course", "Italian", "Easy")
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+	if !strings.Contains(got, "Spaghetti") {
+		t.Error("should contain entity title")
+	}
+}
+
+// ── GenerateHubShareSVG ───────────────────────────────────────────────────────
+
+func TestGenerateHubShareSVG(t *testing.T) {
+	topTypes := []NameCount{{Name: "Pasta", Count: 10}}
+	got := GenerateHubShareSVG("My Site", "Italian", "Cuisine", 25, topTypes)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+	if !strings.Contains(got, "Italian") {
+		t.Error("should contain hub name")
+	}
+}
+
+// ── GenerateTaxIndexShareSVG ──────────────────────────────────────────────────
+
+func TestGenerateTaxIndexShareSVG(t *testing.T) {
+	topEntries := []NameCount{{Name: "Italian", Count: 5}}
+	got := GenerateTaxIndexShareSVG("My Site", "Cuisine", topEntries)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+}
+
+// ── GenerateAllEntitiesShareSVG ───────────────────────────────────────────────
+
+func TestGenerateAllEntitiesShareSVG(t *testing.T) {
+	typeDist := []NameCount{{Name: "Dinner", Count: 50}, {Name: "Lunch", Count: 30}}
+	got := GenerateAllEntitiesShareSVG("My Site", 100, typeDist)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+}
+
+func TestGenerateAllEntitiesShareSVG_Empty(t *testing.T) {
+	got := GenerateAllEntitiesShareSVG("My Site", 0, nil)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("empty dist: should produce SVG, got: %.50s", got)
+	}
+}
+
+// ── GenerateLetterShareSVG ────────────────────────────────────────────────────
+
+func TestGenerateLetterShareSVG(t *testing.T) {
+	got := GenerateLetterShareSVG("My Site", "Cuisine", "A", 7)
+	if !strings.HasPrefix(got, "<svg") {
+		t.Errorf("should start with <svg, got: %.50s", got)
+	}
+	if !strings.Contains(got, "7") {
+		t.Error("should contain entry count")
+	}
+}
 
 func TestTruncateASCII(t *testing.T) {
 	cases := []struct {

--- a/internal/archdocs/pssg/schema/jsonld_test.go
+++ b/internal/archdocs/pssg/schema/jsonld_test.go
@@ -208,6 +208,23 @@ func TestMarshalSchemas_Multiple(t *testing.T) {
 	}
 }
 
+func TestGenerateItemListSchema_WithImage(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	schema := g.GenerateItemListSchema("Best Recipes", "Top picks", nil, "https://example.com/img.jpg")
+	if schema["image"] != "https://example.com/img.jpg" {
+		t.Errorf("expected image in schema, got %v", schema["image"])
+	}
+}
+
+func TestMarshalSchemas_MarshalError(t *testing.T) {
+	// A map containing a channel is not JSON-marshallable → error path → skipped
+	bad := map[string]interface{}{"ch": make(chan int)}
+	out := MarshalSchemas(bad)
+	if out != "" {
+		t.Errorf("expected empty output for unmarshalable schema, got %q", out)
+	}
+}
+
 func TestMarshalSchemas_Empty(t *testing.T) {
 	if got := MarshalSchemas(); got != "" {
 		t.Errorf("no schemas: want empty string, got %q", got)
@@ -320,6 +337,50 @@ func TestGenerateRecipeSchema_WithAuthorAndTimes(t *testing.T) {
 	}
 	if schema["recipeCuisine"] != "Italian" {
 		t.Errorf("recipeCuisine: got %v", schema["recipeCuisine"])
+	}
+}
+
+func TestGenerateRecipeSchema_WithIngredientsAndInstructions(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{BaseURL: "https://example.com"}, config.SchemaConfig{})
+	e := &entity.Entity{
+		Slug:   "soup",
+		Fields: map[string]interface{}{"title": "Soup", "image": "https://example.com/soup.jpg"},
+		Sections: map[string]interface{}{
+			"ingredients":  []string{"1 cup broth", "1 onion"},
+			"instructions": []string{"Boil the broth", "Add onion"},
+		},
+	}
+	schema := g.GenerateRecipeSchema(e, "https://example.com/soup.html")
+	if _, ok := schema["recipeIngredient"]; !ok {
+		t.Error("expected recipeIngredient in schema")
+	}
+	if _, ok := schema["recipeInstructions"]; !ok {
+		t.Error("expected recipeInstructions in schema")
+	}
+	if _, ok := schema["image"]; !ok {
+		t.Error("expected image in schema")
+	}
+}
+
+func TestGenerateRecipeSchema_WithKeywordsAndPairings(t *testing.T) {
+	g := NewGenerator(
+		config.SiteConfig{BaseURL: "https://example.com"},
+		config.SchemaConfig{ExtraKeywords: []string{"easy", "quick"}},
+	)
+	e := &entity.Entity{
+		Slug: "pasta",
+		Fields: map[string]interface{}{
+			"title":    "Pasta",
+			"keywords": []interface{}{"italian", "dinner"},
+			"pairings": []interface{}{"salad", "wine"},
+		},
+	}
+	schema := g.GenerateRecipeSchema(e, "https://example.com/pasta.html")
+	if _, ok := schema["keywords"]; !ok {
+		t.Error("expected keywords in schema")
+	}
+	if _, ok := schema["isRelatedTo"]; !ok {
+		t.Error("expected isRelatedTo in schema for pairings")
 	}
 }
 

--- a/internal/archdocs/pssg/schema/jsonld_test.go
+++ b/internal/archdocs/pssg/schema/jsonld_test.go
@@ -1,8 +1,12 @@
 package schema
 
 import (
+	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
 )
 
 func TestStepName(t *testing.T) {
@@ -47,6 +51,166 @@ func TestStepName(t *testing.T) {
 	got = stepName(multiSentence)
 	if !utf8.ValidString(got) {
 		t.Errorf("multi-byte sentence truncation produced invalid UTF-8: %q", got)
+	}
+}
+
+// ── NewGenerator ──────────────────────────────────────────────────────────────
+
+func TestNewGenerator(t *testing.T) {
+	site := config.SiteConfig{Name: "My Site", BaseURL: "https://example.com"}
+	g := NewGenerator(site, config.SchemaConfig{})
+	if g == nil {
+		t.Fatal("NewGenerator returned nil")
+	}
+	if g.SiteConfig.Name != "My Site" {
+		t.Errorf("SiteConfig.Name: got %q", g.SiteConfig.Name)
+	}
+}
+
+// ── GenerateWebSiteSchema ─────────────────────────────────────────────────────
+
+func TestGenerateWebSiteSchema(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{
+		Name:        "My Site",
+		BaseURL:     "https://example.com",
+		Description: "A recipe site",
+	}, config.SchemaConfig{})
+
+	s := g.GenerateWebSiteSchema("")
+	if s["@type"] != "WebSite" {
+		t.Errorf("@type: got %v", s["@type"])
+	}
+	if s["name"] != "My Site" {
+		t.Errorf("name: got %v", s["name"])
+	}
+	if s["url"] != "https://example.com" {
+		t.Errorf("url: got %v", s["url"])
+	}
+	if _, ok := s["image"]; ok {
+		t.Error("image should not be set when imageURL is empty")
+	}
+
+	// With image
+	s2 := g.GenerateWebSiteSchema("https://example.com/og.png")
+	if s2["image"] != "https://example.com/og.png" {
+		t.Errorf("image: got %v", s2["image"])
+	}
+}
+
+// ── GenerateBreadcrumbSchema ──────────────────────────────────────────────────
+
+func TestGenerateBreadcrumbSchema(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	items := []BreadcrumbItem{
+		{Name: "Home", URL: "https://example.com/"},
+		{Name: "Recipes", URL: "https://example.com/recipes/"},
+		{Name: "Soup"},
+	}
+	s := g.GenerateBreadcrumbSchema(items)
+	if s["@type"] != "BreadcrumbList" {
+		t.Errorf("@type: got %v", s["@type"])
+	}
+	list := s["itemListElement"].([]map[string]interface{})
+	if len(list) != 3 {
+		t.Fatalf("want 3 items, got %d", len(list))
+	}
+	if list[0]["position"] != 1 {
+		t.Errorf("position 1: got %v", list[0]["position"])
+	}
+	if list[0]["item"] != "https://example.com/" {
+		t.Errorf("item[0].item: got %v", list[0]["item"])
+	}
+	// Last item has no URL, so "item" key should not be present
+	if _, ok := list[2]["item"]; ok {
+		t.Error("item without URL should not have 'item' key")
+	}
+}
+
+// ── GenerateFAQSchema ─────────────────────────────────────────────────────────
+
+func TestGenerateFAQSchema_WithFAQs(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	faqs := []entity.FAQ{
+		{Question: "How long does this take?", Answer: "30 minutes."},
+		{Question: "Can I freeze it?", Answer: "Yes!"},
+	}
+	s := g.GenerateFAQSchema(faqs)
+	if s["@type"] != "FAQPage" {
+		t.Errorf("@type: got %v", s["@type"])
+	}
+	qs := s["mainEntity"].([]map[string]interface{})
+	if len(qs) != 2 {
+		t.Fatalf("want 2 FAQs, got %d", len(qs))
+	}
+	if qs[0]["name"] != "How long does this take?" {
+		t.Errorf("first question: got %v", qs[0]["name"])
+	}
+}
+
+func TestGenerateFAQSchema_Empty(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	if got := g.GenerateFAQSchema(nil); got != nil {
+		t.Error("empty FAQs should return nil")
+	}
+}
+
+// ── GenerateItemListSchema ────────────────────────────────────────────────────
+
+func TestGenerateItemListSchema(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	items := []ItemListEntry{
+		{Name: "Tomato Soup", URL: "https://example.com/tomato-soup"},
+		{Name: "Chicken Stew", URL: "https://example.com/chicken-stew"},
+	}
+	s := g.GenerateItemListSchema("Soups", "A collection of soups", items, "")
+	if s["@type"] != "ItemList" {
+		t.Errorf("@type: got %v", s["@type"])
+	}
+	if s["numberOfItems"] != 2 {
+		t.Errorf("numberOfItems: got %v", s["numberOfItems"])
+	}
+	list := s["itemListElement"].([]map[string]interface{})
+	if len(list) != 2 {
+		t.Fatalf("want 2 items, got %d", len(list))
+	}
+	if list[0]["position"] != 1 {
+		t.Errorf("position: got %v", list[0]["position"])
+	}
+}
+
+// ── MarshalSchemas ────────────────────────────────────────────────────────────
+
+func TestMarshalSchemas_Basic(t *testing.T) {
+	s := map[string]interface{}{"@type": "WebSite", "name": "Test"}
+	got := MarshalSchemas(s)
+	if !strings.HasPrefix(got, `<script type="application/ld+json">`) {
+		t.Errorf("should start with script tag, got: %q", got[:50])
+	}
+	if !strings.Contains(got, `"@type":"WebSite"`) {
+		t.Errorf("should contain @type, got: %q", got)
+	}
+}
+
+func TestMarshalSchemas_NilSkipped(t *testing.T) {
+	s := map[string]interface{}{"@type": "WebSite"}
+	got := MarshalSchemas(nil, s, nil)
+	if strings.Count(got, "<script") != 1 {
+		t.Errorf("nil schemas should be skipped, got %d script tags", strings.Count(got, "<script"))
+	}
+}
+
+func TestMarshalSchemas_Multiple(t *testing.T) {
+	s1 := map[string]interface{}{"@type": "WebSite"}
+	s2 := map[string]interface{}{"@type": "BreadcrumbList"}
+	got := MarshalSchemas(s1, s2)
+	if strings.Count(got, "<script") != 2 {
+		t.Errorf("want 2 script tags, got %d", strings.Count(got, "<script"))
+	}
+}
+
+func TestMarshalSchemas_Empty(t *testing.T) {
+	if got := MarshalSchemas(); got != "" {
+		t.Errorf("no schemas: want empty string, got %q", got)
 	}
 }
 

--- a/internal/archdocs/pssg/schema/jsonld_test.go
+++ b/internal/archdocs/pssg/schema/jsonld_test.go
@@ -257,3 +257,103 @@ func TestComputeTotalTime(t *testing.T) {
 		}
 	}
 }
+
+// ── GenerateRecipeSchema ──────────────────────────────────────────────────────
+
+func TestGenerateRecipeSchema_Basic(t *testing.T) {
+	g := NewGenerator(
+		config.SiteConfig{BaseURL: "https://example.com", Name: "My Site"},
+		config.SchemaConfig{DatePublished: "2024-01-15"},
+	)
+	e := &entity.Entity{
+		Slug: "pasta-carbonara",
+		Fields: map[string]interface{}{
+			"title":       "Pasta Carbonara",
+			"description": "A classic Italian pasta dish.",
+		},
+	}
+	schema := g.GenerateRecipeSchema(e, "https://example.com/pasta-carbonara.html")
+	if schema["@type"] != "Recipe" {
+		t.Errorf("@type: got %v, want Recipe", schema["@type"])
+	}
+	if schema["name"] != "Pasta Carbonara" {
+		t.Errorf("name: got %v", schema["name"])
+	}
+	if schema["url"] != "https://example.com/pasta-carbonara.html" {
+		t.Errorf("url: got %v", schema["url"])
+	}
+}
+
+func TestGenerateRecipeSchema_WithAuthorAndTimes(t *testing.T) {
+	g := NewGenerator(
+		config.SiteConfig{BaseURL: "https://example.com"},
+		config.SchemaConfig{},
+	)
+	e := &entity.Entity{
+		Slug: "soup",
+		Fields: map[string]interface{}{
+			"title":           "Tomato Soup",
+			"author":          "Chef Alice",
+			"prep_time":       "PT10M",
+			"cook_time":       "PT30M",
+			"recipe_category": "Soup",
+			"cuisine":         "Italian",
+			"servings":        float64(4),
+			"calories":        float64(200),
+		},
+	}
+	schema := g.GenerateRecipeSchema(e, "https://example.com/soup.html")
+	if _, ok := schema["author"]; !ok {
+		t.Error("schema should have author")
+	}
+	if schema["prepTime"] != "PT10M" {
+		t.Errorf("prepTime: got %v", schema["prepTime"])
+	}
+	if schema["cookTime"] != "PT30M" {
+		t.Errorf("cookTime: got %v", schema["cookTime"])
+	}
+	if _, ok := schema["totalTime"]; !ok {
+		t.Error("schema should have totalTime when both prep and cook are set")
+	}
+	if schema["recipeCategory"] != "Soup" {
+		t.Errorf("recipeCategory: got %v", schema["recipeCategory"])
+	}
+	if schema["recipeCuisine"] != "Italian" {
+		t.Errorf("recipeCuisine: got %v", schema["recipeCuisine"])
+	}
+}
+
+// ── GenerateCollectionPageSchema ──────────────────────────────────────────────
+
+func TestGenerateCollectionPageSchema_Basic(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{BaseURL: "https://example.com"}, config.SchemaConfig{})
+	items := []ItemListEntry{
+		{Name: "Pasta", URL: "https://example.com/pasta.html"},
+		{Name: "Soup", URL: "https://example.com/soup.html"},
+	}
+	schema := g.GenerateCollectionPageSchema("Italian Recipes", "Best Italian food", "https://example.com/italian/", items, "https://example.com/img.png")
+	if schema["@type"] != "CollectionPage" {
+		t.Errorf("@type: got %v, want CollectionPage", schema["@type"])
+	}
+	if schema["name"] != "Italian Recipes" {
+		t.Errorf("name: got %v", schema["name"])
+	}
+	if schema["image"] != "https://example.com/img.png" {
+		t.Errorf("image: got %v", schema["image"])
+	}
+	main, ok := schema["mainEntity"].(map[string]interface{})
+	if !ok {
+		t.Fatal("mainEntity should be a map")
+	}
+	if main["numberOfItems"] != 2 {
+		t.Errorf("numberOfItems: got %v, want 2", main["numberOfItems"])
+	}
+}
+
+func TestGenerateCollectionPageSchema_NoImage(t *testing.T) {
+	g := NewGenerator(config.SiteConfig{}, config.SchemaConfig{})
+	schema := g.GenerateCollectionPageSchema("Name", "Desc", "https://example.com/", nil, "")
+	if _, ok := schema["image"]; ok {
+		t.Error("should not set image when imageURL is empty")
+	}
+}

--- a/internal/archdocs/pssg/taxonomy/taxonomy_test.go
+++ b/internal/archdocs/pssg/taxonomy/taxonomy_test.go
@@ -361,6 +361,48 @@ func TestComputePagination_Empty(t *testing.T) {
 	}
 }
 
+// TestBuildAll_InvertMode covers L73-76: when tc.Invert is true the entity loop
+// hits the continue and no entries are added.
+func TestBuildAll_InvertMode(t *testing.T) {
+	entities := []*entity.Entity{
+		{Slug: "pasta", Fields: map[string]interface{}{"cuisine": "Italian"}},
+	}
+	tc := config.TaxonomyConfig{Name: "cuisine", Field: "cuisine", Invert: true, MinEntities: 1}
+	taxes := BuildAll(entities, []config.TaxonomyConfig{tc}, nil)
+	if len(taxes) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(taxes))
+	}
+	if len(taxes[0].Entries) != 0 {
+		t.Errorf("Invert mode should produce 0 entries, got %d", len(taxes[0].Entries))
+	}
+}
+
+// TestBuildAll_EmptySlugSkipped covers L81-82: a field value that slugifies to
+// "" (e.g. all punctuation) is skipped without adding an entry.
+func TestBuildAll_EmptySlugSkipped(t *testing.T) {
+	entities := []*entity.Entity{
+		{Slug: "pasta", Fields: map[string]interface{}{"cuisine": "@@@"}},
+	}
+	tc := config.TaxonomyConfig{Name: "cuisine", Field: "cuisine", MinEntities: 1}
+	taxes := BuildAll(entities, []config.TaxonomyConfig{tc}, nil)
+	if len(taxes) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(taxes))
+	}
+	if len(taxes[0].Entries) != 0 {
+		t.Errorf("all-punctuation value should produce 0 entries, got %d", len(taxes[0].Entries))
+	}
+}
+
+// TestExtractValues_NonStringValue covers L140: when MultiValue is false and the
+// field value is not a string, extractValues returns nil.
+func TestExtractValues_NonStringValue(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"count": 42}}
+	tc := config.TaxonomyConfig{Field: "count", MultiValue: false}
+	if got := extractValues(e, tc, nil); got != nil {
+		t.Errorf("non-string non-multivalue: want nil, got %v", got)
+	}
+}
+
 // TestTopEntries verifies that TopEntries returns entries sorted by entity count.
 func TestTopEntries(t *testing.T) {
 	e := func(n int) []*entity.Entity {
@@ -385,5 +427,18 @@ func TestTopEntries(t *testing.T) {
 	// original slice must not be modified
 	if entries[0].Name != "A" {
 		t.Errorf("original slice was modified")
+	}
+}
+
+// TestTopEntries_NExceedsLength covers L311-313: when n is larger than the
+// number of entries, TopEntries returns all of them.
+func TestTopEntries_NExceedsLength(t *testing.T) {
+	entries := []Entry{
+		{Name: "A", Slug: "a"},
+		{Name: "B", Slug: "b"},
+	}
+	top := TopEntries(entries, 100)
+	if len(top) != 2 {
+		t.Errorf("n > len: want 2 entries, got %d", len(top))
 	}
 }

--- a/internal/archdocs/pssg/taxonomy/taxonomy_test.go
+++ b/internal/archdocs/pssg/taxonomy/taxonomy_test.go
@@ -90,6 +90,133 @@ func TestGroupByLetterEmpty(t *testing.T) {
 	}
 }
 
+// ── toStringSlice ─────────────────────────────────────────────────────────────
+
+func TestToStringSlice(t *testing.T) {
+	if got := toStringSlice([]string{"a", "b"}); len(got) != 2 || got[0] != "a" {
+		t.Errorf("[]string: got %v", got)
+	}
+	if got := toStringSlice("single"); len(got) != 1 || got[0] != "single" {
+		t.Errorf("string: got %v", got)
+	}
+	if got := toStringSlice([]interface{}{"x", "y"}); len(got) != 2 || got[0] != "x" {
+		t.Errorf("[]interface{}: got %v", got)
+	}
+	if got := toStringSlice(42); got != nil {
+		t.Errorf("int: want nil, got %v", got)
+	}
+}
+
+// ── HubPageURL ────────────────────────────────────────────────────────────────
+
+func TestHubPageURL(t *testing.T) {
+	if got := HubPageURL("cuisine", "italian", 1); got != "/cuisine/italian.html" {
+		t.Errorf("page 1: got %q", got)
+	}
+	if got := HubPageURL("cuisine", "italian", 2); got != "/cuisine/italian-page-2.html" {
+		t.Errorf("page 2: got %q", got)
+	}
+	if got := HubPageURL("cuisine", "italian", 10); got != "/cuisine/italian-page-10.html" {
+		t.Errorf("page 10: got %q", got)
+	}
+}
+
+// ── LetterPageURL ─────────────────────────────────────────────────────────────
+
+func TestLetterPageURL(t *testing.T) {
+	if got := LetterPageURL("cuisine", "A"); got != "/cuisine/letter-a.html" {
+		t.Errorf("A: got %q", got)
+	}
+	if got := LetterPageURL("cuisine", "#"); got != "/cuisine/letter-num.html" {
+		t.Errorf("#: got %q", got)
+	}
+	if got := LetterPageURL("tags", "Z"); got != "/tags/letter-z.html" {
+		t.Errorf("Z: got %q", got)
+	}
+}
+
+// ── FindEntry ─────────────────────────────────────────────────────────────────
+
+func TestFindEntry(t *testing.T) {
+	tx := &Taxonomy{
+		Entries: []Entry{
+			{Slug: "italian", Name: "Italian"},
+			{Slug: "french", Name: "French"},
+		},
+	}
+	e := tx.FindEntry("french")
+	if e == nil {
+		t.Fatal("FindEntry('french') returned nil")
+	}
+	if e.Name != "French" {
+		t.Errorf("FindEntry('french').Name = %q, want 'French'", e.Name)
+	}
+	if tx.FindEntry("japanese") != nil {
+		t.Error("FindEntry for unknown slug should return nil")
+	}
+}
+
+// ── ComputePagination ─────────────────────────────────────────────────────────
+
+func TestComputePagination_SinglePage(t *testing.T) {
+	e := func(n int) []*entity.Entity {
+		s := make([]*entity.Entity, n)
+		for i := range s {
+			s[i] = &entity.Entity{}
+		}
+		return s
+	}
+	entry := Entry{Slug: "italian", Entities: e(5)}
+	info := ComputePagination(entry, 1, 20, "cuisine")
+	if info.TotalPages != 1 {
+		t.Errorf("TotalPages: got %d, want 1", info.TotalPages)
+	}
+	if info.TotalItems != 5 {
+		t.Errorf("TotalItems: got %d, want 5", info.TotalItems)
+	}
+	if info.PrevURL != "" {
+		t.Error("page 1 should have no PrevURL")
+	}
+	if info.NextURL != "" {
+		t.Error("single page should have no NextURL")
+	}
+}
+
+func TestComputePagination_MultiPage(t *testing.T) {
+	e := func(n int) []*entity.Entity {
+		s := make([]*entity.Entity, n)
+		for i := range s {
+			s[i] = &entity.Entity{}
+		}
+		return s
+	}
+	entry := Entry{Slug: "italian", Entities: e(10)}
+	info := ComputePagination(entry, 2, 4, "cuisine")
+	if info.TotalPages != 3 {
+		t.Errorf("TotalPages: got %d, want 3", info.TotalPages)
+	}
+	if info.CurrentPage != 2 {
+		t.Errorf("CurrentPage: got %d, want 2", info.CurrentPage)
+	}
+	if info.PrevURL != "/cuisine/italian.html" {
+		t.Errorf("PrevURL: got %q", info.PrevURL)
+	}
+	if info.NextURL != "/cuisine/italian-page-3.html" {
+		t.Errorf("NextURL: got %q", info.NextURL)
+	}
+	if len(info.PageURLs) != 3 {
+		t.Errorf("PageURLs: got %d entries", len(info.PageURLs))
+	}
+}
+
+func TestComputePagination_Empty(t *testing.T) {
+	entry := Entry{Slug: "empty"}
+	info := ComputePagination(entry, 1, 20, "cuisine")
+	if info.TotalPages != 1 {
+		t.Errorf("empty entries: TotalPages should be 1, got %d", info.TotalPages)
+	}
+}
+
 // TestTopEntries verifies that TopEntries returns entries sorted by entity count.
 func TestTopEntries(t *testing.T) {
 	e := func(n int) []*entity.Entity {

--- a/internal/archdocs/pssg/taxonomy/taxonomy_test.go
+++ b/internal/archdocs/pssg/taxonomy/taxonomy_test.go
@@ -3,8 +3,152 @@ package taxonomy
 import (
 	"testing"
 
+	"github.com/supermodeltools/cli/internal/archdocs/pssg/config"
 	"github.com/supermodeltools/cli/internal/archdocs/pssg/entity"
 )
+
+// ── BuildAll / buildOne / extractValues ───────────────────────────────────────
+
+func TestBuildAll_Basic(t *testing.T) {
+	entities := []*entity.Entity{
+		{Slug: "pasta", Fields: map[string]interface{}{"cuisine": "Italian"}},
+		{Slug: "ramen", Fields: map[string]interface{}{"cuisine": "Japanese"}},
+		{Slug: "sushi", Fields: map[string]interface{}{"cuisine": "Japanese"}},
+	}
+	tc := config.TaxonomyConfig{Name: "cuisine", Field: "cuisine", MinEntities: 1}
+	taxes := BuildAll(entities, []config.TaxonomyConfig{tc}, nil)
+
+	if len(taxes) != 1 {
+		t.Fatalf("expected 1 taxonomy, got %d", len(taxes))
+	}
+	tax := taxes[0]
+	if tax.Name != "cuisine" {
+		t.Errorf("tax name: got %q, want cuisine", tax.Name)
+	}
+	// 2 unique cuisines: Italian (1 entity), Japanese (2 entities)
+	if len(tax.Entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(tax.Entries))
+	}
+}
+
+func TestBuildAll_MinEntitiesFilter(t *testing.T) {
+	entities := []*entity.Entity{
+		{Slug: "pasta", Fields: map[string]interface{}{"cuisine": "Italian"}},
+		{Slug: "ramen", Fields: map[string]interface{}{"cuisine": "Japanese"}},
+		{Slug: "sushi", Fields: map[string]interface{}{"cuisine": "Japanese"}},
+	}
+	tc := config.TaxonomyConfig{Name: "cuisine", Field: "cuisine", MinEntities: 2}
+	taxes := BuildAll(entities, []config.TaxonomyConfig{tc}, nil)
+
+	// Only Japanese (2 entities) passes the min_entities=2 filter.
+	if len(taxes[0].Entries) != 1 {
+		t.Errorf("expected 1 entry (only Japanese), got %d", len(taxes[0].Entries))
+	}
+	if taxes[0].Entries[0].Name != "Japanese" {
+		t.Errorf("expected Japanese, got %q", taxes[0].Entries[0].Name)
+	}
+}
+
+func TestBuildAll_MultiValue(t *testing.T) {
+	entities := []*entity.Entity{
+		{Slug: "pasta", Fields: map[string]interface{}{"tags": []string{"italian", "pasta"}}},
+		{Slug: "pizza", Fields: map[string]interface{}{"tags": []string{"italian", "baked"}}},
+	}
+	tc := config.TaxonomyConfig{Name: "tags", Field: "tags", MultiValue: true, MinEntities: 1}
+	taxes := BuildAll(entities, []config.TaxonomyConfig{tc}, nil)
+
+	// Should have 3 unique tags: italian (2), pasta (1), baked (1)
+	if len(taxes[0].Entries) != 3 {
+		t.Errorf("multi-value: expected 3 entries, got %d: %v", len(taxes[0].Entries), taxes[0].Entries)
+	}
+}
+
+func TestBuildAll_Empty(t *testing.T) {
+	taxes := BuildAll(nil, nil, nil)
+	if taxes != nil {
+		t.Errorf("nil input: want nil, got %v", taxes)
+	}
+}
+
+func TestExtractValues_SingleValue(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{"cuisine": "Italian"}}
+	tc := config.TaxonomyConfig{Field: "cuisine"}
+	got := extractValues(e, tc, nil)
+	if len(got) != 1 || got[0] != "Italian" {
+		t.Errorf("single value: got %v, want [Italian]", got)
+	}
+}
+
+func TestExtractValues_Missing(t *testing.T) {
+	e := &entity.Entity{Fields: map[string]interface{}{}}
+	tc := config.TaxonomyConfig{Field: "cuisine"}
+	if got := extractValues(e, tc, nil); got != nil {
+		t.Errorf("missing field: want nil, got %v", got)
+	}
+}
+
+func TestExtractValues_EnrichmentOverride(t *testing.T) {
+	e := &entity.Entity{
+		Slug:   "pasta",
+		Fields: map[string]interface{}{"cuisine": "Italian"},
+	}
+	tc := config.TaxonomyConfig{
+		Field:                   "cuisine",
+		EnrichmentOverrideField: "override_cuisine",
+	}
+	enrichment := map[string]map[string]interface{}{
+		"pasta": {"override_cuisine": "Mediterranean"},
+	}
+	got := extractValues(e, tc, enrichment)
+	if len(got) != 1 || got[0] != "Mediterranean" {
+		t.Errorf("enrichment override: got %v, want [Mediterranean]", got)
+	}
+}
+
+// ── getEnrichmentOverrides ────────────────────────────────────────────────────
+
+func TestGetEnrichmentOverrides_SimpleField(t *testing.T) {
+	data := map[string]interface{}{"cuisine": "Italian"}
+	got := getEnrichmentOverrides(data, "cuisine")
+	if len(got) != 1 || got[0] != "Italian" {
+		t.Errorf("simple field: got %v, want [Italian]", got)
+	}
+}
+
+func TestGetEnrichmentOverrides_SimpleField_Missing(t *testing.T) {
+	data := map[string]interface{}{}
+	if got := getEnrichmentOverrides(data, "cuisine"); got != nil {
+		t.Errorf("missing field: want nil, got %v", got)
+	}
+}
+
+func TestGetEnrichmentOverrides_ArrayPath(t *testing.T) {
+	data := map[string]interface{}{
+		"ingredients": []interface{}{
+			map[string]interface{}{"normalizedName": "tomato"},
+			map[string]interface{}{"normalizedName": "basil"},
+			map[string]interface{}{"normalizedName": ""}, // empty — should be skipped
+		},
+	}
+	got := getEnrichmentOverrides(data, "ingredients[].normalizedName")
+	if len(got) != 2 || got[0] != "tomato" || got[1] != "basil" {
+		t.Errorf("array path: got %v, want [tomato basil]", got)
+	}
+}
+
+func TestGetEnrichmentOverrides_ArrayField_Missing(t *testing.T) {
+	data := map[string]interface{}{}
+	if got := getEnrichmentOverrides(data, "ingredients[].name"); got != nil {
+		t.Errorf("missing array: want nil, got %v", got)
+	}
+}
+
+func TestGetEnrichmentOverrides_ArrayField_NotArray(t *testing.T) {
+	data := map[string]interface{}{"ingredients": "not-an-array"}
+	if got := getEnrichmentOverrides(data, "ingredients[].name"); got != nil {
+		t.Errorf("non-array: want nil, got %v", got)
+	}
+}
 
 // TestGroupByLetterASCII verifies that ASCII entry names are grouped correctly.
 func TestGroupByLetterASCII(t *testing.T) {

--- a/internal/archdocs/zip_test.go
+++ b/internal/archdocs/zip_test.go
@@ -1,4 +1,4 @@
-package deadcode
+package archdocs
 
 import (
 	"archive/zip"
@@ -9,35 +9,34 @@ import (
 	"testing"
 )
 
-func TestIsGitRepo_NonGitDir(t *testing.T) {
+func TestArchdocsIsGitRepo_NonGitDir(t *testing.T) {
 	if isGitRepo(t.TempDir()) {
 		t.Error("empty temp dir should not be a git repo")
 	}
 }
 
-func TestIsWorktreeClean_NonGitDir(t *testing.T) {
+func TestArchdocsIsWorktreeClean_NonGitDir(t *testing.T) {
 	if isWorktreeClean(t.TempDir()) {
 		t.Error("non-git dir should not be considered clean")
 	}
 }
 
-func TestWalkZip_IncludesFiles(t *testing.T) {
+func TestArchdocsWalkZip_IncludesFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0600); err != nil {
 		t.Fatal(err)
 	}
-
 	dest := filepath.Join(t.TempDir(), "out.zip")
 	if err := walkZip(src, dest); err != nil {
 		t.Fatalf("walkZip: %v", err)
 	}
-	entries := readDeadcodeZipEntries(t, dest)
-	if _, ok := entries["main.go"]; !ok {
+	entries := readArchdocsZipEntries(t, dest)
+	if !entries["main.go"] {
 		t.Error("zip should contain main.go")
 	}
 }
 
-func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
+func TestArchdocsWalkZip_SkipsHiddenFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=x"), 0600); err != nil {
 		t.Fatal(err)
@@ -45,21 +44,20 @@ func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0600); err != nil {
 		t.Fatal(err)
 	}
-
 	dest := filepath.Join(t.TempDir(), "out.zip")
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readDeadcodeZipEntries(t, dest)
-	if _, ok := entries[".env"]; ok {
+	entries := readArchdocsZipEntries(t, dest)
+	if entries[".env"] {
 		t.Error("zip should not contain .env")
 	}
-	if _, ok := entries["main.go"]; !ok {
+	if !entries["main.go"] {
 		t.Error("zip should contain main.go")
 	}
 }
 
-func TestWalkZip_SkipsSkipDirs(t *testing.T) {
+func TestArchdocsWalkZip_SkipsSkipDirs(t *testing.T) {
 	src := t.TempDir()
 	nmDir := filepath.Join(src, "node_modules")
 	if err := os.Mkdir(nmDir, 0750); err != nil {
@@ -71,12 +69,11 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(src, "index.js"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
-
 	dest := filepath.Join(t.TempDir(), "out.zip")
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readDeadcodeZipEntries(t, dest)
+	entries := readArchdocsZipEntries(t, dest)
 	for name := range entries {
 		if strings.HasPrefix(name, "node_modules/") || name == "node_modules" {
 			t.Errorf("should not contain node_modules entry: %s", name)
@@ -84,7 +81,7 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	}
 }
 
-func TestWalkZip_SkipsLargeFiles(t *testing.T) {
+func TestArchdocsWalkZip_SkipsLargeFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "huge.dat"), make([]byte, 10<<20+1), 0600); err != nil {
 		t.Fatal(err)
@@ -96,7 +93,7 @@ func TestWalkZip_SkipsLargeFiles(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readDeadcodeZipEntries(t, dest)
+	entries := readArchdocsZipEntries(t, dest)
 	if entries["huge.dat"] {
 		t.Error("file over 10 MB should be excluded from zip")
 	}
@@ -105,27 +102,22 @@ func TestWalkZip_SkipsLargeFiles(t *testing.T) {
 	}
 }
 
-func TestWalkZip_CreateDestError(t *testing.T) {
+func TestArchdocsWalkZip_CreateDestError(t *testing.T) {
 	src := t.TempDir()
-	// Destination in a non-existent subdirectory → os.Create will fail.
 	dest := filepath.Join(t.TempDir(), "nonexistent-subdir", "out.zip")
 	if err := walkZip(src, dest); err == nil {
 		t.Error("walkZip should fail when dest directory does not exist")
 	}
 }
 
-// TestWalkZip_WalkError covers L101-103: Walk calls the callback with a non-nil
-// error when the source directory does not exist.
-func TestWalkZip_WalkError(t *testing.T) {
+func TestArchdocsWalkZip_WalkError(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "out.zip")
-	if err := walkZip("/nonexistent-dir-xyzzy-deadcode", dest); err == nil {
+	if err := walkZip("/nonexistent-dir-xyzzy-archdocs", dest); err == nil {
 		t.Error("walkZip should fail when source directory does not exist")
 	}
 }
 
-// TestWalkZip_OpenFileError covers L122-124: os.Open fails when the file is
-// not readable.
-func TestWalkZip_OpenFileError(t *testing.T) {
+func TestArchdocsWalkZip_OpenFileError(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		t.Skip("skipping chmod-based test in CI")
 	}
@@ -144,7 +136,7 @@ func TestWalkZip_OpenFileError(t *testing.T) {
 	}
 }
 
-func TestCreateZip_NonGitDir(t *testing.T) {
+func TestArchdocsCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
 		t.Fatal(err)
@@ -159,9 +151,7 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	}
 }
 
-// TestCreateZip_CreateTempError covers L48-50: createZip returns an error when
-// os.CreateTemp fails due to an invalid TMPDIR.
-func TestCreateZip_CreateTempError(t *testing.T) {
+func TestArchdocsCreateZip_CreateTempError(t *testing.T) {
 	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
 	_, err := createZip(t.TempDir())
 	if err == nil {
@@ -169,18 +159,14 @@ func TestCreateZip_CreateTempError(t *testing.T) {
 	}
 }
 
-// TestCreateZip_NonExistentDir covers L60-63: createZip removes the temp file
-// and returns an error when walkZip fails because the source dir does not exist.
-func TestCreateZip_NonExistentDir(t *testing.T) {
-	_, err := createZip("/nonexistent-dir-deadcode-createzip-xyz")
+func TestArchdocsCreateZip_NonExistentDir(t *testing.T) {
+	_, err := createZip("/nonexistent-dir-archdocs-createzip-xyz")
 	if err == nil {
 		t.Error("createZip should fail when directory does not exist")
 	}
 }
 
-// initCleanGitRepo creates a temp directory, initialises a git repo, adds a
-// file, and commits it so that isGitRepo and isWorktreeClean both return true.
-func initCleanGitRepo(t *testing.T) string {
+func initCleanArchdocsGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	run := func(args ...string) {
@@ -202,39 +188,39 @@ func initCleanGitRepo(t *testing.T) string {
 	return dir
 }
 
-func TestGitArchive_CleanRepo(t *testing.T) {
-	dir := initCleanGitRepo(t)
+func TestArchdocsGitArchive_CleanRepo(t *testing.T) {
+	dir := initCleanArchdocsGitRepo(t)
 	dest := filepath.Join(t.TempDir(), "out.zip")
 	if err := gitArchive(dir, dest); err != nil {
 		t.Fatalf("gitArchive: %v", err)
 	}
-	entries := readDeadcodeZipEntries(t, dest)
+	entries := readArchdocsZipEntries(t, dest)
 	if !entries["main.go"] {
 		t.Error("git archive should contain main.go")
 	}
 }
 
-func TestIsWorktreeClean_CleanRepo(t *testing.T) {
-	dir := initCleanGitRepo(t)
+func TestArchdocsIsWorktreeClean_CleanRepo(t *testing.T) {
+	dir := initCleanArchdocsGitRepo(t)
 	if !isWorktreeClean(dir) {
 		t.Error("freshly committed repo should be considered clean")
 	}
 }
 
-func TestCreateZip_CleanGitRepo(t *testing.T) {
-	dir := initCleanGitRepo(t)
+func TestArchdocsCreateZip_CleanGitRepo(t *testing.T) {
+	dir := initCleanArchdocsGitRepo(t)
 	path, err := createZip(dir)
 	if err != nil {
 		t.Fatalf("createZip on clean git repo: %v", err)
 	}
 	defer os.Remove(path)
-	entries := readDeadcodeZipEntries(t, path)
+	entries := readArchdocsZipEntries(t, path)
 	if !entries["main.go"] {
 		t.Error("zip should contain main.go from git archive")
 	}
 }
 
-func readDeadcodeZipEntries(t *testing.T, path string) map[string]bool {
+func readArchdocsZipEntries(t *testing.T, path string) map[string]bool {
 	t.Helper()
 	r, err := zip.OpenReader(path)
 	if err != nil {

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,0 +1,948 @@
+package audit
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/supermodeltools/cli/internal/api"
+)
+
+// ── CouplingStatus ────────────────────────────────────────────────────────────
+
+func TestCouplingStatus_OK(t *testing.T) {
+	d := &DomainHealth{IncomingDeps: []string{"A", "B"}}
+	if got := d.CouplingStatus(); got != "✅ OK" {
+		t.Errorf("2 deps: want '✅ OK', got %q", got)
+	}
+}
+
+func TestCouplingStatus_Warn(t *testing.T) {
+	d := &DomainHealth{IncomingDeps: []string{"A", "B", "C"}}
+	if !strings.Contains(d.CouplingStatus(), "WARN") {
+		t.Errorf("3 deps: expected WARN, got %q", d.CouplingStatus())
+	}
+}
+
+func TestCouplingStatus_High(t *testing.T) {
+	d := &DomainHealth{IncomingDeps: []string{"A", "B", "C", "D", "E"}}
+	if !strings.Contains(d.CouplingStatus(), "HIGH") {
+		t.Errorf("5 deps: expected HIGH, got %q", d.CouplingStatus())
+	}
+}
+
+func TestCouplingStatus_Zero(t *testing.T) {
+	d := &DomainHealth{}
+	if got := d.CouplingStatus(); got != "✅ OK" {
+		t.Errorf("0 deps: want '✅ OK', got %q", got)
+	}
+}
+
+// ── pluralf ───────────────────────────────────────────────────────────────────
+
+func TestPluralf_Singular(t *testing.T) {
+	got := pluralf("Resolve %d cycle%s.", 1)
+	if !strings.Contains(got, "1 cycle.") {
+		t.Errorf("singular: want '1 cycle.', got %q", got)
+	}
+}
+
+func TestPluralf_Plural(t *testing.T) {
+	got := pluralf("Resolve %d cycle%s.", 3)
+	if !strings.Contains(got, "3 cycles.") {
+		t.Errorf("plural: want '3 cycles.', got %q", got)
+	}
+}
+
+// ── scoreStatus ───────────────────────────────────────────────────────────────
+
+func TestScoreStatus_Healthy(t *testing.T) {
+	r := &HealthReport{Status: StatusHealthy}
+	if got := scoreStatus(r); got != StatusHealthy {
+		t.Errorf("empty report: want HEALTHY, got %q", got)
+	}
+}
+
+func TestScoreStatus_CriticalWhenCircularDeps(t *testing.T) {
+	r := &HealthReport{CircularDeps: 2}
+	if got := scoreStatus(r); got != StatusCritical {
+		t.Errorf("circular deps: want CRITICAL, got %q", got)
+	}
+}
+
+func TestScoreStatus_DegradedOnCriticalImpact(t *testing.T) {
+	r := &HealthReport{
+		ImpactFiles: []ImpactFile{{Path: "src/db.go", RiskScore: "critical"}},
+	}
+	if got := scoreStatus(r); got != StatusDegraded {
+		t.Errorf("critical impact file: want DEGRADED, got %q", got)
+	}
+}
+
+func TestScoreStatus_DegradedOnHighCoupling(t *testing.T) {
+	r := &HealthReport{
+		Domains: []DomainHealth{
+			{Name: "Core", IncomingDeps: []string{"A", "B", "C", "D", "E"}},
+		},
+	}
+	if got := scoreStatus(r); got != StatusDegraded {
+		t.Errorf("5 incoming deps: want DEGRADED, got %q", got)
+	}
+}
+
+// ── detectCircularDeps ────────────────────────────────────────────────────────
+
+func TestDetectCircularDeps_None(t *testing.T) {
+	ir := &api.SupermodelIR{}
+	count, cycles := detectCircularDeps(ir)
+	if count != 0 || len(cycles) != 0 {
+		t.Errorf("no circular deps: want 0, got count=%d cycles=%v", count, cycles)
+	}
+}
+
+func TestDetectCircularDeps_Found(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "CIRCULAR_DEPENDENCY", Source: "A", Target: "B"},
+				{Type: "CIRCULAR_DEP", Source: "C", Target: "D"},
+				{Type: "other", Source: "X", Target: "Y"}, // ignored
+			},
+		},
+	}
+	count, cycles := detectCircularDeps(ir)
+	if count != 2 {
+		t.Errorf("want 2 circular deps, got %d", count)
+	}
+	if len(cycles) != 2 {
+		t.Errorf("want 2 cycles, got %d", len(cycles))
+	}
+}
+
+func TestDetectCircularDeps_Deduplication(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "CIRCULAR_DEPENDENCY", Source: "A", Target: "B"},
+				{Type: "CIRCULAR_DEPENDENCY", Source: "A", Target: "B"}, // duplicate
+			},
+		},
+	}
+	count, _ := detectCircularDeps(ir)
+	if count != 1 {
+		t.Errorf("deduplication: want 1 cycle, got %d", count)
+	}
+}
+
+// ── buildExternalDeps ─────────────────────────────────────────────────────────
+
+func TestBuildExternalDeps_Empty(t *testing.T) {
+	ir := &api.SupermodelIR{}
+	deps := buildExternalDeps(ir)
+	if len(deps) != 0 {
+		t.Errorf("empty IR: want no deps, got %v", deps)
+	}
+}
+
+func TestBuildExternalDeps_Sorted(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Nodes: []api.IRNode{
+				{Type: "ExternalDependency", Name: "zlib"},
+				{Type: "ExternalDependency", Name: "axios"},
+				{Type: "Function", Name: "foo"}, // ignored
+				{Type: "ExternalDependency", Name: ""},  // empty name, ignored
+			},
+		},
+	}
+	deps := buildExternalDeps(ir)
+	if len(deps) != 2 {
+		t.Errorf("want 2 deps, got %v", deps)
+	}
+	if deps[0] != "axios" || deps[1] != "zlib" {
+		t.Errorf("want sorted [axios, zlib], got %v", deps)
+	}
+}
+
+func TestBuildExternalDeps_Deduplicated(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Nodes: []api.IRNode{
+				{Type: "ExternalDependency", Name: "axios"},
+				{Type: "ExternalDependency", Name: "axios"},
+			},
+		},
+	}
+	deps := buildExternalDeps(ir)
+	if len(deps) != 1 {
+		t.Errorf("want 1 unique dep, got %v", deps)
+	}
+}
+
+// ── buildCriticalFiles ────────────────────────────────────────────────────────
+
+func TestBuildCriticalFiles_None(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{Name: "Auth", KeyFiles: []string{"a.go"}},
+		},
+	}
+	files := buildCriticalFiles(ir)
+	if len(files) != 0 {
+		t.Errorf("no file shared across >1 domain: want 0, got %v", files)
+	}
+}
+
+func TestBuildCriticalFiles_SharedFile(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{Name: "Auth", KeyFiles: []string{"shared.go", "auth.go"}},
+			{Name: "API", KeyFiles: []string{"shared.go", "api.go"}},
+		},
+	}
+	files := buildCriticalFiles(ir)
+	if len(files) != 1 {
+		t.Fatalf("want 1 critical file, got %v", files)
+	}
+	if files[0].Path != "shared.go" {
+		t.Errorf("want shared.go, got %q", files[0].Path)
+	}
+	if files[0].RelationshipCount != 2 {
+		t.Errorf("want relationship count 2, got %d", files[0].RelationshipCount)
+	}
+}
+
+func TestBuildCriticalFiles_DedupWithinDomain(t *testing.T) {
+	// Same file listed twice in one domain should only count once per domain.
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{Name: "Auth", KeyFiles: []string{"shared.go", "shared.go"}},
+			{Name: "API", KeyFiles: []string{"shared.go"}},
+		},
+	}
+	files := buildCriticalFiles(ir)
+	if len(files) != 1 || files[0].RelationshipCount != 2 {
+		t.Errorf("want 1 file with count 2, got %v", files)
+	}
+}
+
+func TestBuildCriticalFiles_MoreThanTen(t *testing.T) {
+	// Build an IR with 12 files each shared across 2 domains → must cap at 10.
+	domains := make([]api.IRDomain, 0, 2)
+	var keys1, keys2 []string
+	for i := 0; i < 12; i++ {
+		f := "file%02d.go"
+		k := "file" + string(rune('0'+i/10)) + string(rune('0'+i%10)) + ".go"
+		_ = f
+		keys1 = append(keys1, k)
+		keys2 = append(keys2, k)
+	}
+	domains = append(domains,
+		api.IRDomain{Name: "D1", KeyFiles: keys1},
+		api.IRDomain{Name: "D2", KeyFiles: keys2},
+	)
+	ir := &api.SupermodelIR{Domains: domains}
+	files := buildCriticalFiles(ir)
+	if len(files) > 10 {
+		t.Errorf("should cap at 10, got %d", len(files))
+	}
+}
+
+func TestBuildCriticalFiles_EqualCountsSortedByPath(t *testing.T) {
+	// Two files both shared across 2 domains → sorted by path when counts equal.
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{Name: "D1", KeyFiles: []string{"b.go", "a.go"}},
+			{Name: "D2", KeyFiles: []string{"b.go", "a.go"}},
+		},
+	}
+	files := buildCriticalFiles(ir)
+	if len(files) != 2 {
+		t.Fatalf("want 2 critical files, got %d", len(files))
+	}
+	// Equal counts → sorted lexicographically.
+	if files[0].Path != "a.go" {
+		t.Errorf("equal counts: expected a.go first, got %q", files[0].Path)
+	}
+}
+
+// ── buildDomainHealthList ─────────────────────────────────────────────────────
+
+func TestBuildDomainHealthList_Empty(t *testing.T) {
+	ir := &api.SupermodelIR{}
+	domains := buildDomainHealthList(ir, map[string][]string{}, map[string][]string{})
+	if len(domains) != 0 {
+		t.Errorf("empty IR: want 0 domains, got %d", len(domains))
+	}
+}
+
+func TestBuildDomainHealthList_WithDomains(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{
+				Name:               "Auth",
+				DescriptionSummary: "Authentication",
+				KeyFiles:           []string{"auth.go", "login.go"},
+				Responsibilities:   []string{"verify tokens"},
+				Subdomains:         []api.IRSubdomain{{Name: "OAuth"}},
+			},
+		},
+	}
+	incoming := map[string][]string{"Auth": {"API", "Web"}}
+	outgoing := map[string][]string{"Auth": {"DB"}}
+	domains := buildDomainHealthList(ir, incoming, outgoing)
+	if len(domains) != 1 {
+		t.Fatalf("want 1 domain, got %d", len(domains))
+	}
+	d := domains[0]
+	if d.Name != "Auth" {
+		t.Errorf("want 'Auth', got %q", d.Name)
+	}
+	if d.Description != "Authentication" {
+		t.Errorf("want 'Authentication', got %q", d.Description)
+	}
+	if d.KeyFileCount != 2 {
+		t.Errorf("want 2 key files, got %d", d.KeyFileCount)
+	}
+	if d.Responsibilities != 1 {
+		t.Errorf("want 1 responsibility, got %d", d.Responsibilities)
+	}
+	if d.Subdomains != 1 {
+		t.Errorf("want 1 subdomain, got %d", d.Subdomains)
+	}
+	if len(d.IncomingDeps) != 2 {
+		t.Errorf("want 2 incoming deps, got %v", d.IncomingDeps)
+	}
+	if len(d.OutgoingDeps) != 1 {
+		t.Errorf("want 1 outgoing dep, got %v", d.OutgoingDeps)
+	}
+	// Incoming deps should be sorted.
+	if d.IncomingDeps[0] != "API" {
+		t.Errorf("sorted incoming: want 'API' first, got %q", d.IncomingDeps[0])
+	}
+}
+
+func TestBuildDomainHealthList_NoCouplingData(t *testing.T) {
+	// Domain with no entries in the coupling maps → empty dep slices.
+	ir := &api.SupermodelIR{
+		Domains: []api.IRDomain{
+			{Name: "Isolated", KeyFiles: []string{"iso.go"}},
+		},
+	}
+	domains := buildDomainHealthList(ir, map[string][]string{}, map[string][]string{})
+	if len(domains) != 1 {
+		t.Fatalf("want 1 domain, got %d", len(domains))
+	}
+	if len(domains[0].IncomingDeps) != 0 {
+		t.Errorf("want 0 incoming deps, got %v", domains[0].IncomingDeps)
+	}
+}
+
+// ── buildCouplingMaps ─────────────────────────────────────────────────────────
+
+func TestBuildCouplingMaps_Empty(t *testing.T) {
+	ir := &api.SupermodelIR{}
+	inc, out := buildCouplingMaps(ir)
+	if len(inc) != 0 || len(out) != 0 {
+		t.Error("empty IR: want empty coupling maps")
+	}
+}
+
+func TestBuildCouplingMaps_DomainRelates(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "DOMAIN_RELATES", Source: "Auth", Target: "DB"},
+				{Type: "other_type", Source: "X", Target: "Y"}, // ignored
+			},
+		},
+	}
+	inc, out := buildCouplingMaps(ir)
+	if len(out["Auth"]) != 1 || out["Auth"][0] != "DB" {
+		t.Errorf("outgoing: want Auth→[DB], got %v", out)
+	}
+	if len(inc["DB"]) != 1 || inc["DB"][0] != "Auth" {
+		t.Errorf("incoming: want DB←[Auth], got %v", inc)
+	}
+}
+
+func TestBuildCouplingMaps_Deduplication(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "DOMAIN_RELATES", Source: "Auth", Target: "DB"},
+				{Type: "DOMAIN_RELATES", Source: "Auth", Target: "DB"}, // duplicate
+			},
+		},
+	}
+	_, out := buildCouplingMaps(ir)
+	if len(out["Auth"]) != 1 {
+		t.Errorf("deduplication: want 1 outgoing, got %v", out["Auth"])
+	}
+}
+
+func TestBuildCouplingMaps_EmptySourceTarget(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "DOMAIN_RELATES", Source: "", Target: "DB"}, // empty source, ignored
+				{Type: "DOMAIN_RELATES", Source: "Auth", Target: ""}, // empty target, ignored
+			},
+		},
+	}
+	inc, out := buildCouplingMaps(ir)
+	if len(inc) != 0 || len(out) != 0 {
+		t.Error("empty source/target: want empty coupling maps")
+	}
+}
+
+// ── generateRecommendations ───────────────────────────────────────────────────
+
+func TestGenerateRecommendations_Empty(t *testing.T) {
+	r := &HealthReport{}
+	recs := generateRecommendations(r)
+	if len(recs) != 0 {
+		t.Errorf("empty report: want no recs, got %v", recs)
+	}
+}
+
+func TestGenerateRecommendations_CircularDeps(t *testing.T) {
+	r := &HealthReport{CircularDeps: 2}
+	recs := generateRecommendations(r)
+	if len(recs) == 0 {
+		t.Fatal("circular deps: want recommendation, got none")
+	}
+	if recs[0].Priority != 1 {
+		t.Errorf("circular dep rec should be priority 1, got %d", recs[0].Priority)
+	}
+	if !strings.Contains(recs[0].Message, "circular") {
+		t.Errorf("expected circular dep message, got %q", recs[0].Message)
+	}
+}
+
+func TestGenerateRecommendations_HighCoupling(t *testing.T) {
+	r := &HealthReport{
+		Domains: []DomainHealth{
+			{Name: "Core", IncomingDeps: []string{"A", "B", "C"}},
+		},
+	}
+	recs := generateRecommendations(r)
+	if len(recs) == 0 {
+		t.Fatal("high coupling: want recommendation, got none")
+	}
+	found := false
+	for _, rec := range recs {
+		if strings.Contains(rec.Message, "Core") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected recommendation mentioning 'Core', got %v", recs)
+	}
+}
+
+func TestGenerateRecommendations_NoKeyFiles(t *testing.T) {
+	r := &HealthReport{
+		Domains: []DomainHealth{
+			{Name: "Orphan", KeyFileCount: 0},
+		},
+	}
+	recs := generateRecommendations(r)
+	found := false
+	for _, rec := range recs {
+		if strings.Contains(rec.Message, "Orphan") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected recommendation for domain with no key files, got %v", recs)
+	}
+}
+
+func TestGenerateRecommendations_HighBlastRadius(t *testing.T) {
+	r := &HealthReport{
+		CriticalFiles: []CriticalFile{
+			{Path: "core/db.go", RelationshipCount: 4},
+		},
+	}
+	recs := generateRecommendations(r)
+	found := false
+	for _, rec := range recs {
+		if strings.Contains(rec.Message, "core/db.go") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected recommendation for high blast radius file, got %v", recs)
+	}
+}
+
+func TestGenerateRecommendations_CriticalImpactFile(t *testing.T) {
+	r := &HealthReport{
+		ImpactFiles: []ImpactFile{
+			{Path: "api/auth.go", RiskScore: "critical", Direct: 10, Transitive: 30, Files: 5},
+		},
+	}
+	recs := generateRecommendations(r)
+	found := false
+	for _, rec := range recs {
+		if strings.Contains(rec.Message, "api/auth.go") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected recommendation for critical impact file, got %v", recs)
+	}
+}
+
+// ── summaryInt ────────────────────────────────────────────────────────────────
+
+func TestSummaryInt_Present(t *testing.T) {
+	summary := map[string]any{"filesProcessed": float64(42)}
+	if got := summaryInt(summary, "filesProcessed"); got != 42 {
+		t.Errorf("want 42, got %d", got)
+	}
+}
+
+func TestSummaryInt_Missing(t *testing.T) {
+	if got := summaryInt(map[string]any{}, "missing"); got != 0 {
+		t.Errorf("missing key: want 0, got %d", got)
+	}
+}
+
+func TestSummaryInt_WrongType(t *testing.T) {
+	summary := map[string]any{"count": "not a number"}
+	if got := summaryInt(summary, "count"); got != 0 {
+		t.Errorf("wrong type: want 0, got %d", got)
+	}
+}
+
+// ── Analyze ───────────────────────────────────────────────────────────────────
+
+func TestAnalyze_EmptyIR(t *testing.T) {
+	ir := &api.SupermodelIR{}
+	r := Analyze(ir, "testproject")
+	if r.ProjectName != "testproject" {
+		t.Errorf("want 'testproject', got %q", r.ProjectName)
+	}
+	if r.Status != StatusHealthy {
+		t.Errorf("empty IR: want HEALTHY, got %q", r.Status)
+	}
+}
+
+func TestAnalyze_SetsLanguage(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Summary:  map[string]any{"primaryLanguage": "Go"},
+		Metadata: api.IRMetadata{Languages: []string{"Go", "TypeScript"}},
+	}
+	r := Analyze(ir, "myproject")
+	if r.Language != "Go" {
+		t.Errorf("want 'Go', got %q", r.Language)
+	}
+}
+
+func TestAnalyze_LanguageFallsBackToMetadata(t *testing.T) {
+	// No primaryLanguage in summary; falls back to first metadata language.
+	ir := &api.SupermodelIR{
+		Metadata: api.IRMetadata{Languages: []string{"TypeScript"}},
+	}
+	r := Analyze(ir, "proj")
+	if r.Language != "TypeScript" {
+		t.Errorf("fallback: want 'TypeScript', got %q", r.Language)
+	}
+}
+
+func TestAnalyze_CircularDepsCritical(t *testing.T) {
+	ir := &api.SupermodelIR{
+		Graph: api.IRGraph{
+			Relationships: []api.IRRelationship{
+				{Type: "CIRCULAR_DEPENDENCY", Source: "A", Target: "B"},
+			},
+		},
+	}
+	r := Analyze(ir, "proj")
+	if r.Status != StatusCritical {
+		t.Errorf("circular dep: want CRITICAL, got %q", r.Status)
+	}
+	if r.CircularDeps != 1 {
+		t.Errorf("want 1 circular dep, got %d", r.CircularDeps)
+	}
+}
+
+// ── EnrichWithImpact ──────────────────────────────────────────────────────────
+
+func TestEnrichWithImpact_Nil(t *testing.T) {
+	r := &HealthReport{Status: StatusHealthy}
+	EnrichWithImpact(r, nil) // should not panic
+	if r.Status != StatusHealthy {
+		t.Error("nil impact: status should not change")
+	}
+}
+
+func TestEnrichWithImpact_AddsImpactFiles(t *testing.T) {
+	r := &HealthReport{Status: StatusHealthy}
+	impact := &api.ImpactResult{
+		Impacts: []api.ImpactTarget{
+			{
+				Target:      api.ImpactTargetInfo{File: "src/auth.go"},
+				BlastRadius: api.BlastRadius{RiskScore: "high", DirectDependents: 5, TransitiveDependents: 20, AffectedFiles: 3},
+			},
+		},
+	}
+	EnrichWithImpact(r, impact)
+	if len(r.ImpactFiles) == 0 {
+		t.Fatal("expected impact files after enrichment")
+	}
+	if r.ImpactFiles[0].Path != "src/auth.go" {
+		t.Errorf("want 'src/auth.go', got %q", r.ImpactFiles[0].Path)
+	}
+}
+
+func TestEnrichWithImpact_GlobalMetrics(t *testing.T) {
+	r := &HealthReport{}
+	impact := &api.ImpactResult{
+		GlobalMetrics: api.ImpactGlobalMetrics{
+			MostCriticalFiles: []api.CriticalFileMetric{
+				{File: "core/main.go", DependentCount: 10},
+			},
+		},
+	}
+	EnrichWithImpact(r, impact)
+	if len(r.ImpactFiles) == 0 {
+		t.Fatal("expected impact files from global metrics")
+	}
+}
+
+func TestEnrichWithImpact_CapsAtTen(t *testing.T) {
+	r := &HealthReport{}
+	var impacts []api.ImpactTarget
+	for i := 0; i < 15; i++ {
+		impacts = append(impacts, api.ImpactTarget{
+			Target:      api.ImpactTargetInfo{File: "file.go"},
+			BlastRadius: api.BlastRadius{DirectDependents: i},
+		})
+	}
+	EnrichWithImpact(r, &api.ImpactResult{Impacts: impacts})
+	if len(r.ImpactFiles) > 10 {
+		t.Errorf("should cap at 10, got %d", len(r.ImpactFiles))
+	}
+}
+
+// ── RenderHealth ──────────────────────────────────────────────────────────────
+
+func makeHealthReport() *HealthReport {
+	return &HealthReport{
+		ProjectName:    "myproject",
+		AnalyzedAt:     time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC),
+		Status:         StatusHealthy,
+		TotalFiles:     100,
+		TotalFunctions: 500,
+	}
+}
+
+func TestRenderHealth_BasicFields(t *testing.T) {
+	r := makeHealthReport()
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	for _, want := range []string{"myproject", "HEALTHY", "100", "500"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in health report output", want)
+		}
+	}
+}
+
+func TestRenderHealth_CircularDeps(t *testing.T) {
+	r := makeHealthReport()
+	r.Status = StatusCritical
+	r.CircularDeps = 2
+	r.CircularCycles = [][]string{{"A", "B"}, {"C", "D"}}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	if !strings.Contains(output, "Circular Dependencies") {
+		t.Error("expected Circular Dependencies section")
+	}
+	if !strings.Contains(output, "A → B") {
+		t.Errorf("expected 'A → B' in output, got:\n%s", output)
+	}
+}
+
+func TestRenderHealth_CriticalFiles(t *testing.T) {
+	r := makeHealthReport()
+	r.CriticalFiles = []CriticalFile{
+		{Path: "core/db.go", RelationshipCount: 3},
+	}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	if !strings.Contains(output, "Critical Files") {
+		t.Error("expected Critical Files section")
+	}
+	if !strings.Contains(output, "core/db.go") {
+		t.Error("expected critical file path in output")
+	}
+}
+
+func TestRenderHealth_ImpactFiles(t *testing.T) {
+	r := makeHealthReport()
+	r.ImpactFiles = []ImpactFile{
+		{Path: "api/auth.go", RiskScore: "high", Direct: 5, Transitive: 15, Files: 3},
+		{Path: "core/util.go"}, // empty RiskScore → should render as "-"
+	}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	if !strings.Contains(output, "Impact Analysis") {
+		t.Error("expected Impact Analysis section")
+	}
+	if !strings.Contains(output, "api/auth.go") {
+		t.Error("expected impact file path in output")
+	}
+	if !strings.Contains(output, "-") {
+		t.Error("expected '-' for empty risk score")
+	}
+}
+
+func TestRenderHealth_NoImpactSection(t *testing.T) {
+	r := makeHealthReport()
+	// No ImpactFiles → section should be absent.
+	var w strings.Builder
+	RenderHealth(&w, r)
+	if strings.Contains(w.String(), "Impact Analysis") {
+		t.Error("no impact files: should not render Impact Analysis section")
+	}
+}
+
+func TestRenderHealth_Domains(t *testing.T) {
+	r := makeHealthReport()
+	r.Domains = []DomainHealth{
+		{
+			Name:         "Auth",
+			Description:  "Handles authentication",
+			KeyFileCount: 5,
+			IncomingDeps: []string{"API", "Web"},
+			OutgoingDeps: []string{"DB"},
+		},
+	}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	if !strings.Contains(output, "Domain Health") {
+		t.Error("expected Domain Health section")
+	}
+	if !strings.Contains(output, "Auth") {
+		t.Error("expected domain name in output")
+	}
+	if !strings.Contains(output, "Depended on by") {
+		t.Error("expected 'Depended on by' for incoming deps")
+	}
+	if !strings.Contains(output, "Depends on") {
+		t.Error("expected 'Depends on' for outgoing deps")
+	}
+}
+
+func TestRenderHealth_DomainNoDescription(t *testing.T) {
+	// Domain with no description should not produce an empty line.
+	r := makeHealthReport()
+	r.Domains = []DomainHealth{{Name: "Simple"}}
+	var w strings.Builder
+	RenderHealth(&w, r) // should not panic
+}
+
+func TestRenderHealth_ExternalDeps(t *testing.T) {
+	r := makeHealthReport()
+	r.ExternalDeps = []string{"axios", "zlib"}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	if !strings.Contains(w.String(), "Tech Stack") {
+		t.Error("expected Tech Stack section with external deps")
+	}
+}
+
+func TestRenderHealth_Languages(t *testing.T) {
+	r := makeHealthReport()
+	r.Languages = []string{"Go", "TypeScript"}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	if !strings.Contains(w.String(), "Go") {
+		t.Error("expected languages in metrics table")
+	}
+}
+
+func TestRenderHealth_RecommendationsPresent(t *testing.T) {
+	r := makeHealthReport()
+	r.Recommendations = []Recommendation{
+		{Priority: 1, Message: "Fix circular deps now."},
+		{Priority: 2, Message: "Reduce coupling."},
+		{Priority: 4, Message: "Low priority suggestion."}, // unknown priority → falls through to Info
+	}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	output := w.String()
+
+	if !strings.Contains(output, "Fix circular deps now.") {
+		t.Error("expected critical recommendation message")
+	}
+}
+
+func TestRenderHealth_NoRecommendations(t *testing.T) {
+	r := makeHealthReport()
+	r.Recommendations = nil
+	var w strings.Builder
+	RenderHealth(&w, r)
+	if !strings.Contains(w.String(), "No issues found") {
+		t.Error("no recommendations: expected 'No issues found' message")
+	}
+}
+
+func TestRenderHealth_HighCouplingDomain(t *testing.T) {
+	// Domain with ≥3 incoming deps triggers high-coupling counter in metrics table.
+	r := makeHealthReport()
+	r.Domains = []DomainHealth{
+		{Name: "HeavyCore", IncomingDeps: []string{"A", "B", "C"}},
+	}
+	var w strings.Builder
+	RenderHealth(&w, r)
+	if !strings.Contains(w.String(), "WARN") {
+		t.Error("high coupling domain: expected WARN in coupling status")
+	}
+}
+
+// ── RenderRunPrompt ───────────────────────────────────────────────────────────
+
+func makeSDLCData() *SDLCPromptData {
+	return &SDLCPromptData{
+		ProjectName:    "myproject",
+		Language:       "Go",
+		TotalFiles:     100,
+		TotalFunctions: 500,
+		GeneratedAt:    "2025-01-15",
+	}
+}
+
+func TestRenderRunPrompt_BasicFields(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Add rate limiting to the API"
+	var w strings.Builder
+	RenderRunPrompt(&w, d)
+	output := w.String()
+
+	for _, want := range []string{"myproject", "Go", "Add rate limiting", "Phase 1", "Phase 8"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in run prompt output", want)
+		}
+	}
+}
+
+func TestRenderRunPrompt_WithCircularDeps(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Refactor auth"
+	d.CircularDeps = 3
+	var w strings.Builder
+	RenderRunPrompt(&w, d)
+	output := w.String()
+
+	if !strings.Contains(output, "circular") || !strings.Contains(output, "3") {
+		t.Errorf("expected circular dep warning with count, got:\n%s", output)
+	}
+}
+
+func TestRenderRunPrompt_WithDomains(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Add feature"
+	d.Domains = []DomainHealth{
+		{Name: "Auth", Description: "Authentication layer", KeyFileCount: 3},
+	}
+	var w strings.Builder
+	RenderRunPrompt(&w, d)
+	if !strings.Contains(w.String(), "Auth") {
+		t.Error("expected domain name in run prompt")
+	}
+}
+
+func TestRenderRunPrompt_WithDomainNoDescription(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Add feature"
+	d.Domains = []DomainHealth{
+		{Name: "Auth", KeyFileCount: 3}, // no description
+	}
+	var w strings.Builder
+	RenderRunPrompt(&w, d) // should not panic; KeyFileCount printed
+}
+
+func TestRenderRunPrompt_WithExternalDeps(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Fix bug"
+	d.ExternalDeps = []string{"axios", "pg"}
+	var w strings.Builder
+	RenderRunPrompt(&w, d)
+	if !strings.Contains(w.String(), "axios") {
+		t.Error("expected external deps in output")
+	}
+}
+
+func TestRenderRunPrompt_WithCriticalFiles(t *testing.T) {
+	d := makeSDLCData()
+	d.Goal = "Fix bug"
+	d.CriticalFiles = []CriticalFile{
+		{Path: "core/db.go", RelationshipCount: 4},
+	}
+	var w strings.Builder
+	RenderRunPrompt(&w, d)
+	if !strings.Contains(w.String(), "core/db.go") {
+		t.Error("expected critical file in output")
+	}
+}
+
+// ── RenderImprovePrompt ───────────────────────────────────────────────────────
+
+func TestRenderImprovePrompt_NoHealthReport(t *testing.T) {
+	d := makeSDLCData()
+	var w strings.Builder
+	RenderImprovePrompt(&w, d)
+	output := w.String()
+
+	for _, want := range []string{"myproject", "Improvement", "Step 1", "Step 4"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected %q in improve prompt output", want)
+		}
+	}
+	// Should not have a Health section when HealthReport is nil.
+	if strings.Contains(output, "Current Health") {
+		t.Error("no health report: should not render Current Health section")
+	}
+}
+
+func TestRenderImprovePrompt_WithHealthReport(t *testing.T) {
+	d := makeSDLCData()
+	d.HealthReport = &HealthReport{
+		Status:          StatusDegraded,
+		Recommendations: []Recommendation{{Priority: 2, Message: "Reduce coupling."}},
+	}
+	var w strings.Builder
+	RenderImprovePrompt(&w, d)
+	output := w.String()
+
+	if !strings.Contains(output, "Current Health") {
+		t.Error("expected Current Health section")
+	}
+	if !strings.Contains(output, "Reduce coupling.") {
+		t.Error("expected recommendation in output")
+	}
+}
+
+func TestRenderImprovePrompt_WithHealthReportNoRecs(t *testing.T) {
+	d := makeSDLCData()
+	d.HealthReport = &HealthReport{Status: StatusHealthy}
+	var w strings.Builder
+	RenderImprovePrompt(&w, d) // should not panic; no recommendations section
+	if !strings.Contains(w.String(), "Current Health") {
+		t.Error("expected Current Health section even with no recommendations")
+	}
+}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -186,3 +186,14 @@ func TestLogout(t *testing.T) {
 		t.Errorf("expected empty key after logout, got %q", cfg.APIKey)
 	}
 }
+
+func TestLogout_AlreadyLoggedOut(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+
+	// No API key set.
+	if err := Logout(context.Background()); err != nil {
+		t.Fatalf("Logout when already logged out: %v", err)
+	}
+}

--- a/internal/auth/handler_test.go
+++ b/internal/auth/handler_test.go
@@ -197,3 +197,82 @@ func TestLogout_AlreadyLoggedOut(t *testing.T) {
 		t.Fatalf("Logout when already logged out: %v", err)
 	}
 }
+
+func TestLoginWithToken_ConfigLoadError(t *testing.T) {
+	// Make config.yaml a directory → os.ReadFile returns a non-NotExist error.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	cfgDir := filepath.Join(tmp, ".supermodel")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Create a directory where config.yaml would be → ReadFile fails.
+	if err := os.Mkdir(filepath.Join(cfgDir, "config.yaml"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := LoginWithToken("smsk_live_test"); err == nil {
+		t.Error("expected error when config.Load fails")
+	}
+}
+
+func TestLoginWithToken_SaveError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	cfgDir := filepath.Join(tmp, ".supermodel")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cfgDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cfgDir, 0o755) }) //nolint:errcheck
+	if err := LoginWithToken("smsk_live_test"); err == nil {
+		t.Error("expected error when cfg.Save fails")
+	}
+}
+
+func TestLogout_ConfigLoadError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	cfgDir := filepath.Join(tmp, ".supermodel")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(cfgDir, "config.yaml"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := Logout(context.Background()); err == nil {
+		t.Error("expected error when config.Load fails")
+	}
+}
+
+func TestLogout_SaveError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	// Pre-create a config with a key so Logout proceeds to Save.
+	cfgDir := filepath.Join(tmp, ".supermodel")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{APIKey: "smsk_live_toremove"}
+	if err := cfg.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cfgDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cfgDir, 0o755) }) //nolint:errcheck
+	if err := Logout(context.Background()); err == nil {
+		t.Error("expected error when cfg.Save fails during logout")
+	}
+}

--- a/internal/blastradius/zip_test.go
+++ b/internal/blastradius/zip_test.go
@@ -3,6 +3,7 @@ package blastradius
 import (
 	"archive/zip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -93,6 +94,30 @@ func TestWalkZip_SkipsNodeModules(t *testing.T) {
 	}
 }
 
+func TestWalkZip_SkipsLargeFiles(t *testing.T) {
+	src := t.TempDir()
+	// Create a file just over 10 MB
+	bigFile := filepath.Join(src, "huge.dat")
+	if err := os.WriteFile(bigFile, make([]byte, 10<<20+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "small.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readBlastZipEntries(t, dest)
+	if entries["huge.dat"] {
+		t.Error("file over 10 MB should be excluded from zip")
+	}
+	if !entries["small.go"] {
+		t.Error("small file should be included in zip")
+	}
+}
+
 func TestWalkZip_SkipsOtherSkipDirs(t *testing.T) {
 	for _, dir := range []string{"dist", "build", "vendor", ".git"} {
 		src := t.TempDir()
@@ -122,6 +147,44 @@ func TestWalkZip_SkipsOtherSkipDirs(t *testing.T) {
 
 // ── createZip ─────────────────────────────────────────────────────────────────
 
+func TestWalkZip_CreateDestError(t *testing.T) {
+	src := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "nonexistent-subdir", "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when dest directory does not exist")
+	}
+}
+
+// TestWalkZip_WalkError covers L101-103: filepath.Walk calls the callback with
+// a non-nil error when the source directory does not exist.
+func TestWalkZip_WalkError(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip("/nonexistent-dir-xyzzy-blast", dest); err == nil {
+		t.Error("walkZip should fail when source directory does not exist")
+	}
+}
+
+// TestWalkZip_OpenFileError covers L122-124: os.Open fails when the file exists
+// but is not readable (e.g. mode 0000).
+func TestWalkZip_OpenFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	secret := filepath.Join(src, "secret.go")
+	if err := os.WriteFile(secret, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(secret, 0600) }) //nolint:errcheck
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when a source file cannot be opened")
+	}
+}
+
 func TestCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
@@ -139,6 +202,79 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	entries := readBlastZipEntries(t, path)
 	if !entries["main.go"] {
 		t.Error("created zip should contain main.go")
+	}
+}
+
+// TestCreateZip_CreateTempError covers L48-50: createZip returns an error when
+// os.CreateTemp fails due to an invalid TMPDIR.
+func TestCreateZip_CreateTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
+	_, err := createZip(t.TempDir())
+	if err == nil {
+		t.Error("createZip should fail when os.CreateTemp fails")
+	}
+}
+
+// TestCreateZip_NonExistentDir covers L60-63: createZip cleans up the temp
+// file and returns an error when walkZip fails on a missing source dir.
+func TestCreateZip_NonExistentDir(t *testing.T) {
+	_, err := createZip("/nonexistent-dir-blast-createzip-xyz")
+	if err == nil {
+		t.Error("createZip should fail when directory does not exist")
+	}
+}
+
+func initCleanBlastGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "ci@test.local")
+	run("git", "config", "user.name", "CI")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	return dir
+}
+
+func TestGitArchive_CleanRepo(t *testing.T) {
+	dir := initCleanBlastGitRepo(t)
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := gitArchive(dir, dest); err != nil {
+		t.Fatalf("gitArchive: %v", err)
+	}
+	entries := readBlastZipEntries(t, dest)
+	if !entries["main.go"] {
+		t.Error("git archive should contain main.go")
+	}
+}
+
+func TestIsWorktreeClean_CleanRepo(t *testing.T) {
+	dir := initCleanBlastGitRepo(t)
+	if !isWorktreeClean(dir) {
+		t.Error("freshly committed repo should be considered clean")
+	}
+}
+
+func TestCreateZip_CleanGitRepo(t *testing.T) {
+	dir := initCleanBlastGitRepo(t)
+	path, err := createZip(dir)
+	if err != nil {
+		t.Fatalf("createZip on clean git repo: %v", err)
+	}
+	defer os.Remove(path)
+	entries := readBlastZipEntries(t, path)
+	if !entries["main.go"] {
+		t.Error("zip should contain main.go from git archive")
 	}
 }
 

--- a/internal/blastradius/zip_test.go
+++ b/internal/blastradius/zip_test.go
@@ -1,0 +1,157 @@
+package blastradius
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── isGitRepo ─────────────────────────────────────────────────────────────────
+
+func TestIsGitRepo_NonGitDir(t *testing.T) {
+	if isGitRepo(t.TempDir()) {
+		t.Error("empty temp dir should not be a git repo")
+	}
+}
+
+// ── isWorktreeClean ───────────────────────────────────────────────────────────
+
+func TestIsWorktreeClean_NonGitDir(t *testing.T) {
+	// git status on a non-repo exits non-zero → returns false
+	if isWorktreeClean(t.TempDir()) {
+		t.Error("non-git dir should not be considered clean")
+	}
+}
+
+// ── walkZip ───────────────────────────────────────────────────────────────────
+
+func TestWalkZip_IncludesSourceFiles(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatalf("walkZip: %v", err)
+	}
+	entries := readBlastZipEntries(t, dest)
+	if !entries["main.go"] {
+		t.Error("zip should contain main.go")
+	}
+}
+
+func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "app.ts"), []byte("export {}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readBlastZipEntries(t, dest)
+	if entries[".env"] {
+		t.Error("zip should not contain .env")
+	}
+	if !entries["app.ts"] {
+		t.Error("zip should contain app.ts")
+	}
+}
+
+func TestWalkZip_SkipsNodeModules(t *testing.T) {
+	src := t.TempDir()
+	nmDir := filepath.Join(src, "node_modules")
+	if err := os.Mkdir(nmDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "pkg.js"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "index.ts"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readBlastZipEntries(t, dest)
+	for name := range entries {
+		if strings.HasPrefix(name, "node_modules/") || name == "node_modules" {
+			t.Errorf("should not contain node_modules entry: %s", name)
+		}
+	}
+	if !entries["index.ts"] {
+		t.Error("zip should contain index.ts")
+	}
+}
+
+func TestWalkZip_SkipsOtherSkipDirs(t *testing.T) {
+	for _, dir := range []string{"dist", "build", "vendor", ".git"} {
+		src := t.TempDir()
+		skipDir := filepath.Join(src, dir)
+		if err := os.Mkdir(skipDir, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skipDir, "file.js"), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		dest := filepath.Join(t.TempDir(), "out.zip")
+		if err := walkZip(src, dest); err != nil {
+			t.Fatalf("walkZip with %s: %v", dir, err)
+		}
+		entries := readBlastZipEntries(t, dest)
+		for name := range entries {
+			if strings.HasPrefix(name, dir+"/") {
+				t.Errorf("should not contain %s/ entry: %s", dir, name)
+			}
+		}
+	}
+}
+
+// ── createZip ─────────────────────────────────────────────────────────────────
+
+func TestCreateZip_NonGitDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	path, err := createZip(dir)
+	if err != nil {
+		t.Fatalf("createZip: %v", err)
+	}
+	defer os.Remove(path)
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("zip file not created: %v", err)
+	}
+	// Verify it's a valid zip
+	entries := readBlastZipEntries(t, path)
+	if !entries["main.go"] {
+		t.Error("created zip should contain main.go")
+	}
+}
+
+func readBlastZipEntries(t *testing.T, path string) map[string]bool {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", path, err)
+	}
+	defer r.Close()
+	m := make(map[string]bool, len(r.File))
+	for _, f := range r.File {
+		m[f.Name] = true
+	}
+	return m
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -193,6 +193,67 @@ func TestPut_OverwritesExisting(t *testing.T) {
 	}
 }
 
+// ── PutJSON / GetJSON ─────────────────────────────────────────────────────────
+
+func TestPutGetJSON_RoundTrip(t *testing.T) {
+	withTempCacheDir(t)
+
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	v := payload{Name: "deadcode", Count: 42}
+
+	if err := PutJSON("jsonhash1", v); err != nil {
+		t.Fatalf("PutJSON: %v", err)
+	}
+
+	var got payload
+	hit, err := GetJSON("jsonhash1", &got)
+	if err != nil {
+		t.Fatalf("GetJSON: %v", err)
+	}
+	if !hit {
+		t.Fatal("GetJSON: expected cache hit")
+	}
+	if got.Name != "deadcode" || got.Count != 42 {
+		t.Errorf("GetJSON: got %+v, want {deadcode 42}", got)
+	}
+}
+
+func TestGetJSON_Miss(t *testing.T) {
+	withTempCacheDir(t)
+
+	var v any
+	hit, err := GetJSON("nonexistent", &v)
+	if err != nil {
+		t.Fatalf("GetJSON miss: want nil error, got %v", err)
+	}
+	if hit {
+		t.Error("GetJSON miss: want hit=false")
+	}
+}
+
+func TestPutGetJSON_Overwrite(t *testing.T) {
+	withTempCacheDir(t)
+
+	if err := PutJSON("overwrite-key", map[string]string{"v": "1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := PutJSON("overwrite-key", map[string]string{"v": "2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]string
+	hit, err := GetJSON("overwrite-key", &got)
+	if err != nil || !hit {
+		t.Fatalf("GetJSON: hit=%v err=%v", hit, err)
+	}
+	if got["v"] != "2" {
+		t.Errorf("expected overwritten value '2', got %q", got["v"])
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 func writeTempFile(t *testing.T, content []byte) string {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -254,6 +254,216 @@ func TestPutGetJSON_Overwrite(t *testing.T) {
 	}
 }
 
+func TestGet_CorruptJSON(t *testing.T) {
+	withTempCacheDir(t)
+
+	// Write malformed JSON directly into the cache file.
+	cacheFile := filepath.Join(dir(), "badhash.json")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("{not valid json}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Get("badhash")
+	if err == nil {
+		t.Error("Get with corrupt JSON should return error")
+	}
+}
+
+func TestGetJSON_CorruptJSON(t *testing.T) {
+	withTempCacheDir(t)
+
+	cacheFile := filepath.Join(dir(), "corruptkey.json")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheFile, []byte("{not valid}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var v any
+	_, err := GetJSON("corruptkey", &v)
+	if err == nil {
+		t.Error("GetJSON with corrupt JSON should return error")
+	}
+}
+
+func TestGet_NonNotExistError(t *testing.T) {
+	withTempCacheDir(t)
+
+	// Create a directory where the cache file would be, so ReadFile returns
+	// a non-IsNotExist error (it's a directory, not a file).
+	cacheFile := filepath.Join(dir(), "dirkey.json")
+	if err := os.MkdirAll(cacheFile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Get("dirkey")
+	if err == nil {
+		t.Error("Get with directory-as-file should return error")
+	}
+}
+
+func TestGetJSON_NonNotExistError(t *testing.T) {
+	withTempCacheDir(t)
+
+	cacheFile := filepath.Join(dir(), "dirkey2.json")
+	if err := os.MkdirAll(cacheFile, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	var v any
+	_, err := GetJSON("dirkey2", &v)
+	if err == nil {
+		t.Error("GetJSON with directory-as-file should return error")
+	}
+}
+
+func TestPut_MkdirAllError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Create a regular file where ~/.supermodel would be → MkdirAll fails.
+	smFile := home + "/.supermodel"
+	if err := os.WriteFile(smFile, []byte("not a dir"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	g := &api.Graph{}
+	if err := Put("any-hash", g); err == nil {
+		t.Error("Put should fail when cache dir cannot be created")
+	}
+}
+
+func TestPutJSON_MarshalError(t *testing.T) {
+	withTempCacheDir(t)
+	// Channels cannot be JSON-marshaled; json.Marshal returns an error.
+	if err := PutJSON("marshal-fail", make(chan int)); err == nil {
+		t.Error("PutJSON should fail when value cannot be JSON-marshaled")
+	}
+}
+
+func TestPutJSON_MkdirAllError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	smFile := home + "/.supermodel"
+	if err := os.WriteFile(smFile, []byte("not a dir"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := PutJSON("any-hash", map[string]string{"k": "v"}); err == nil {
+		t.Error("PutJSON should fail when cache dir cannot be created")
+	}
+}
+
+func TestPutJSON_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := home + "/.supermodel/cache"
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cacheDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cacheDir, 0755) }) //nolint:errcheck
+	if err := PutJSON("any-hash", map[string]string{"k": "v"}); err == nil {
+		t.Error("PutJSON should fail when temp file cannot be written")
+	}
+}
+
+func TestPut_RenameError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := filepath.Join(home, ".supermodel", "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Create the destination path as a directory so Rename from .tmp → dest fails.
+	hash := "rename-error-hash"
+	destDir := filepath.Join(cacheDir, hash+".json")
+	if err := os.Mkdir(destDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	g := &api.Graph{}
+	if err := Put(hash, g); err == nil {
+		t.Error("Put should fail when rename destination is a directory")
+	}
+}
+
+func TestPutJSON_RenameError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cacheDir := filepath.Join(home, ".supermodel", "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Block Rename by placing a directory at the destination path.
+	hash := "rename-error-json-hash"
+	destDir := filepath.Join(cacheDir, hash+".json")
+	if err := os.Mkdir(destDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := PutJSON(hash, map[string]string{"k": "v"}); err == nil {
+		t.Error("PutJSON should fail when rename destination is a directory")
+	}
+}
+
+func TestPut_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Create the cache dir but make it read-only so WriteFile fails.
+	cacheDir := home + "/.supermodel/cache"
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cacheDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cacheDir, 0755) }) //nolint:errcheck
+	g := &api.Graph{}
+	if err := Put("any-hash", g); err == nil {
+		t.Error("Put should fail when temp file cannot be written")
+	}
+}
+
+func TestHashFile_ReadError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	path := dir + "/secret.dat"
+	if err := os.WriteFile(path, []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(path, 0600) }) //nolint:errcheck
+	_, err := HashFile(path)
+	if err == nil {
+		t.Error("HashFile should fail when file is not readable")
+	}
+}
+
+func TestPut_MarshalError(t *testing.T) {
+	withTempCacheDir(t)
+	// A graph with a channel property cannot be JSON-marshaled.
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "n1", Labels: []string{"File"}, Properties: map[string]any{"bad": make(chan int)}},
+		},
+	}
+	if err := Put("marshal-error-put", g); err == nil {
+		t.Error("Put should fail when graph has non-JSON-serializable properties")
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 func writeTempFile(t *testing.T, content []byte) string {

--- a/internal/compact/handler_test.go
+++ b/internal/compact/handler_test.go
@@ -608,3 +608,60 @@ func TestCompactDir_EmptyDir(t *testing.T) {
 		t.Errorf("empty dir: want 0 files, got %d", stats.Files)
 	}
 }
+
+// ── nextShortName ─────────────────────────────────────────────────────────────
+
+func TestNextShortName_SingleLetters(t *testing.T) {
+	counter := 0
+	existing := map[string]bool{}
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < 26; i++ {
+		got := nextShortName(&counter, existing)
+		want := string(letters[i])
+		if got != want {
+			t.Errorf("call %d: got %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestNextShortName_TwoLetterOverflow(t *testing.T) {
+	counter := 0
+	existing := map[string]bool{}
+	// Exhaust all 26 single-char names.
+	for i := 0; i < 26; i++ {
+		nextShortName(&counter, existing)
+	}
+	if got := nextShortName(&counter, existing); got != "aa" {
+		t.Errorf("first two-char name: got %q, want %q", got, "aa")
+	}
+	if got := nextShortName(&counter, existing); got != "ab" {
+		t.Errorf("second two-char name: got %q, want %q", got, "ab")
+	}
+}
+
+func TestNextShortName_SkipsExisting(t *testing.T) {
+	counter := 0
+	existing := map[string]bool{"a": true, "b": true}
+	got := nextShortName(&counter, existing)
+	if got != "c" {
+		t.Errorf("expected 'c' (skipping a, b), got %q", got)
+	}
+}
+
+func TestNextShortName_SkipsBuiltins(t *testing.T) {
+	// '_' is a Go builtin; if the counter somehow produces it, it must be skipped.
+	// We test indirectly by filling every single-char slot except 'z' with existing
+	// names, then verifying we get 'z' (the only remaining free single-char slot).
+	existing := map[string]bool{}
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	for _, ch := range letters {
+		if ch != 'z' {
+			existing[string(ch)] = true
+		}
+	}
+	counter := 0
+	got := nextShortName(&counter, existing)
+	if got != "z" {
+		t.Errorf("expected 'z' as only free single-char slot, got %q", got)
+	}
+}

--- a/internal/compact/handler_test.go
+++ b/internal/compact/handler_test.go
@@ -133,6 +133,15 @@ var hello string
 	}
 }
 
+func TestCompactGoParseError(t *testing.T) {
+	// Invalid Go source should produce a parse error from compactGo.
+	src := []byte("package foo\nfunc {{{")
+	_, err := CompactSource(src, Go)
+	if err == nil {
+		t.Error("expected parse error for invalid Go source, got nil")
+	}
+}
+
 func TestCompactGoReducesSize(t *testing.T) {
 	src := []byte(`// Package math provides basic math utilities.
 // It is intentionally simple.
@@ -609,6 +618,71 @@ func TestCompactDir_EmptyDir(t *testing.T) {
 	}
 }
 
+func TestCompactDir_SkipsParseError(t *testing.T) {
+	// CompactDir should skip (not fail) files that fail to parse.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "broken.go"), []byte("package foo\nfunc {{{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "good.go"), []byte("package foo\nfunc Noop() {}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	stats, err := CompactDir(dir, "")
+	if err != nil {
+		t.Fatalf("CompactDir should not error on parse failure: %v", err)
+	}
+	// Only the valid file is counted
+	if stats.Files != 1 {
+		t.Errorf("want 1 file (broken skipped), got %d", stats.Files)
+	}
+}
+
+// ── shortenFuncLocals: range value and var spec ───────────────────────────────
+
+func TestShortenRangeValueVar(t *testing.T) {
+	src := []byte(`package foo
+func processItems(items []string) {
+	for _, itemValue := range items {
+		_ = itemValue
+	}
+}
+`)
+	got, err := CompactSource(src, Go)
+	if err != nil {
+		t.Fatalf("CompactSource error: %v", err)
+	}
+	text := string(got)
+	if strings.Contains(text, "itemValue") {
+		t.Errorf("range value 'itemValue' should be shortened:\n%s", text)
+	}
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "", got, 0); err != nil {
+		t.Fatalf("output is not valid Go: %v\n%s", err, got)
+	}
+}
+
+func TestShortenVarStatement(t *testing.T) {
+	src := []byte(`package foo
+func buildMessage() string {
+	var messageContent string
+	messageContent = "hello"
+	return messageContent
+}
+`)
+	got, err := CompactSource(src, Go)
+	if err != nil {
+		t.Fatalf("CompactSource error: %v", err)
+	}
+	text := string(got)
+	if strings.Contains(text, "messageContent") {
+		t.Errorf("var 'messageContent' should be shortened:\n%s", text)
+	}
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "", got, 0); err != nil {
+		t.Fatalf("output is not valid Go: %v\n%s", err, got)
+	}
+}
+
 // ── nextShortName ─────────────────────────────────────────────────────────────
 
 func TestNextShortName_SingleLetters(t *testing.T) {
@@ -663,5 +737,130 @@ func TestNextShortName_SkipsBuiltins(t *testing.T) {
 	got := nextShortName(&counter, existing)
 	if got != "z" {
 		t.Errorf("expected 'z' as only free single-char slot, got %q", got)
+	}
+}
+
+// ── shortenFuncLocals: KeyValueExpr branch ────────────────────────────────────
+
+// TestDoNotShortenStructLiteralKey covers the KeyValueExpr branch (L221-224):
+// a struct literal key inside a function must be protected from renaming because
+// the key is a field name, not a local variable.
+func TestDoNotShortenStructLiteralKey(t *testing.T) {
+	src := []byte(`package foo
+type Point struct{ x, y int }
+func makePoint() Point {
+	longXValue := 5
+	longYValue := 10
+	return Point{x: longXValue, y: longYValue}
+}
+`)
+	got, err := CompactSource(src, Go)
+	if err != nil {
+		t.Fatalf("CompactSource error: %v", err)
+	}
+	text := string(got)
+	// Struct literal keys 'x' and 'y' are field names — they must not be renamed.
+	if !strings.Contains(text, "x:") {
+		t.Errorf("struct literal key 'x' should not be renamed:\n%s", text)
+	}
+	if !strings.Contains(text, "y:") {
+		t.Errorf("struct literal key 'y' should not be renamed:\n%s", text)
+	}
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, "", got, 0); err != nil {
+		t.Fatalf("output is not valid Go: %v\n%s", err, got)
+	}
+}
+
+// ── stripComments: backtick string with backslash ─────────────────────────────
+
+// TestStripComments_BacktickWithBackslash covers L406-409: when a backtick string
+// (JS/TS template literal) contains a backslash, the next character must be
+// consumed together to avoid mistaking an escaped backtick (\`) for a terminator.
+func TestStripComments_BacktickWithBackslash(t *testing.T) {
+	// TypeScript template literal: const s = `foo\nbar`;  // comment
+	// The \n inside the backtick string hits c=='\\' at L406.
+	src := []byte("const s = `foo\\nbar`; // comment")
+	got, _ := CompactSource(src, TypeScript)
+	text := string(got)
+	if !strings.Contains(text, "foo") {
+		t.Errorf("backtick string content should be preserved:\n%s", text)
+	}
+	// The trailing comment must be stripped.
+	if strings.Contains(text, "comment") {
+		t.Errorf("line comment after backtick string should be stripped:\n%s", text)
+	}
+}
+
+// ── CompactDir error paths ────────────────────────────────────────────────────
+
+// TestCompactDir_ReadFileError covers L477-479: WalkDir lists a file that cannot
+// be read → os.ReadFile returns an error → CompactDir returns error.
+func TestCompactDir_ReadFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	f := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(f, []byte("package main\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(f, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(f, 0600) }) //nolint:errcheck
+	_, err := CompactDir(dir, "")
+	if err == nil {
+		t.Error("CompactDir should fail when a source file is unreadable")
+	}
+}
+
+// TestCompactDir_OutDirMkdirAllError covers L494-496: when outDir is set and a
+// blocking file exists where a subdirectory would be created, MkdirAll fails.
+func TestCompactDir_OutDirMkdirAllError(t *testing.T) {
+	dir := t.TempDir()
+	out := t.TempDir()
+
+	// Create dir/sub/main.go so the relative path is "sub/main.go".
+	subDir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "main.go"), []byte("package main\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Block out/sub creation by placing a regular file there.
+	if err := os.WriteFile(filepath.Join(out, "sub"), []byte("blocker"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := CompactDir(dir, out)
+	if err == nil {
+		t.Error("CompactDir should fail when output subdirectory cannot be created")
+	}
+}
+
+// TestCompactDir_WalkDirError covers L466-468: when WalkDir calls the callback
+// with a non-nil error (unreadable subdirectory), CompactDir returns that error.
+func TestCompactDir_WalkDirError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "locked")
+	if err := os.Mkdir(subdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "main.go"), []byte("package main\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(subdir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(subdir, 0o700) }) //nolint:errcheck
+	_, err := CompactDir(dir, "")
+	if err == nil {
+		t.Error("CompactDir should fail when a subdirectory is unreadable")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,3 +75,105 @@ func TestPath(t *testing.T) {
 		t.Errorf("Path() = %q, want %q", got, want)
 	}
 }
+
+// ── ShardsEnabled ─────────────────────────────────────────────────────────────
+
+func TestShardsEnabled_DefaultTrue(t *testing.T) {
+	cfg := &Config{}
+	if !cfg.ShardsEnabled() {
+		t.Error("ShardsEnabled() with nil Shards should default to true")
+	}
+}
+
+func TestShardsEnabled_ExplicitFalse(t *testing.T) {
+	f := false
+	cfg := &Config{Shards: &f}
+	if cfg.ShardsEnabled() {
+		t.Error("ShardsEnabled() with Shards=false should return false")
+	}
+}
+
+func TestShardsEnabled_ExplicitTrue(t *testing.T) {
+	tr := true
+	cfg := &Config{Shards: &tr}
+	if !cfg.ShardsEnabled() {
+		t.Error("ShardsEnabled() with Shards=true should return true")
+	}
+}
+
+// ── applyEnv ──────────────────────────────────────────────────────────────────
+
+func TestApplyEnv_APIKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SUPERMODEL_API_KEY", "env-key-123")
+	t.Setenv("SUPERMODEL_API_BASE", "")
+	t.Setenv("SUPERMODEL_SHARDS", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.APIKey != "env-key-123" {
+		t.Errorf("SUPERMODEL_API_KEY env override: got %q", cfg.APIKey)
+	}
+}
+
+func TestApplyEnv_APIBase(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	t.Setenv("SUPERMODEL_API_BASE", "https://custom.api.com")
+	t.Setenv("SUPERMODEL_SHARDS", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.APIBase != "https://custom.api.com" {
+		t.Errorf("SUPERMODEL_API_BASE env override: got %q", cfg.APIBase)
+	}
+}
+
+func TestApplyEnv_ShardsDisabled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	t.Setenv("SUPERMODEL_API_BASE", "")
+	t.Setenv("SUPERMODEL_SHARDS", "false")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.ShardsEnabled() {
+		t.Error("SUPERMODEL_SHARDS=false should disable shards")
+	}
+}
+
+// ── applyDefaults ─────────────────────────────────────────────────────────────
+
+func TestApplyDefaults_FilledFromFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	t.Setenv("SUPERMODEL_API_BASE", "")
+	t.Setenv("SUPERMODEL_SHARDS", "")
+
+	// Write a config that has api_key but no api_base or output
+	cfgFile := filepath.Join(home, ".supermodel", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfgFile), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgFile, []byte("api_key: loaded-key\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.APIKey != "loaded-key" {
+		t.Errorf("loaded api_key: got %q", cfg.APIKey)
+	}
+	if cfg.APIBase != DefaultAPIBase {
+		t.Errorf("default api_base: got %q", cfg.APIBase)
+	}
+	if cfg.Output != "human" {
+		t.Errorf("default output: got %q", cfg.Output)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -145,6 +145,107 @@ func TestApplyEnv_ShardsDisabled(t *testing.T) {
 	}
 }
 
+func TestLoad_CorruptYAML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgFile := filepath.Join(home, ".supermodel", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(cfgFile), 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Write invalid YAML
+	if err := os.WriteFile(cfgFile, []byte(": invalid: [yaml"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load()
+	if err == nil {
+		t.Error("Load with corrupt YAML should return error")
+	}
+}
+
+// ── Load read error (non-IsNotExist) ─────────────────────────────────────────
+
+func TestLoad_ReadError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		// Some CI environments run as root and can read everything.
+		t.Skip("skipping permission test in CI")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a directory at the config file path → ReadFile returns EISDIR,
+	// which is not IsNotExist → covers the "read config: ..." error path.
+	cfgPath := filepath.Join(home, ".supermodel", "config.yaml")
+	if err := os.MkdirAll(cfgPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load()
+	if err == nil {
+		t.Error("Load should fail when config path is a directory")
+	}
+}
+
+// ── Save error paths ──────────────────────────────────────────────────────────
+
+// TestSave_MkdirAllError covers L63-65: MkdirAll fails when ~/.supermodel exists
+// as a regular file rather than a directory.
+func TestSave_MkdirAllError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Place a regular file at ~/.supermodel so MkdirAll fails with ENOTDIR.
+	if err := os.WriteFile(filepath.Join(home, ".supermodel"), []byte("not a dir"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{APIKey: "test"}
+	if err := cfg.Save(); err == nil {
+		t.Error("Save should fail when config directory cannot be created")
+	}
+}
+
+// TestSave_WriteFileError covers L72-74: WriteFile fails when the config directory
+// is read-only, preventing the .tmp file from being created.
+func TestSave_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgDir := filepath.Join(home, ".supermodel")
+	if err := os.MkdirAll(cfgDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cfgDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(cfgDir, 0755) }) //nolint:errcheck
+	cfg := &Config{APIKey: "test"}
+	if err := cfg.Save(); err == nil {
+		t.Error("Save should fail when config file cannot be written")
+	}
+}
+
+// ── Save Rename error ─────────────────────────────────────────────────────────
+
+func TestSave_RenameError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping rename-error test in CI")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Create a directory at the config file path → os.Rename(tmp, dest) will fail
+	// because dest is a directory, triggering the os.Remove(tmp) cleanup branch.
+	cfgPath := filepath.Join(home, ".supermodel", "config.yaml")
+	if err := os.MkdirAll(cfgPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{APIKey: "test"}
+	if err := cfg.Save(); err == nil {
+		t.Error("Save should fail when config path is a directory")
+	}
+}
+
 // ── applyDefaults ─────────────────────────────────────────────────────────────
 
 func TestApplyDefaults_FilledFromFile(t *testing.T) {

--- a/internal/deadcode/zip_test.go
+++ b/internal/deadcode/zip_test.go
@@ -1,4 +1,4 @@
-package analyze
+package deadcode
 
 import (
 	"archive/zip"
@@ -9,16 +9,12 @@ import (
 )
 
 func TestIsGitRepo_NonGitDir(t *testing.T) {
-	// isGitRepo uses `git rev-parse --git-dir`; an empty temp dir is not a git repo.
 	if isGitRepo(t.TempDir()) {
 		t.Error("empty temp dir should not be a git repo")
 	}
 }
 
-// ── isWorktreeClean ───────────────────────────────────────────────────────────
-
 func TestIsWorktreeClean_NonGitDir(t *testing.T) {
-	// git status on a non-repo exits non-zero → returns false
 	if isWorktreeClean(t.TempDir()) {
 		t.Error("non-git dir should not be considered clean")
 	}
@@ -34,7 +30,7 @@ func TestWalkZip_IncludesFiles(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatalf("walkZip: %v", err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readDeadcodeZipEntries(t, dest)
 	if _, ok := entries["main.go"]; !ok {
 		t.Error("zip should contain main.go")
 	}
@@ -53,7 +49,7 @@ func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readDeadcodeZipEntries(t, dest)
 	if _, ok := entries[".env"]; ok {
 		t.Error("zip should not contain .env")
 	}
@@ -79,7 +75,7 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readDeadcodeZipEntries(t, dest)
 	for name := range entries {
 		if strings.HasPrefix(name, "node_modules/") || name == "node_modules" {
 			t.Errorf("should not contain node_modules entry: %s", name)
@@ -102,7 +98,7 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	}
 }
 
-func readZipEntries(t *testing.T, path string) map[string]bool {
+func readDeadcodeZipEntries(t *testing.T, path string) map[string]bool {
 	t.Helper()
 	r, err := zip.OpenReader(path)
 	if err != nil {

--- a/internal/find/handler.go
+++ b/internal/find/handler.go
@@ -141,9 +141,11 @@ func dedupSorted(ss []string) []string {
 	if len(ss) == 0 {
 		return nil
 	}
-	sort.Strings(ss)
-	out := ss[:1]
-	for _, s := range ss[1:] {
+	cp := make([]string, len(ss))
+	copy(cp, ss)
+	sort.Strings(cp)
+	out := cp[:1]
+	for _, s := range cp[1:] {
 		if s != out[len(out)-1] {
 			out = append(out, s)
 		}

--- a/internal/find/handler_test.go
+++ b/internal/find/handler_test.go
@@ -227,6 +227,44 @@ func TestPrintMatches_HumanShowsMatchCount(t *testing.T) {
 	}
 }
 
+// ── dedupSorted ───────────────────────────────────────────────────────────────
+
+func TestDedupSorted_Basic(t *testing.T) {
+	got := dedupSorted([]string{"c", "a", "b", "a"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestDedupSorted_Empty(t *testing.T) {
+	if got := dedupSorted(nil); got != nil {
+		t.Errorf("nil input: want nil, got %v", got)
+	}
+	if got := dedupSorted([]string{}); got != nil {
+		t.Errorf("empty input: want nil, got %v", got)
+	}
+}
+
+func TestDedupSorted_DoesNotMutateInput(t *testing.T) {
+	// Prior bug: out := ss[:1] shared the backing array, so appends overwrote
+	// the original slice. Verify the input is unchanged after dedupSorted.
+	input := []string{"b", "a", "c", "a"}
+	snapshot := make([]string, len(input))
+	copy(snapshot, input)
+	dedupSorted(input)
+	for i, v := range snapshot {
+		if input[i] != v {
+			t.Errorf("input mutated at index %d: was %q, now %q", i, v, input[i])
+		}
+	}
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 func makeGraph() *api.Graph {

--- a/internal/find/handler_test.go
+++ b/internal/find/handler_test.go
@@ -209,6 +209,22 @@ func TestPrintMatches_HumanNoFile(t *testing.T) {
 	}
 }
 
+func TestPrintMatches_HumanWithCallees(t *testing.T) {
+	matches := []Match{
+		{ID: "n1", Kind: "Function", Name: "handleRequest", Callees: []string{"parseToken", "respond"}},
+	}
+	var buf bytes.Buffer
+	if err := printMatches(&buf, matches, "handle", ui.FormatHuman); err != nil {
+		t.Fatalf("printMatches: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"parseToken", "respond", "calls:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("should contain %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestPrintMatches_HumanShowsMatchCount(t *testing.T) {
 	matches := []Match{
 		{ID: "n1", Kind: "Function", Name: "foo"},

--- a/internal/find/zip_test.go
+++ b/internal/find/zip_test.go
@@ -14,6 +14,12 @@ func TestIsGitRepo_NotGit(t *testing.T) {
 	}
 }
 
+func TestIsWorktreeClean_NonGitDir(t *testing.T) {
+	if isWorktreeClean(t.TempDir()) {
+		t.Error("non-git dir should not be considered clean")
+	}
+}
+
 func TestWalkZip_IncludesFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0600); err != nil {

--- a/internal/find/zip_test.go
+++ b/internal/find/zip_test.go
@@ -3,6 +3,7 @@ package find
 import (
 	"archive/zip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -80,6 +81,27 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	}
 }
 
+func TestWalkZip_SkipsLargeFiles(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "huge.dat"), make([]byte, 10<<20+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "small.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readZipEntries(t, dest)
+	if _, ok := entries["huge.dat"]; ok {
+		t.Error("file over 10 MB should be excluded from zip")
+	}
+	if _, ok := entries["small.go"]; !ok {
+		t.Error("small file should be included in zip")
+	}
+}
+
 func TestCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
@@ -92,6 +114,117 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	defer os.Remove(path)
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("zip file not created: %v", err)
+	}
+}
+
+func initCleanFindGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "ci@test.local")
+	run("git", "config", "user.name", "CI")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	return dir
+}
+
+func TestGitArchive_CleanRepo(t *testing.T) {
+	dir := initCleanFindGitRepo(t)
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := gitArchive(dir, dest); err != nil {
+		t.Fatalf("gitArchive: %v", err)
+	}
+	entries := readZipEntries(t, dest)
+	if !entries["main.go"] {
+		t.Error("git archive should contain main.go")
+	}
+}
+
+func TestIsWorktreeClean_CleanRepo(t *testing.T) {
+	dir := initCleanFindGitRepo(t)
+	if !isWorktreeClean(dir) {
+		t.Error("freshly committed repo should be considered clean")
+	}
+}
+
+func TestCreateZip_CleanGitRepo(t *testing.T) {
+	dir := initCleanFindGitRepo(t)
+	path, err := createZip(dir)
+	if err != nil {
+		t.Fatalf("createZip on clean git repo: %v", err)
+	}
+	defer os.Remove(path)
+	entries := readZipEntries(t, path)
+	if !entries["main.go"] {
+		t.Error("zip from git archive should contain main.go")
+	}
+}
+
+// TestCreateZip_CreateTempError covers L48-50: createZip returns an error when
+// os.CreateTemp fails due to an invalid TMPDIR.
+func TestCreateZip_CreateTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
+	_, err := createZip(t.TempDir())
+	if err == nil {
+		t.Error("createZip should fail when os.CreateTemp fails")
+	}
+}
+
+// TestCreateZip_NonExistentDir covers L60-63: createZip removes the temp file
+// and returns an error when walkZip fails because the source dir does not exist.
+func TestCreateZip_NonExistentDir(t *testing.T) {
+	_, err := createZip("/nonexistent-dir-find-createzip-xyz")
+	if err == nil {
+		t.Error("createZip should fail when directory does not exist")
+	}
+}
+
+func TestWalkZip_CreateDestError(t *testing.T) {
+	src := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "nonexistent-subdir", "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when dest directory does not exist")
+	}
+}
+
+// TestWalkZip_WalkError covers L101-103: Walk calls the callback with a non-nil
+// error when the source directory does not exist.
+func TestWalkZip_WalkError(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip("/nonexistent-dir-xyzzy-find", dest); err == nil {
+		t.Error("walkZip should fail when source directory does not exist")
+	}
+}
+
+// TestWalkZip_OpenFileError covers L122-124: os.Open fails when the file is
+// not readable.
+func TestWalkZip_OpenFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	secret := filepath.Join(src, "secret.go")
+	if err := os.WriteFile(secret, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(secret, 0600) }) //nolint:errcheck
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when a source file cannot be opened")
 	}
 }
 

--- a/internal/focus/handler.go
+++ b/internal/focus/handler.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/supermodeltools/cli/internal/analyze"
 	"github.com/supermodeltools/cli/internal/api"
@@ -171,6 +172,14 @@ func extract(g *api.Graph, target string, depth int, includeTypes bool) *Slice {
 // reachableImports does a BFS on IMPORTS edges from seed, up to maxDepth hops,
 // and returns the file/package paths of the imported nodes.
 func reachableImports(g *api.Graph, seedID string, nodeByID map[string]*api.Node, rels []api.Relationship, maxDepth int) []string {
+	// Pre-index imports edges by source node to avoid O(queue × rels) inner loop.
+	importEdges := make(map[string][]string, len(rels)/2)
+	for _, rel := range rels {
+		if rel.Type == "imports" || rel.Type == "wildcard_imports" {
+			importEdges[rel.StartNode] = append(importEdges[rel.StartNode], rel.EndNode)
+		}
+	}
+
 	visited := map[string]bool{seedID: true}
 	queue := []string{seedID}
 	var imports []string
@@ -178,16 +187,13 @@ func reachableImports(g *api.Graph, seedID string, nodeByID map[string]*api.Node
 	for depth := 0; depth < maxDepth && len(queue) > 0; depth++ {
 		next := make([]string, 0)
 		for _, cur := range queue {
-			for _, rel := range rels {
-				if rel.Type != "imports" && rel.Type != "wildcard_imports" {
+			for _, endNode := range importEdges[cur] {
+				if visited[endNode] {
 					continue
 				}
-				if rel.StartNode != cur || visited[rel.EndNode] {
-					continue
-				}
-				visited[rel.EndNode] = true
-				next = append(next, rel.EndNode)
-				if n := nodeByID[rel.EndNode]; n != nil {
+				visited[endNode] = true
+				next = append(next, endNode)
+				if n := nodeByID[endNode]; n != nil {
 					p := n.Prop("path", "name", "importPath")
 					if p != "" {
 						imports = append(imports, p)
@@ -265,7 +271,7 @@ func estimateTokens(sl *Slice) int {
 	for _, c := range sl.CalledBy {
 		s += c.Caller + c.File
 	}
-	return len(s) / 4
+	return utf8.RuneCountInString(s) / 4
 }
 
 func pathMatches(nodePath, target string) bool {

--- a/internal/focus/handler_test.go
+++ b/internal/focus/handler_test.go
@@ -303,6 +303,43 @@ func TestRender_MarkdownTokenHint(t *testing.T) {
 	}
 }
 
+func TestRender_MarkdownCalledByNoCallerName(t *testing.T) {
+	// CalledBy with empty Caller (only File) covers the else branch in printMarkdown.
+	sl := &Slice{
+		File:     "util.go",
+		CalledBy: []Call{{Caller: "", File: "main.go"}},
+	}
+	var buf bytes.Buffer
+	if err := render(&buf, sl, ""); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Called by") {
+		t.Errorf("should have 'Called by' section:\n%s", out)
+	}
+	if !strings.Contains(out, "main.go") {
+		t.Errorf("should contain caller file name:\n%s", out)
+	}
+}
+
+func TestRender_MarkdownTypes(t *testing.T) {
+	sl := &Slice{
+		File:  "models.go",
+		Types: []Type{{Name: "User", Kind: "class"}, {Name: "ID", Kind: "type"}},
+	}
+	var buf bytes.Buffer
+	if err := render(&buf, sl, ""); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "### Types") {
+		t.Errorf("should have 'Types' section:\n%s", out)
+	}
+	if !strings.Contains(out, "User") || !strings.Contains(out, "class") {
+		t.Errorf("should show type name and kind:\n%s", out)
+	}
+}
+
 // ── extractTypes ──────────────────────────────────────────────────────────────
 
 func TestExtractTypes(t *testing.T) {
@@ -377,5 +414,278 @@ func TestExtract_WithTypes(t *testing.T) {
 	}
 	if len(sl.Types) != 1 || sl.Types[0].Name != "AuthService" {
 		t.Errorf("types: got %v", sl.Types)
+	}
+}
+
+// ── extract: caller node not in graph ────────────────────────────────────────
+
+func TestExtract_CallerNodeMissing(t *testing.T) {
+	// A "calls" relationship whose StartNode doesn't exist in the graph.
+	// The callerNode == nil branch should be taken silently.
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork", "filePath": "a.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines", StartNode: "f1", EndNode: "fn1"},
+			// StartNode "missing-caller" is not in nodeByID
+			{ID: "r2", Type: "calls", StartNode: "missing-caller", EndNode: "fn1"},
+		},
+	}
+	sl := extract(g, "a.go", 1, false)
+	if sl == nil {
+		t.Fatal("nil slice")
+	}
+	// No CalledBy entries — the missing caller was silently skipped
+	if len(sl.CalledBy) != 0 {
+		t.Errorf("expected 0 CalledBy (missing caller skipped), got %v", sl.CalledBy)
+	}
+}
+
+// ── reachableImports: wildcard_imports and empty prop ────────────────────────
+
+func TestReachableImports_WildcardImports(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"path": "b.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "wildcard_imports", StartNode: "f1", EndNode: "f2"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	imports := reachableImports(g, "f1", nodeByID, g.Rels(), 1)
+	found := false
+	for _, imp := range imports {
+		if imp == "b.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("wildcard_imports should be followed; got %v", imports)
+	}
+}
+
+func TestReachableImports_NodeWithEmptyProp(t *testing.T) {
+	// Node found but has no path/name/importPath → not added to imports
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "ext1", Labels: []string{"ExternalDependency"}, Properties: map[string]any{}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "f1", EndNode: "ext1"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	imports := reachableImports(g, "f1", nodeByID, g.Rels(), 1)
+	if len(imports) != 0 {
+		t.Errorf("node with empty prop should not be added to imports; got %v", imports)
+	}
+}
+
+// ── extractTypes: dangling EndNode ────────────────────────────────────────────
+
+func TestExtractTypes_DanglingEndNode(t *testing.T) {
+	// Relationship points to a node not in nodeByID → n == nil → continue
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines", StartNode: "f1", EndNode: "missing-type"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	types := extractTypes(g, "f1", nodeByID, g.Rels())
+	if len(types) != 0 {
+		t.Errorf("dangling endNode should be skipped; got %v", types)
+	}
+}
+
+func TestExtractTypes_NonClassKind(t *testing.T) {
+	// A "defines" rel to a non-Class node → kind stays "type"
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "t1", Labels: []string{"Type"}, Properties: map[string]any{"name": "MyStruct"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines", StartNode: "f1", EndNode: "t1"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	types := extractTypes(g, "f1", nodeByID, g.Rels())
+	if len(types) != 1 || types[0].Kind != "type" {
+		t.Errorf("non-Class node should have kind='type', got %v", types)
+	}
+}
+
+// ── extract: fn node missing from nodeByID ───────────────────────────────────
+
+func TestExtract_FnNodeMissing(t *testing.T) {
+	// defines relationship references a fn ID not in the graph → fn == nil → skip
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines", StartNode: "f1", EndNode: "missing-fn"},
+		},
+	}
+	sl := extract(g, "a.go", 1, false)
+	if sl == nil {
+		t.Fatal("nil slice")
+	}
+	if len(sl.Functions) != 0 {
+		t.Errorf("missing fn node should be skipped; got %v", sl.Functions)
+	}
+}
+
+// ── reachableImports: cycle detection ────────────────────────────────────────
+
+func TestReachableImports_CycleSkipped(t *testing.T) {
+	// f1 imports f2, f2 imports f1 → cycle; f1 is already visited so second visit skipped
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"path": "b.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "f1", EndNode: "f2"},
+			{ID: "r2", Type: "imports", StartNode: "f2", EndNode: "f1"}, // cycle back to f1
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	// depth=2 so we traverse both hops; the cycle back to f1 should be skipped
+	imports := reachableImports(g, "f1", nodeByID, g.Rels(), 2)
+	// Only b.go should appear (a.go is the seed, not imported)
+	if len(imports) != 1 || imports[0] != "b.go" {
+		t.Errorf("cycle: expected [b.go], got %v", imports)
+	}
+}
+
+// TestExtract_DuplicateCaller covers L150: seenCallers deduplication.
+// When the same external function calls two different functions in the target file,
+// the caller should only appear once in CalledBy.
+func TestExtract_DuplicateCaller(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "fn-a1", Labels: []string{"Function"}, Properties: map[string]any{"name": "FuncA", "filePath": "a.go"}},
+			{ID: "fn-a2", Labels: []string{"Function"}, Properties: map[string]any{"name": "FuncB", "filePath": "a.go"}},
+			{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"path": "b.go"}},
+			{ID: "fn-b", Labels: []string{"Function"}, Properties: map[string]any{"name": "Caller", "filePath": "b.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines_function", StartNode: "f1", EndNode: "fn-a1"},
+			{ID: "r2", Type: "defines_function", StartNode: "f1", EndNode: "fn-a2"},
+			// Same caller calls BOTH functions in the target file.
+			{ID: "r3", Type: "calls", StartNode: "fn-b", EndNode: "fn-a1"},
+			{ID: "r4", Type: "calls", StartNode: "fn-b", EndNode: "fn-a2"},
+		},
+	}
+	sl := extract(g, "a.go", 1, false)
+	if sl == nil {
+		t.Fatal("nil slice")
+	}
+	// Caller should appear exactly once even though they call two functions.
+	if len(sl.CalledBy) != 1 {
+		t.Errorf("duplicate caller should be deduplicated; got %d callers: %v", len(sl.CalledBy), sl.CalledBy)
+	}
+}
+
+// TestExtract_MultipleCallersSorted covers L159: sort.Slice on sl.CalledBy
+// with multiple callers from different files.
+func TestExtract_MultipleCallersSorted(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "fn-target", Labels: []string{"Function"}, Properties: map[string]any{"name": "Target", "filePath": "a.go"}},
+			{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"path": "z.go"}},
+			{ID: "fn-z", Labels: []string{"Function"}, Properties: map[string]any{"name": "ZCaller", "filePath": "z.go"}},
+			{ID: "f3", Labels: []string{"File"}, Properties: map[string]any{"path": "b.go"}},
+			{ID: "fn-b", Labels: []string{"Function"}, Properties: map[string]any{"name": "BCaller", "filePath": "b.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "defines_function", StartNode: "f1", EndNode: "fn-target"},
+			{ID: "r2", Type: "calls", StartNode: "fn-z", EndNode: "fn-target"},
+			{ID: "r3", Type: "calls", StartNode: "fn-b", EndNode: "fn-target"},
+		},
+	}
+	sl := extract(g, "a.go", 1, false)
+	if sl == nil {
+		t.Fatal("nil slice")
+	}
+	if len(sl.CalledBy) != 2 {
+		t.Fatalf("expected 2 callers, got %d: %v", len(sl.CalledBy), sl.CalledBy)
+	}
+	// Should be sorted by file: b.go before z.go
+	if sl.CalledBy[0].File != "b.go" || sl.CalledBy[1].File != "z.go" {
+		t.Errorf("callers should be sorted by file; got %v", sl.CalledBy)
+	}
+}
+
+// TestExtractTypes_NonMatchingRelSkipped covers L237: a non-declares_class/defines
+// relationship causes 'continue' in extractTypes.
+func TestExtractTypes_NonMatchingRelSkipped(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "cls1", Labels: []string{"Class"}, Properties: map[string]any{"name": "MyClass"}},
+		},
+		Relationships: []api.Relationship{
+			// Non-matching type → skipped (covers L237 continue branch)
+			{ID: "r1", Type: "imports", StartNode: "f1", EndNode: "cls1"},
+			// Matching type → included
+			{ID: "r2", Type: "declares_class", StartNode: "f1", EndNode: "cls1"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	types := extractTypes(g, "f1", nodeByID, g.Rels())
+	if len(types) != 1 {
+		t.Errorf("only declares_class/defines rels should be processed; got %v", types)
+	}
+}
+
+// ── reachableImports: endNode not in nodeByID ────────────────────────────────
+
+func TestReachableImports_EndNodeMissingFromGraph(t *testing.T) {
+	// import edge points to a node not in nodeByID → n == nil → no prop appended
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "f1", EndNode: "ghost-node"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	imports := reachableImports(g, "f1", nodeByID, g.Rels(), 1)
+	if len(imports) != 0 {
+		t.Errorf("ghost endNode should produce 0 imports; got %v", imports)
 	}
 }

--- a/internal/focus/handler_test.go
+++ b/internal/focus/handler_test.go
@@ -302,3 +302,80 @@ func TestRender_MarkdownTokenHint(t *testing.T) {
 		t.Errorf("should show token hint:\n%s", buf.String())
 	}
 }
+
+// ── extractTypes ──────────────────────────────────────────────────────────────
+
+func TestExtractTypes(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "auth/handler.go"}},
+			{ID: "cls1", Labels: []string{"Class"}, Properties: map[string]any{"name": "AuthService", "file": "auth/handler.go"}},
+			{ID: "iface1", Labels: []string{"Interface"}, Properties: map[string]any{"name": "Authenticator", "file": "auth/handler.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "declares_class", StartNode: "f1", EndNode: "cls1"},
+			{ID: "r2", Type: "defines", StartNode: "f1", EndNode: "iface1"},
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	types := extractTypes(g, "f1", nodeByID, g.Rels())
+	if len(types) != 2 {
+		t.Fatalf("want 2 types, got %d: %v", len(types), types)
+	}
+	// Class should have kind "class"
+	var foundClass bool
+	for _, typ := range types {
+		if typ.Name == "AuthService" && typ.Kind == "class" {
+			foundClass = true
+		}
+	}
+	if !foundClass {
+		t.Errorf("should have AuthService with kind='class', got %v", types)
+	}
+}
+
+func TestExtractTypes_OtherFileExcluded(t *testing.T) {
+	// Relations from a different file should not appear
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+			{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"path": "b.go"}},
+			{ID: "cls1", Labels: []string{"Class"}, Properties: map[string]any{"name": "Foo"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "declares_class", StartNode: "f2", EndNode: "cls1"}, // from f2, not f1
+		},
+	}
+	nodeByID := map[string]*api.Node{}
+	for i := range g.Nodes {
+		nodeByID[g.Nodes[i].ID] = &g.Nodes[i]
+	}
+	types := extractTypes(g, "f1", nodeByID, g.Rels())
+	if len(types) != 0 {
+		t.Errorf("other file's types should not appear, got %v", types)
+	}
+}
+
+// ── extract with includeTypes ─────────────────────────────────────────────────
+
+func TestExtract_WithTypes(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "auth.go"}},
+			{ID: "cls1", Labels: []string{"Class"}, Properties: map[string]any{"name": "AuthService"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "declares_class", StartNode: "f1", EndNode: "cls1"},
+		},
+	}
+	sl := extract(g, "auth.go", 1, true)
+	if sl == nil {
+		t.Fatal("nil slice")
+	}
+	if len(sl.Types) != 1 || sl.Types[0].Name != "AuthService" {
+		t.Errorf("types: got %v", sl.Types)
+	}
+}

--- a/internal/graph/handler_test.go
+++ b/internal/graph/handler_test.go
@@ -245,6 +245,34 @@ func TestWriteDOT_FilterExcludesEdgesToFilteredNodes(t *testing.T) {
 	}
 }
 
+func TestWriteDOT_FilterExcludesEdgesFromFilteredStartNode(t *testing.T) {
+	// StartNode (fn1) has label Function — filtered out when filter="File".
+	// EndNode (file1) has label File — included.
+	// The edge fn1→file1 should be skipped because fn1 is not in nodeLabel.
+	g := &api.Graph{
+		Nodes: []api.Node{
+			{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork"}},
+			{ID: "file1", Labels: []string{"File"}, Properties: map[string]any{"path": "a.go"}},
+		},
+		Relationships: []api.Relationship{
+			{ID: "r1", Type: "DEFINED_IN", StartNode: "fn1", EndNode: "file1"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := writeDOT(&buf, g, "File"); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	// fn1 is not in nodeLabel (filtered), so the edge must not appear
+	if strings.Contains(out, "->") {
+		t.Errorf("edge from filtered start node should not appear:\n%s", out)
+	}
+	// file1 should still appear as a node
+	if !strings.Contains(out, "file1") {
+		t.Errorf("included File node should appear in output:\n%s", out)
+	}
+}
+
 func TestWriteDOT_LongNameTruncated(t *testing.T) {
 	longName := strings.Repeat("a", 50)
 	g := &api.Graph{
@@ -333,5 +361,24 @@ func TestWriteDOT_LongNameTruncated_MultiByteUTF8(t *testing.T) {
 	}
 	if strings.Contains(out, longName) {
 		t.Errorf("long multi-byte name should be truncated in DOT output")
+	}
+}
+
+// TestWriteDOT_NodeWithNoNameUsesID covers L100: when a node has no name/path/file
+// property, writeDOT falls back to using the node ID as the label.
+func TestWriteDOT_NodeWithNoNameUsesID(t *testing.T) {
+	g := &api.Graph{
+		Nodes: []api.Node{
+			// No name, path, or file properties → label falls back to ID
+			{ID: "node-without-name", Labels: []string{"Unknown"}, Properties: map[string]any{}},
+		},
+	}
+	var buf strings.Builder
+	if err := writeDOT(&buf, g, ""); err != nil {
+		t.Fatalf("writeDOT: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "node-without-name") {
+		t.Errorf("node ID should appear as fallback label:\n%s", out)
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -204,6 +204,40 @@ func makeTestGraph() *api.Graph {
 	}
 }
 
+// ── boolArg / intArg ──────────────────────────────────────────────────────────
+
+func TestBoolArg(t *testing.T) {
+	args := map[string]any{"flag": true, "off": false, "num": 42}
+	if !boolArg(args, "flag") {
+		t.Error("boolArg(flag=true) should return true")
+	}
+	if boolArg(args, "off") {
+		t.Error("boolArg(off=false) should return false")
+	}
+	if boolArg(args, "num") {
+		t.Error("boolArg(num=42) should return false (wrong type)")
+	}
+	if boolArg(args, "absent") {
+		t.Error("boolArg(absent) should return false")
+	}
+}
+
+func TestIntArg(t *testing.T) {
+	args := map[string]any{"count": float64(5), "zero": float64(0), "str": "hello"}
+	if got := intArg(args, "count"); got != 5 {
+		t.Errorf("intArg(count=5.0) = %d, want 5", got)
+	}
+	if got := intArg(args, "zero"); got != 0 {
+		t.Errorf("intArg(zero=0.0) = %d, want 0", got)
+	}
+	if got := intArg(args, "str"); got != 0 {
+		t.Errorf("intArg(str='hello') = %d, want 0 (wrong type)", got)
+	}
+	if got := intArg(args, "absent"); got != 0 {
+		t.Errorf("intArg(absent) = %d, want 0", got)
+	}
+}
+
 func TestFormatImpact_NoEntryPoints(t *testing.T) {
 	result := &api.ImpactResult{
 		Metadata: api.ImpactMetadata{TargetsAnalyzed: 1, TotalFiles: 50, TotalFunctions: 200},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,10 +1,16 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/api"
+	"github.com/supermodeltools/cli/internal/build"
+	"github.com/supermodeltools/cli/internal/cache"
+	"github.com/supermodeltools/cli/internal/config"
 )
 
 func TestFormatDeadCode_Empty(t *testing.T) {
@@ -251,5 +257,573 @@ func TestFormatImpact_NoEntryPoints(t *testing.T) {
 	got := formatImpact(result)
 	if strings.Contains(got, "Entry points") {
 		t.Error("should not contain entry points section when none affected")
+	}
+}
+
+// ── server.dispatch ───────────────────────────────────────────────────────────
+
+func newTestServer() *server {
+	return &server{cfg: &config.Config{}, dir: "/tmp/test-repo"}
+}
+
+func TestDispatch_Initialize(t *testing.T) {
+	s := newTestServer()
+	result, rpcErr := s.dispatch(context.Background(), "initialize", nil)
+	if rpcErr != nil {
+		t.Fatalf("dispatch initialize: unexpected rpcError: %v", rpcErr)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if m["protocolVersion"] == nil {
+		t.Error("expected protocolVersion in result")
+	}
+}
+
+func TestDispatch_ToolsList(t *testing.T) {
+	s := newTestServer()
+	result, rpcErr := s.dispatch(context.Background(), "tools/list", nil)
+	if rpcErr != nil {
+		t.Fatalf("dispatch tools/list: unexpected rpcError: %v", rpcErr)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if m["tools"] == nil {
+		t.Error("expected 'tools' key in result")
+	}
+}
+
+func TestDispatch_NotificationsInitialized(t *testing.T) {
+	s := newTestServer()
+	result, rpcErr := s.dispatch(context.Background(), "notifications/initialized", nil)
+	if rpcErr != nil {
+		t.Fatalf("notifications/initialized: unexpected rpcError: %v", rpcErr)
+	}
+	if result != nil {
+		t.Errorf("notifications/initialized: expected nil result, got %v", result)
+	}
+}
+
+func TestDispatch_UnknownMethod(t *testing.T) {
+	s := newTestServer()
+	_, rpcErr := s.dispatch(context.Background(), "unknown/method", nil)
+	if rpcErr == nil {
+		t.Fatal("expected rpcError for unknown method")
+	}
+	if rpcErr.Code != codeMethodNotFound {
+		t.Errorf("expected codeMethodNotFound (%d), got %d", codeMethodNotFound, rpcErr.Code)
+	}
+}
+
+func TestDispatch_ToolsCall_UnknownTool(t *testing.T) {
+	// Covers the "tools/call" dispatch branch and callTool error path via handleToolCall.
+	s := newTestServer()
+	params := json.RawMessage(`{"name":"nonexistent_tool","arguments":{}}`)
+	_, rpcErr := s.dispatch(context.Background(), "tools/call", params)
+	if rpcErr == nil {
+		t.Fatal("expected rpcError for unknown tool name in tools/call")
+	}
+	if rpcErr.Code != codeInternalError {
+		t.Errorf("expected codeInternalError (%d), got %d", codeInternalError, rpcErr.Code)
+	}
+}
+
+// ── handleInitialize ──────────────────────────────────────────────────────────
+
+func TestHandleInitialize_Fields(t *testing.T) {
+	s := newTestServer()
+	result := s.handleInitialize()
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map, got %T", result)
+	}
+	if _, ok := m["protocolVersion"]; !ok {
+		t.Error("missing protocolVersion")
+	}
+	if _, ok := m["capabilities"]; !ok {
+		t.Error("missing capabilities")
+	}
+	if _, ok := m["serverInfo"]; !ok {
+		t.Error("missing serverInfo")
+	}
+}
+
+// ── callTool ──────────────────────────────────────────────────────────────────
+
+func TestCallTool_UnknownTool(t *testing.T) {
+	s := newTestServer()
+	_, err := s.callTool(context.Background(), "nonexistent_tool", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("error should mention 'unknown tool': %v", err)
+	}
+}
+
+// TestCallTool_KnownToolsReachSwitch exercises each case branch in callTool.
+// The tools themselves fail (no API key / repo), but the switch cases are covered.
+func TestCallTool_AnalyzeCase(t *testing.T) {
+	s := newTestServer()
+	// analyze fails (no API key / zip) but covers the case branch.
+	_, err := s.callTool(context.Background(), "analyze", map[string]any{})
+	if err == nil {
+		t.Error("expected error from analyze without API key")
+	}
+}
+
+func TestCallTool_DeadCodeCase(t *testing.T) {
+	s := newTestServer()
+	_, err := s.callTool(context.Background(), "dead_code", map[string]any{})
+	if err == nil {
+		t.Error("expected error from dead_code without API key")
+	}
+}
+
+func TestCallTool_BlastRadiusCase(t *testing.T) {
+	s := newTestServer()
+	_, err := s.callTool(context.Background(), "blast_radius", map[string]any{"targets": []any{"src/a.ts"}})
+	if err == nil {
+		t.Error("expected error from blast_radius without API key")
+	}
+}
+
+func TestCallTool_GetGraphCase(t *testing.T) {
+	s := newTestServer()
+	_, err := s.callTool(context.Background(), "get_graph", map[string]any{})
+	if err == nil {
+		t.Error("expected error from get_graph without API key")
+	}
+}
+
+// newServerWithGraph returns a server pre-loaded with a cached graph so that
+// getOrAnalyze returns immediately without needing an API key.
+func newServerWithGraph() *server {
+	return &server{
+		cfg:  &config.Config{},
+		dir:  "/tmp/test-repo",
+		graph: &api.Graph{
+			Metadata: map[string]any{"repoId": "test-repo-123"},
+			Nodes: []api.Node{
+				{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"path": "main.go"}},
+				{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "main"}},
+			},
+			Relationships: []api.Relationship{
+				{ID: "r1", Type: "DEFINES", StartNode: "f1", EndNode: "fn1"},
+			},
+		},
+		hash: "testhash123",
+	}
+}
+
+func TestCallTool_AnalyzeWithCachedGraph(t *testing.T) {
+	// Pre-load graph so getOrAnalyze returns immediately — covers success path of toolAnalyze.
+	s := newServerWithGraph()
+	result, err := s.callTool(context.Background(), "analyze", map[string]any{})
+	if err != nil {
+		t.Fatalf("analyze with cached graph: %v", err)
+	}
+	if !strings.Contains(result, "Analysis complete") {
+		t.Errorf("expected 'Analysis complete', got:\n%s", result)
+	}
+}
+
+func TestCallTool_GetGraphWithCachedGraph(t *testing.T) {
+	// Pre-load graph so toolGetGraph returns a JSON slice — covers success path.
+	s := newServerWithGraph()
+	result, err := s.callTool(context.Background(), "get_graph", map[string]any{})
+	if err != nil {
+		t.Fatalf("get_graph with cached graph: %v", err)
+	}
+	if !strings.Contains(result, "nodes") {
+		t.Errorf("expected JSON with 'nodes' key, got:\n%s", result)
+	}
+}
+
+func TestCallTool_GetGraphWithLabelFilter(t *testing.T) {
+	s := newServerWithGraph()
+	result, err := s.callTool(context.Background(), "get_graph", map[string]any{"label": "File"})
+	if err != nil {
+		t.Fatalf("get_graph with label filter: %v", err)
+	}
+	if !strings.Contains(result, "main.go") {
+		t.Errorf("expected File node in result, got:\n%s", result)
+	}
+}
+
+func TestHandleToolCall_SuccessPath(t *testing.T) {
+	// Pre-load graph so handleToolCall succeeds and covers the return-content path.
+	s := newServerWithGraph()
+	params := json.RawMessage(`{"name":"analyze","arguments":{}}`)
+	result, rpcErr := s.handleToolCall(context.Background(), params)
+	if rpcErr != nil {
+		t.Fatalf("expected success, got rpcError: %v", rpcErr)
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	if m["content"] == nil {
+		t.Error("expected 'content' key in result")
+	}
+}
+
+func TestGetOrAnalyze_CachedGraph(t *testing.T) {
+	// force=false, graph pre-set → returns immediately without API call.
+	s := newServerWithGraph()
+	g, hash, err := s.getOrAnalyze(context.Background(), false)
+	if err != nil {
+		t.Fatalf("getOrAnalyze with cached graph: %v", err)
+	}
+	if g == nil {
+		t.Fatal("expected non-nil graph")
+	}
+	if hash != "testhash123" {
+		t.Errorf("expected hash 'testhash123', got %q", hash)
+	}
+}
+
+func TestGetOrAnalyze_ForceNoAPIKey(t *testing.T) {
+	// force=true with no API key → RequireAPIKey returns error (covers L422-423).
+	s := newTestServer()
+	_, _, err := s.getOrAnalyze(context.Background(), true)
+	if err == nil {
+		t.Fatal("expected error when force=true without API key")
+	}
+	if !strings.Contains(err.Error(), "authenticated") {
+		t.Errorf("error should mention authentication: %v", err)
+	}
+}
+
+func TestEnsureZip_NoAPIKey(t *testing.T) {
+	// No API key → RequireAPIKey fails (covers L438-439).
+	s := newTestServer()
+	_, _, err := s.ensureZip()
+	if err == nil {
+		t.Fatal("expected error without API key")
+	}
+	if !strings.Contains(err.Error(), "authenticated") {
+		t.Errorf("error should mention authentication: %v", err)
+	}
+}
+
+func TestEnsureZip_CreateZipError(t *testing.T) {
+	// API key set but dir doesn't exist → createZip fails (covers L439-441).
+	s := &server{
+		cfg: &config.Config{APIKey: "smsk_live_test123"},
+		dir: "/nonexistent/dir/that/does/not/exist",
+	}
+	_, _, err := s.ensureZip()
+	if err == nil {
+		t.Fatal("expected error for non-existent dir")
+	}
+}
+
+func TestEnsureZip_SuccessPath(t *testing.T) {
+	// API key + valid dir → createZip succeeds, HashFile succeeds (covers L443-448).
+	dir := t.TempDir()
+	// Write a dummy file so the zip is non-empty.
+	if err := os.WriteFile(dir+"/main.go", []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := &server{
+		cfg: &config.Config{APIKey: "smsk_live_fake"},
+		dir: dir,
+	}
+	zipPath, hash, err := s.ensureZip()
+	if err != nil {
+		t.Fatalf("ensureZip: %v", err)
+	}
+	defer os.Remove(zipPath)
+	if hash == "" {
+		t.Error("expected non-empty hash from ensureZip")
+	}
+}
+
+func TestGetOrAnalyze_ForceWithAPIKeyButNoServer(t *testing.T) {
+	// API key is set but no server available → analyze.GetGraph fails (covers L422-425).
+	s := &server{
+		cfg: &config.Config{
+			APIKey:  "smsk_live_fake_key_for_test",
+			APIBase: "http://127.0.0.1:1", // unreachable address
+		},
+		dir: t.TempDir(),
+	}
+	_, _, err := s.getOrAnalyze(context.Background(), true)
+	if err == nil {
+		t.Fatal("expected error from unreachable API server")
+	}
+}
+
+// ── handleToolCall ────────────────────────────────────────────────────────────
+
+func TestHandleToolCall_ParseError(t *testing.T) {
+	s := newTestServer()
+	badParams := json.RawMessage(`{not valid json`)
+	_, rpcErr := s.handleToolCall(context.Background(), badParams)
+	if rpcErr == nil {
+		t.Fatal("expected rpcError for invalid params JSON")
+	}
+	if rpcErr.Code != codeParseError {
+		t.Errorf("expected codeParseError (%d), got %d", codeParseError, rpcErr.Code)
+	}
+}
+
+// ── server.run ────────────────────────────────────────────────────────────────
+
+func TestRun_EmptyInput(t *testing.T) {
+	s := newTestServer()
+	r := strings.NewReader("")
+	var w strings.Builder
+	err := s.run(context.Background(), r, &w)
+	if err != nil {
+		t.Fatalf("run with empty input: %v", err)
+	}
+}
+
+func TestRun_ParseErrorLine(t *testing.T) {
+	s := newTestServer()
+	r := strings.NewReader("{not valid json}\n")
+	var w strings.Builder
+	if err := s.run(context.Background(), r, &w); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Should have written a parse error response
+	if !strings.Contains(w.String(), "parse error") {
+		t.Errorf("expected parse error response, got: %s", w.String())
+	}
+}
+
+func TestRun_BlankLines(t *testing.T) {
+	s := newTestServer()
+	r := strings.NewReader("\n  \n\n")
+	var w strings.Builder
+	if err := s.run(context.Background(), r, &w); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// No output for blank lines
+	if w.String() != "" {
+		t.Errorf("blank lines should produce no output, got: %s", w.String())
+	}
+}
+
+func TestRun_InitializeRequest(t *testing.T) {
+	s := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`
+	r := strings.NewReader(req + "\n")
+	var w strings.Builder
+	if err := s.run(context.Background(), r, &w); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(w.String(), "protocolVersion") {
+		t.Errorf("expected protocolVersion in response, got: %s", w.String())
+	}
+}
+
+func TestRun_ContextCancelled(t *testing.T) {
+	s := newTestServer()
+	// Use a pipe so we can block on reading
+	pr, pw := strings.NewReader(""), &strings.Builder{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	// Even with cancelled context, empty input should return ctx.Err or nil
+	_ = s.run(ctx, pr, pw)
+}
+
+func TestRun_ContextCancelledWithPendingInput(t *testing.T) {
+	// Context is cancelled before run; scanner.Scan() succeeds but ctx.Done()
+	// fires in the select — covers the ctx.Done() branch in the run loop.
+	s := newTestServer()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+	req := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+	r := strings.NewReader(req + "\n")
+	var w strings.Builder
+	err := s.run(ctx, r, &w)
+	if err == nil {
+		t.Error("expected non-nil error when context is pre-cancelled with pending input")
+	}
+}
+
+func TestRun_UnknownMethod(t *testing.T) {
+	// dispatch returns rpcError for unknown method; run should encode an error response
+	s := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"unknown/method"}`
+	r := strings.NewReader(req + "\n")
+	var w strings.Builder
+	if err := s.run(context.Background(), r, &w); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.Contains(w.String(), "method not found") {
+		t.Errorf("expected 'method not found' in response, got: %s", w.String())
+	}
+}
+
+func TestRun_ToolsCall_ParseError(t *testing.T) {
+	// tools/call with invalid params JSON should return codeParseError via handleToolCall
+	s := newTestServer()
+	req := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{not valid`
+	r := strings.NewReader(req + "\n")
+	var w strings.Builder
+	if err := s.run(context.Background(), r, &w); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// Should have encoded a parse error
+	if !strings.Contains(w.String(), "parse error") && !strings.Contains(w.String(), "error") {
+		t.Errorf("expected error response for invalid params, got: %s", w.String())
+	}
+}
+
+// ── toolDeadCode / toolBlastRadius cache-hit paths ────────────────────────────
+
+// repoDir returns the root of the git repo (two levels up from internal/mcp).
+func repoDir(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return wd
+}
+
+func TestToolDeadCode_CacheHit(t *testing.T) {
+	// Redirect the cache to an isolated temp dir.
+	t.Setenv("HOME", t.TempDir())
+
+	dir := repoDir(t)
+	fp, err := cache.RepoFingerprint(dir)
+	if err != nil {
+		t.Skipf("cannot fingerprint repo: %v", err)
+	}
+
+	// toolDeadCode computes: fmt.Sprintf("dead-code:%s:%d", minConfidence, limit)
+	// With no args: minConfidence="", limit=0 → "dead-code::0"
+	key := cache.AnalysisKey(fp, "dead-code::0", build.Version)
+	preloaded := &api.DeadCodeResult{
+		Metadata: api.DeadCodeMetadata{TotalDeclarations: 20, DeadCodeCandidates: 1},
+		DeadCodeCandidates: []api.DeadCodeCandidate{
+			{File: "internal/api/client.go", Line: 42, Name: "cachedDeadFn", Confidence: "high", Reason: "No callers"},
+		},
+	}
+	if err := cache.PutJSON(key, preloaded); err != nil {
+		t.Fatalf("PutJSON: %v", err)
+	}
+
+	s := &server{cfg: &config.Config{}, dir: dir}
+	result, err := s.toolDeadCode(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("toolDeadCode cache hit: %v", err)
+	}
+	if !strings.Contains(result, "cachedDeadFn") {
+		t.Errorf("expected cached result containing 'cachedDeadFn', got:\n%s", result)
+	}
+}
+
+func TestToolDeadCode_CacheHitWithArgs(t *testing.T) {
+	// Same as above but with min_confidence and limit args.
+	t.Setenv("HOME", t.TempDir())
+
+	dir := repoDir(t)
+	fp, err := cache.RepoFingerprint(dir)
+	if err != nil {
+		t.Skipf("cannot fingerprint repo: %v", err)
+	}
+
+	// minConfidence="high", limit=5 → "dead-code:high:5"
+	key := cache.AnalysisKey(fp, "dead-code:high:5", build.Version)
+	preloaded := &api.DeadCodeResult{
+		Metadata: api.DeadCodeMetadata{TotalDeclarations: 10, DeadCodeCandidates: 1},
+		DeadCodeCandidates: []api.DeadCodeCandidate{
+			{File: "src/main.go", Line: 10, Name: "highConfFn", Confidence: "high", Reason: "Unreachable"},
+		},
+	}
+	if err := cache.PutJSON(key, preloaded); err != nil {
+		t.Fatalf("PutJSON: %v", err)
+	}
+
+	s := &server{cfg: &config.Config{}, dir: dir}
+	result, err := s.toolDeadCode(context.Background(), map[string]any{
+		"min_confidence": "high",
+		"limit":          float64(5),
+	})
+	if err != nil {
+		t.Fatalf("toolDeadCode cache hit with args: %v", err)
+	}
+	if !strings.Contains(result, "highConfFn") {
+		t.Errorf("expected 'highConfFn' in result, got:\n%s", result)
+	}
+}
+
+func TestToolBlastRadius_CacheHit(t *testing.T) {
+	// toolBlastRadius with no file arg: analysisType = "impact"
+	t.Setenv("HOME", t.TempDir())
+
+	dir := repoDir(t)
+	fp, err := cache.RepoFingerprint(dir)
+	if err != nil {
+		t.Skipf("cannot fingerprint repo: %v", err)
+	}
+
+	key := cache.AnalysisKey(fp, "impact", build.Version)
+	preloaded := &api.ImpactResult{
+		Metadata: api.ImpactMetadata{TargetsAnalyzed: 0, TotalFiles: 50, TotalFunctions: 200},
+		GlobalMetrics: api.ImpactGlobalMetrics{
+			MostCriticalFiles: []api.CriticalFileMetric{
+				{File: "core/db.go", DependentCount: 15},
+			},
+		},
+	}
+	if err := cache.PutJSON(key, preloaded); err != nil {
+		t.Fatalf("PutJSON: %v", err)
+	}
+
+	s := &server{cfg: &config.Config{}, dir: dir}
+	result, err := s.toolBlastRadius(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("toolBlastRadius cache hit: %v", err)
+	}
+	if !strings.Contains(result, "core/db.go") {
+		t.Errorf("expected 'core/db.go' in result, got:\n%s", result)
+	}
+}
+
+func TestToolBlastRadius_CacheHitWithTarget(t *testing.T) {
+	// toolBlastRadius with file arg: analysisType = "impact:<file>"
+	t.Setenv("HOME", t.TempDir())
+
+	dir := repoDir(t)
+	fp, err := cache.RepoFingerprint(dir)
+	if err != nil {
+		t.Skipf("cannot fingerprint repo: %v", err)
+	}
+
+	target := "internal/api/client.go"
+	key := cache.AnalysisKey(fp, "impact:"+target, build.Version)
+	preloaded := &api.ImpactResult{
+		Metadata: api.ImpactMetadata{TargetsAnalyzed: 1, TotalFiles: 80, TotalFunctions: 400},
+		Impacts: []api.ImpactTarget{
+			{
+				Target: api.ImpactTargetInfo{File: target, Type: "file"},
+				BlastRadius: api.BlastRadius{
+					DirectDependents: 3, TransitiveDependents: 10, AffectedFiles: 5,
+					RiskScore: "medium",
+				},
+			},
+		},
+	}
+	if err := cache.PutJSON(key, preloaded); err != nil {
+		t.Fatalf("PutJSON: %v", err)
+	}
+
+	s := &server{cfg: &config.Config{}, dir: dir}
+	result, err := s.toolBlastRadius(context.Background(), map[string]any{"file": target})
+	if err != nil {
+		t.Fatalf("toolBlastRadius cache hit with target: %v", err)
+	}
+	if !strings.Contains(result, target) {
+		t.Errorf("expected target %q in result, got:\n%s", target, result)
 	}
 }

--- a/internal/mcp/zip_test.go
+++ b/internal/mcp/zip_test.go
@@ -1,4 +1,4 @@
-package analyze
+package mcp
 
 import (
 	"archive/zip"
@@ -8,23 +8,19 @@ import (
 	"testing"
 )
 
-func TestIsGitRepo_NonGitDir(t *testing.T) {
-	// isGitRepo uses `git rev-parse --git-dir`; an empty temp dir is not a git repo.
+func TestMCPIsGitRepo_NonGitDir(t *testing.T) {
 	if isGitRepo(t.TempDir()) {
 		t.Error("empty temp dir should not be a git repo")
 	}
 }
 
-// ── isWorktreeClean ───────────────────────────────────────────────────────────
-
-func TestIsWorktreeClean_NonGitDir(t *testing.T) {
-	// git status on a non-repo exits non-zero → returns false
+func TestMCPIsWorktreeClean_NonGitDir(t *testing.T) {
 	if isWorktreeClean(t.TempDir()) {
 		t.Error("non-git dir should not be considered clean")
 	}
 }
 
-func TestWalkZip_IncludesFiles(t *testing.T) {
+func TestMCPWalkZip_IncludesFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("package main"), 0600); err != nil {
 		t.Fatal(err)
@@ -34,13 +30,13 @@ func TestWalkZip_IncludesFiles(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatalf("walkZip: %v", err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readMCPZipEntries(t, dest)
 	if _, ok := entries["main.go"]; !ok {
 		t.Error("zip should contain main.go")
 	}
 }
 
-func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
+func TestMCPWalkZip_SkipsHiddenFiles(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=x"), 0600); err != nil {
 		t.Fatal(err)
@@ -53,7 +49,7 @@ func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readMCPZipEntries(t, dest)
 	if _, ok := entries[".env"]; ok {
 		t.Error("zip should not contain .env")
 	}
@@ -62,7 +58,7 @@ func TestWalkZip_SkipsHiddenFiles(t *testing.T) {
 	}
 }
 
-func TestWalkZip_SkipsSkipDirs(t *testing.T) {
+func TestMCPWalkZip_SkipsSkipDirs(t *testing.T) {
 	src := t.TempDir()
 	nmDir := filepath.Join(src, "node_modules")
 	if err := os.Mkdir(nmDir, 0750); err != nil {
@@ -79,7 +75,7 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	if err := walkZip(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	entries := readZipEntries(t, dest)
+	entries := readMCPZipEntries(t, dest)
 	for name := range entries {
 		if strings.HasPrefix(name, "node_modules/") || name == "node_modules" {
 			t.Errorf("should not contain node_modules entry: %s", name)
@@ -87,7 +83,7 @@ func TestWalkZip_SkipsSkipDirs(t *testing.T) {
 	}
 }
 
-func TestCreateZip_NonGitDir(t *testing.T) {
+func TestMCPCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
 		t.Fatal(err)
@@ -102,7 +98,7 @@ func TestCreateZip_NonGitDir(t *testing.T) {
 	}
 }
 
-func readZipEntries(t *testing.T, path string) map[string]bool {
+func readMCPZipEntries(t *testing.T, path string) map[string]bool {
 	t.Helper()
 	r, err := zip.OpenReader(path)
 	if err != nil {

--- a/internal/mcp/zip_test.go
+++ b/internal/mcp/zip_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"archive/zip"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -83,6 +84,27 @@ func TestMCPWalkZip_SkipsSkipDirs(t *testing.T) {
 	}
 }
 
+func TestMCPWalkZip_SkipsLargeFiles(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "huge.dat"), make([]byte, 10<<20+1), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "small.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	entries := readMCPZipEntries(t, dest)
+	if entries["huge.dat"] {
+		t.Error("file over 10 MB should be excluded from zip")
+	}
+	if !entries["small.go"] {
+		t.Error("small file should be included in zip")
+	}
+}
+
 func TestMCPCreateZip_NonGitDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
@@ -95,6 +117,109 @@ func TestMCPCreateZip_NonGitDir(t *testing.T) {
 	defer os.Remove(path)
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("zip file not created: %v", err)
+	}
+}
+
+func TestMCPWalkZip_CreateDestError(t *testing.T) {
+	src := t.TempDir()
+	dest := filepath.Join(t.TempDir(), "nonexistent-subdir", "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when dest directory does not exist")
+	}
+}
+
+func TestMCPWalkZip_WalkError(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip("/nonexistent-dir-xyzzy-mcp", dest); err == nil {
+		t.Error("walkZip should fail when source directory does not exist")
+	}
+}
+
+func TestMCPWalkZip_OpenFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	src := t.TempDir()
+	secret := filepath.Join(src, "secret.go")
+	if err := os.WriteFile(secret, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(secret, 0600) }) //nolint:errcheck
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := walkZip(src, dest); err == nil {
+		t.Error("walkZip should fail when a source file cannot be opened")
+	}
+}
+
+func TestMCPCreateZip_CreateTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp"))
+	_, err := createZip(t.TempDir())
+	if err == nil {
+		t.Error("createZip should fail when os.CreateTemp fails")
+	}
+}
+
+func TestMCPCreateZip_NonExistentDir(t *testing.T) {
+	_, err := createZip("/nonexistent-dir-mcp-createzip-xyz")
+	if err == nil {
+		t.Error("createZip should fail when directory does not exist")
+	}
+}
+
+func initCleanMCPGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "ci@test.local")
+	run("git", "config", "user.name", "CI")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+	return dir
+}
+
+func TestMCPGitArchive_CleanRepo(t *testing.T) {
+	dir := initCleanMCPGitRepo(t)
+	dest := filepath.Join(t.TempDir(), "out.zip")
+	if err := gitArchive(dir, dest); err != nil {
+		t.Fatalf("gitArchive: %v", err)
+	}
+	entries := readMCPZipEntries(t, dest)
+	if !entries["main.go"] {
+		t.Error("git archive should contain main.go")
+	}
+}
+
+func TestMCPIsWorktreeClean_CleanRepo(t *testing.T) {
+	dir := initCleanMCPGitRepo(t)
+	if !isWorktreeClean(dir) {
+		t.Error("freshly committed repo should be considered clean")
+	}
+}
+
+func TestMCPCreateZip_CleanGitRepo(t *testing.T) {
+	dir := initCleanMCPGitRepo(t)
+	path, err := createZip(dir)
+	if err != nil {
+		t.Fatalf("createZip on clean git repo: %v", err)
+	}
+	defer os.Remove(path)
+	entries := readMCPZipEntries(t, path)
+	if !entries["main.go"] {
+		t.Error("zip should contain main.go from git archive")
 	}
 }
 

--- a/internal/restore/render.go
+++ b/internal/restore/render.go
@@ -7,6 +7,7 @@ import (
 	gotmpl "text/template"
 	"time"
 	"unicode"
+	"unicode/utf8"
 )
 
 const maxCyclesToShow = 10
@@ -288,7 +289,7 @@ func CountTokens(text string) int {
 			inWord = true
 		}
 	}
-	charEstimate := len(text) / 4
+	charEstimate := utf8.RuneCountInString(text) / 4
 	wordEstimate := words * 100 / 75
 	if charEstimate > wordEstimate {
 		return charEstimate

--- a/internal/restore/restore_test.go
+++ b/internal/restore/restore_test.go
@@ -52,6 +52,18 @@ func TestCountTokens_RealText(t *testing.T) {
 	}
 }
 
+func TestCountTokens_MultiByteChars(t *testing.T) {
+	// Prior bug: used len(text)/4 (bytes) not RuneCountInString/4.
+	// Each CJK character is 3 bytes; 100 of them = 300 bytes but only 100 runes.
+	// charEstimate must be 100/4 = 25, not 300/4 = 75.
+	cjk := strings.Repeat("中", 100) // 100 runes, 300 bytes
+	got := CountTokens(cjk)
+	// charEstimate = 25, wordEstimate = 1*100/75 = 1 → 25
+	if got != 25 {
+		t.Errorf("100 CJK chars: want 25 tokens, got %d (byte-based would give 75)", got)
+	}
+}
+
 // ── isHorizontalRule ─────────────────────────────────────────────────────────
 
 func TestIsHorizontalRule(t *testing.T) {

--- a/internal/restore/restore_test.go
+++ b/internal/restore/restore_test.go
@@ -820,6 +820,61 @@ func TestRender_ContainsProjectOverview(t *testing.T) {
 	}
 }
 
+// TestRender_LanguageList covers the languageList FuncMap lambda (L21) by supplying
+// Stats.Languages which is rendered via {{languageList .Graph.Stats.Languages}}.
+func TestRender_LanguageList(t *testing.T) {
+	g := &ProjectGraph{
+		Name:     "proj",
+		Language: "Go",
+		Stats:    Stats{TotalFiles: 5, Languages: []string{"Go", "TypeScript"}},
+	}
+	output, _, err := Render(g, "proj", RenderOptions{MaxTokens: 5000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "TypeScript") {
+		t.Errorf("languageList should render languages: %s", output)
+	}
+}
+
+// TestRender_CriticalFilesAdd1 covers the add1 FuncMap lambda (L22) by including
+// CriticalFiles which are rendered with {{add1 $i}} for 1-based numbering.
+func TestRender_CriticalFilesAdd1(t *testing.T) {
+	g := &ProjectGraph{
+		Name:     "proj",
+		Language: "Go",
+		Stats:    Stats{TotalFiles: 5},
+		CriticalFiles: []CriticalFile{
+			{Path: "core/db.go", RelationshipCount: 8},
+		},
+	}
+	output, _, err := Render(g, "proj", RenderOptions{MaxTokens: 5000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "core/db.go") {
+		t.Errorf("critical file should appear: %s", output)
+	}
+}
+
+// TestRender_StaleWithStaleAt covers L99-101: staleDuration computed when
+// opts.Stale=true and opts.StaleAt is non-nil inside Render().
+func TestRender_StaleWithStaleAt(t *testing.T) {
+	staleAt := time.Now().Add(-3 * time.Hour)
+	g := &ProjectGraph{Name: "proj", Language: "Go", Stats: Stats{TotalFiles: 1}}
+	output, _, err := Render(g, "proj", RenderOptions{
+		MaxTokens: 5000,
+		Stale:     true,
+		StaleAt:   &staleAt,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "STALE") {
+		t.Errorf("output should contain STALE banner: %s", output)
+	}
+}
+
 // ── truncateToTokenBudget ─────────────────────────────────────────────────────
 
 func TestTruncateToTokenBudget_TinyBudgetFallback(t *testing.T) {
@@ -1088,6 +1143,58 @@ pydantic = "^2.0"
 	}
 }
 
+func TestDetectExternalDeps_PyprojectTomlProjectSection(t *testing.T) {
+	// Tests the [project] section with a multi-line dependencies array.
+	dir := t.TempDir()
+	pyproject := `[project]
+name = "myapp"
+dependencies = [
+    "requests>=2.0",
+    "pydantic",
+    "fastapi ; python_version>='3.8'",
+]
+`
+	writeFile(t, dir, "pyproject.toml", pyproject)
+	deps := DetectExternalDeps(dir)
+	for _, want := range []string{"requests", "pydantic", "fastapi"} {
+		if !contains(deps, want) {
+			t.Errorf("should include %q, got %v", want, deps)
+		}
+	}
+}
+
+func TestDetectExternalDeps_PyprojectTomlProjectInlineArray(t *testing.T) {
+	// Tests the [project] section with an inline array on one line.
+	dir := t.TempDir()
+	pyproject := `[project]
+name = "myapp"
+dependencies = ["requests", "pydantic"]
+`
+	writeFile(t, dir, "pyproject.toml", pyproject)
+	deps := DetectExternalDeps(dir)
+	for _, want := range []string{"requests", "pydantic"} {
+		if !contains(deps, want) {
+			t.Errorf("should include %q in inline array, got %v", want, deps)
+		}
+	}
+}
+
+func TestDetectExternalDeps_NpmDevDepsFillRemainingCapacity(t *testing.T) {
+	// 14 non-npm deps from requirements.txt + 1 npm runtime + 2 npm dev;
+	// only 1 slot remains after non-npm, so only 1 npm runtime should be added.
+	dir := t.TempDir()
+	lines := make([]string, 14)
+	for i := range lines {
+		lines[i] = "dep" + strings.Repeat("x", i+1)
+	}
+	writeFile(t, dir, "requirements.txt", strings.Join(lines, "\n"))
+	writeFile(t, dir, "package.json", `{"dependencies":{"npm-a":"^1.0"},"devDependencies":{"npm-dev":"^1.0"}}`)
+	deps := DetectExternalDeps(dir)
+	if len(deps) > 15 {
+		t.Errorf("should cap at 15, got %d: %v", len(deps), deps)
+	}
+}
+
 func TestDetectExternalDeps_CapAt15(t *testing.T) {
 	dir := t.TempDir()
 	lines := make([]string, 20)
@@ -1198,6 +1305,177 @@ func TestBuildProjectGraph_ReadsREADMEDescription(t *testing.T) {
 	}
 	if !strings.Contains(g.Description, "command-line") {
 		t.Errorf("should extract description from README, got %q", g.Description)
+	}
+}
+
+// ── collectFiles edge cases ───────────────────────────────────────────────────
+
+// TestBuildProjectGraph_NonExistentRoot covers L325-327: WalkDir calls the
+// callback with a non-nil error for the root directory when it does not exist.
+func TestBuildProjectGraph_NonExistentRoot(t *testing.T) {
+	ctx := context.Background()
+	_, err := BuildProjectGraph(ctx, "/nonexistent-dir-for-collectfiles-test-xyz", "proj")
+	if err == nil {
+		t.Error("BuildProjectGraph should fail for a non-existent root directory")
+	}
+}
+
+// TestBuildProjectGraph_HiddenAndIgnoredDirs covers L335-337: a hidden directory
+// and an ignoreDirs entry (node_modules) are both skipped during the walk.
+func TestBuildProjectGraph_HiddenAndIgnoredDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main\n")
+	// Hidden dir (starts with "."): should be skipped.
+	if err := os.MkdirAll(filepath.Join(dir, ".hidden_dir"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, ".hidden_dir/secret.go", "package hidden\n")
+	// ignoreDirs entry (node_modules): should be skipped.
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "node_modules/pkg.js", "x\n")
+
+	ctx := context.Background()
+	g, err := BuildProjectGraph(ctx, dir, "proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only main.go should be counted; hidden and ignored dirs must not add files.
+	if g.Stats.TotalFiles != 1 {
+		t.Errorf("want 1 file (hidden and node_modules skipped), got %d", g.Stats.TotalFiles)
+	}
+}
+
+// TestBuildProjectGraph_SymlinkSkipped covers L340-342: a symlink entry in the
+// walk is silently skipped.
+func TestBuildProjectGraph_SymlinkSkipped(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "main.go")
+	writeFile(t, dir, "main.go", "package main\n")
+	link := filepath.Join(dir, "link.go")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlink creation not supported: " + err.Error())
+	}
+
+	ctx := context.Background()
+	g, err := BuildProjectGraph(ctx, dir, "proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The symlink must not be counted as a separate file.
+	if g.Stats.TotalFiles != 1 {
+		t.Errorf("want 1 file (symlink skipped), got %d", g.Stats.TotalFiles)
+	}
+}
+
+// TestBuildProjectGraph_HiddenFileSkipped covers L348-350: a hidden file
+// (starting with ".") in the walk is silently skipped.
+func TestBuildProjectGraph_HiddenFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "main.go", "package main\n")
+	writeFile(t, dir, ".hidden_file", "not a source file\n")
+
+	ctx := context.Background()
+	g, err := BuildProjectGraph(ctx, dir, "proj")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g.Stats.TotalFiles != 1 {
+		t.Errorf("want 1 file (.hidden_file skipped), got %d", g.Stats.TotalFiles)
+	}
+}
+
+// ── DetectExternalDeps edge cases ─────────────────────────────────────────────
+
+// TestDetectExternalDeps_DuplicateDep covers L99-101: the seen[name] check in the
+// add closure skips an already-added dependency.
+func TestDetectExternalDeps_DuplicateDep(t *testing.T) {
+	dir := t.TempDir()
+	// Same dep listed under two different top-level require statements → add called
+	// twice with "cobra", second call hits seen[name] == true branch.
+	writeFile(t, dir, "go.mod", "module example.com/x\n\nrequire github.com/spf13/cobra v1.0.0\nrequire github.com/spf13/cobra v1.8.0\n")
+	deps := DetectExternalDeps(dir)
+	count := 0
+	for _, d := range deps {
+		if d == "cobra" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("duplicate dep 'cobra' should appear once, got %d times in %v", count, deps)
+	}
+}
+
+// TestDetectExternalDeps_GoModInlineComment covers L132-134: a require block entry
+// with an inline // comment has the comment stripped before the module name is parsed.
+func TestDetectExternalDeps_GoModInlineComment(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "go.mod", `module example.com/x
+
+go 1.21
+
+require (
+	github.com/spf13/cobra v1.8.0 // indirect
+	github.com/pkg/errors v0.9.0
+)
+`)
+	deps := DetectExternalDeps(dir)
+	if !contains(deps, "cobra") {
+		t.Errorf("should detect cobra from require block with // comment, got %v", deps)
+	}
+}
+
+// TestDetectExternalDeps_RequirementsURLSpec covers L175-177: a requirements.txt
+// line using the "name @ URL" PEP 440 URL specifier strips the URL part.
+func TestDetectExternalDeps_RequirementsURLSpec(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "requirements.txt", "requests @ https://files.pythonhosted.org/requests.tar.gz\nflask\n")
+	deps := DetectExternalDeps(dir)
+	if !contains(deps, "requests") {
+		t.Errorf("should detect 'requests' from URL spec line, got %v", deps)
+	}
+}
+
+// TestDetectExternalDeps_CargoNegativeDepth covers L206-208: a rogue "}" in
+// Cargo.toml when depth is already 0 would make depth negative; the guard resets
+// it to 0 so subsequent lines are still processed correctly.
+func TestDetectExternalDeps_CargoNegativeDepth(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Cargo.toml", `[package]
+name = "myapp"
+
+[dependencies]
+serde = "1.0"
+}
+anyhow = "1.0"
+`)
+	deps := DetectExternalDeps(dir)
+	if !contains(deps, "serde") {
+		t.Errorf("should detect 'serde' despite rogue }, got %v", deps)
+	}
+}
+
+// TestDetectExternalDeps_NpmRuntimeCapAtMaxDeps covers L294-295: when deps is
+// already at maxDeps (15) from non-npm sources, the npmRuntime loop breaks
+// immediately at L294.
+func TestDetectExternalDeps_NpmRuntimeCapAtMaxDeps(t *testing.T) {
+	dir := t.TempDir()
+	// 15 requirements.txt deps to fill the cap, plus one npm runtime dep.
+	pyDeps := make([]string, 15)
+	for i := range pyDeps {
+		pyDeps[i] = "pydep" + strings.Repeat("x", i+1)
+	}
+	writeFile(t, dir, "requirements.txt", strings.Join(pyDeps, "\n"))
+	writeFile(t, dir, "package.json", `{"dependencies":{"npm-extra":"^1.0"}}`)
+	deps := DetectExternalDeps(dir)
+	// Cap must be respected.
+	if len(deps) > 15 {
+		t.Errorf("deps should be capped at 15, got %d", len(deps))
+	}
+	// npm-extra should not appear because the cap was already hit.
+	if contains(deps, "npm-extra") {
+		t.Errorf("npm-extra should be excluded due to cap, got %v", deps)
 	}
 }
 
@@ -1312,4 +1590,123 @@ func contains(ss []string, target string) bool {
 		}
 	}
 	return false
+}
+
+// ── truncateToTokenBudget additional branches ─────────────────────────────────
+
+func TestTruncateToTokenBudget_CriticalFilesWithRelCount(t *testing.T) {
+	g := &ProjectGraph{
+		Name:     "proj",
+		Language: "Go",
+		Stats:    Stats{TotalFiles: 5},
+		CriticalFiles: []CriticalFile{
+			{Path: "core/db.go", RelationshipCount: 10},
+			{Path: "util/helpers.go", RelationshipCount: 0},
+		},
+	}
+	output, _, err := truncateToTokenBudget(g, "proj", RenderOptions{MaxTokens: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "Critical Files") {
+		t.Error("should contain Critical Files section")
+	}
+	if !strings.Contains(output, "relationships") {
+		t.Errorf("file with RelationshipCount>0 should show 'relationships': %s", output)
+	}
+}
+
+func TestTruncateToTokenBudget_CriticalFilesTruncatedByBudget(t *testing.T) {
+	// Very tight budget: Critical Files header fits but individual file lines don't.
+	files := make([]CriticalFile, 5)
+	for i := range files {
+		files[i] = CriticalFile{
+			Path:              strings.Repeat("a", 80),
+			RelationshipCount: i + 1,
+		}
+	}
+	g := &ProjectGraph{
+		Name:          "proj",
+		Language:      "Go",
+		Stats:         Stats{TotalFiles: 5},
+		CriticalFiles: files,
+	}
+	// Small enough that not all files fit
+	_, tokens, err := truncateToTokenBudget(g, "proj", RenderOptions{MaxTokens: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tokens > 130 {
+		t.Errorf("tokens %d should stay close to budget 100", tokens)
+	}
+}
+
+func TestTruncateToTokenBudget_StaleBanner(t *testing.T) {
+	staleAt := time.Now().Add(-2 * time.Hour)
+	g := &ProjectGraph{Name: "proj", Language: "Go", Stats: Stats{TotalFiles: 1}}
+	opts := RenderOptions{
+		MaxTokens: 500,
+		Stale:     true,
+		StaleAt:   &staleAt,
+	}
+	output, _, err := truncateToTokenBudget(g, "proj", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "STALE") {
+		t.Errorf("stale output should contain 'STALE': %s", output)
+	}
+}
+
+// TestTruncateToTokenBudget_LocalMode covers L156-158: local mode banner appended
+// in truncateToTokenBudget when opts.LocalMode is true.
+func TestTruncateToTokenBudget_LocalMode(t *testing.T) {
+	g := &ProjectGraph{Name: "proj", Language: "Go", Stats: Stats{TotalFiles: 1}}
+	output, _, err := truncateToTokenBudget(g, "proj", RenderOptions{
+		MaxTokens: 500,
+		LocalMode: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "local mode") {
+		t.Errorf("output should contain local mode banner: %s", output)
+	}
+}
+
+// TestTruncateToTokenBudget_CircularOneCycle covers L163-168: the
+// CircularDependencyCycles>0 branch and the ==1 singular "cycle" label.
+func TestTruncateToTokenBudget_CircularOneCycle(t *testing.T) {
+	g := &ProjectGraph{
+		Name:     "proj",
+		Language: "Go",
+		Stats:    Stats{TotalFiles: 1, CircularDependencyCycles: 1},
+	}
+	output, _, err := truncateToTokenBudget(g, "proj", RenderOptions{MaxTokens: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "circular dependency") {
+		t.Errorf("output should mention circular dependency: %s", output)
+	}
+	// Singular "cycle" (not "cycles") is used when count == 1.
+	if !strings.Contains(output, "cycle") {
+		t.Errorf("singular 'cycle' should appear for count=1: %s", output)
+	}
+}
+
+// TestTruncateToTokenBudget_ClaudeMD covers L231-240: ClaudeMD section written
+// when opts.ClaudeMD is non-empty and fits within remaining budget.
+func TestTruncateToTokenBudget_ClaudeMD(t *testing.T) {
+	g := &ProjectGraph{Name: "proj", Language: "Go", Stats: Stats{TotalFiles: 1}}
+	output, _, err := truncateToTokenBudget(g, "proj", RenderOptions{
+		MaxTokens: 1000,
+		ClaudeMD:  "## Instructions\nDo the thing.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "Do the thing.") {
+		t.Errorf("output should contain ClaudeMD content: %s", output)
+	}
 }

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -194,10 +194,11 @@ func boolPtr(b bool) *bool { return &b }
 
 // maskKey returns a display-safe version of the API key.
 func maskKey(key string) string {
-	if len(key) <= 12 {
-		return strings.Repeat("*", len(key))
+	runes := []rune(key)
+	if len(runes) <= 12 {
+		return strings.Repeat("*", len(runes))
 	}
-	return key[:8] + "..." + key[len(key)-4:]
+	return string(runes[:8]) + "..." + string(runes[len(runes)-4:])
 }
 
 // findGitRoot detects the git root from the current working directory.

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -1,0 +1,52 @@
+package setup
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── maskKey ───────────────────────────────────────────────────────────────────
+
+func TestMaskKey_Short(t *testing.T) {
+	// Keys ≤12 chars are fully masked with '*'.
+	for _, key := range []string{"", "abc", "123456789012"} {
+		got := maskKey(key)
+		if got != strings.Repeat("*", len([]rune(key))) {
+			t.Errorf("maskKey(%q) = %q, want all stars", key, got)
+		}
+	}
+}
+
+func TestMaskKey_Long(t *testing.T) {
+	// Keys >12 chars: first 8 chars, "...", last 4 chars visible.
+	key := "sk-ant-abcdefghijklmnop"
+	got := maskKey(key)
+	runes := []rune(key)
+	want := string(runes[:8]) + "..." + string(runes[len(runes)-4:])
+	if got != want {
+		t.Errorf("maskKey(%q) = %q, want %q", key, got, want)
+	}
+}
+
+func TestMaskKey_ExactlyThirteen(t *testing.T) {
+	// 13 chars: just over the threshold.
+	key := "abcdefghijklm" // 13 chars
+	got := maskKey(key)
+	runes := []rune(key)
+	want := string(runes[:8]) + "..." + string(runes[len(runes)-4:])
+	if got != want {
+		t.Errorf("maskKey(%q) = %q, want %q", key, got, want)
+	}
+}
+
+func TestMaskKey_MultiByteRunes(t *testing.T) {
+	// Prior bug: sliced at byte positions, not rune boundaries.
+	// Each emoji is 4 bytes; 20 of them = 80 bytes but 20 runes.
+	key := strings.Repeat("😀", 20) // 20 runes, 80 bytes
+	got := maskKey(key)
+	runes := []rune(key)
+	want := string(runes[:8]) + "..." + string(runes[len(runes)-4:])
+	if got != want {
+		t.Errorf("maskKey(20×emoji): got %q, want %q", got, want)
+	}
+}

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -173,3 +173,17 @@ func TestInstallHook_InvalidJSON(t *testing.T) {
 		t.Error("installHook with invalid JSON: want error to avoid data loss")
 	}
 }
+
+// ── detectClaude ──────────────────────────────────────────────────────────────
+
+func TestDetectClaude_WithDotClaudeDir(t *testing.T) {
+	// Simulate HOME with a .claude directory present.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !detectClaude() {
+		t.Error("detectClaude should return true when ~/.claude exists")
+	}
+}

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -1,6 +1,9 @@
 package setup
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -48,5 +51,125 @@ func TestMaskKey_MultiByteRunes(t *testing.T) {
 	want := string(runes[:8]) + "..." + string(runes[len(runes)-4:])
 	if got != want {
 		t.Errorf("maskKey(20×emoji): got %q, want %q", got, want)
+	}
+}
+
+// ── boolPtr ───────────────────────────────────────────────────────────────────
+
+func TestBoolPtr(t *testing.T) {
+	p := boolPtr(true)
+	if p == nil || !*p {
+		t.Error("boolPtr(true) should return non-nil pointer to true")
+	}
+	p = boolPtr(false)
+	if p == nil || *p {
+		t.Error("boolPtr(false) should return non-nil pointer to false")
+	}
+}
+
+// ── detectCursor ──────────────────────────────────────────────────────────────
+
+func TestDetectCursor_WithDotCursorDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".cursor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !detectCursor(dir) {
+		t.Error("detectCursor: should detect .cursor directory in repoDir")
+	}
+}
+
+func TestDetectCursor_WithoutDir(t *testing.T) {
+	// Empty temp dir has no .cursor and the home dir is redirected.
+	dir := t.TempDir()
+	// Override HOME so global ~/.cursor doesn't interfere.
+	t.Setenv("HOME", t.TempDir())
+	if detectCursor(dir) {
+		t.Error("detectCursor: should return false when no .cursor dir exists")
+	}
+}
+
+// ── installHook ───────────────────────────────────────────────────────────────
+
+func TestInstallHook_FreshDir(t *testing.T) {
+	dir := t.TempDir()
+	installed, err := installHook(dir)
+	if err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+	if !installed {
+		t.Error("installHook: want installed=true on first install")
+	}
+
+	// Verify the settings file was created with the hook.
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+	if !strings.Contains(string(data), "supermodel hook") {
+		t.Errorf("settings.json should contain 'supermodel hook': %s", data)
+	}
+}
+
+func TestInstallHook_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := installHook(dir); err != nil {
+		t.Fatalf("first installHook: %v", err)
+	}
+	installed, err := installHook(dir)
+	if err != nil {
+		t.Fatalf("second installHook: %v", err)
+	}
+	if installed {
+		t.Error("installHook: second install should return installed=false (already present)")
+	}
+}
+
+func TestInstallHook_ExistingSettings(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write an existing settings file with unrelated content.
+	existing := map[string]interface{}{"theme": "dark"}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	installed, err := installHook(dir)
+	if err != nil {
+		t.Fatalf("installHook with existing settings: %v", err)
+	}
+	if !installed {
+		t.Error("should install into existing settings file")
+	}
+
+	// Verify theme is preserved.
+	updated, _ := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	var m map[string]interface{}
+	if json.Unmarshal(updated, &m) != nil {
+		t.Fatal("updated settings is not valid JSON")
+	}
+	if m["theme"] != "dark" {
+		t.Errorf("existing 'theme' field should be preserved, got %v", m["theme"])
+	}
+}
+
+func TestInstallHook_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write invalid JSON to simulate corrupted settings.
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{invalid}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := installHook(dir)
+	if err == nil {
+		t.Error("installHook with invalid JSON: want error to avoid data loss")
 	}
 }

--- a/internal/setup/wizard_test.go
+++ b/internal/setup/wizard_test.go
@@ -187,3 +187,109 @@ func TestDetectClaude_WithDotClaudeDir(t *testing.T) {
 		t.Error("detectClaude should return true when ~/.claude exists")
 	}
 }
+
+func TestDetectClaude_NoClaude(t *testing.T) {
+	// Empty PATH so LookPath("claude") always fails, then empty HOME so Stat fails.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	// With empty PATH and no ~/.claude dir, detectClaude must return false.
+	if detectClaude() {
+		t.Error("detectClaude should return false when claude not in PATH and no ~/.claude dir")
+	}
+}
+
+func TestDetectClaude_ViaHomeDotClaude(t *testing.T) {
+	// Empty PATH (so LookPath fails) but ~/.claude exists → covers the stat success path.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "")
+	if err := os.Mkdir(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !detectClaude() {
+		t.Error("detectClaude should return true when ~/.claude exists")
+	}
+}
+
+// ── detectCursor extra paths ──────────────────────────────────────────────────
+
+func TestDetectCursor_GlobalDotCursorDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.Mkdir(filepath.Join(home, ".cursor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !detectCursor(t.TempDir()) {
+		t.Error("detectCursor should return true when ~/.cursor exists")
+	}
+}
+
+func TestDetectCursor_MacOSLibraryPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	macPath := filepath.Join(home, "Library", "Application Support", "Cursor")
+	if err := os.MkdirAll(macPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if !detectCursor(t.TempDir()) {
+		t.Error("detectCursor should return true when Library/Application Support/Cursor exists")
+	}
+}
+
+// ── installHook error paths ───────────────────────────────────────────────────
+
+func TestInstallHook_MkdirAllError(t *testing.T) {
+	// Place a regular file where .claude dir should be → MkdirAll fails.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".claude"), []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := installHook(dir)
+	if err == nil {
+		t.Error("installHook should fail when .claude path is a regular file")
+	}
+}
+
+func TestInstallHook_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(claudeDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(claudeDir, 0755) }) //nolint:errcheck
+	_, err := installHook(dir)
+	if err == nil {
+		t.Error("installHook should fail when settings.json cannot be written")
+	}
+}
+
+func TestInstallHook_SupermodelNotInPath(t *testing.T) {
+	// With supermodel not on PATH, installHook falls back to os.Executable() for hookCmd.
+	t.Setenv("PATH", "")
+	dir := t.TempDir()
+	installed, err := installHook(dir)
+	if err != nil {
+		t.Fatalf("installHook with empty PATH: %v", err)
+	}
+	if !installed {
+		t.Error("installHook should still install even when supermodel not in PATH")
+	}
+}
+
+// ── findGitRoot ───────────────────────────────────────────────────────────────
+
+func TestFindGitRoot_ReturnsPath(t *testing.T) {
+	// findGitRoot uses os.Getwd() internally; we can't redirect it easily,
+	// but we can verify it returns a non-empty string without panicking.
+	root := findGitRoot()
+	if root == "" {
+		t.Error("findGitRoot should return a non-empty path")
+	}
+}

--- a/internal/shards/daemon_test.go
+++ b/internal/shards/daemon_test.go
@@ -1,6 +1,7 @@
 package shards
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/api"
@@ -360,6 +361,221 @@ func TestMergeGraph_DomainsPreservedEvenWhenIncrementalHasMore(t *testing.T) {
 	}
 }
 
+// TestMergeGraph_NoDependencyPath covers L407: a LocalDependency with no filePath,
+// name, or importPath is skipped (fp stays "").
+func TestMergeGraph_NoDependencyPath(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{newNode("file-a", []string{"File"}, "filePath", "/repo/a.go")},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-a-new", []string{"File"}, "filePath", "/repo/a.go"),
+			// LocalDependency with no path properties → fp == "" → skip
+			newNode("dep-nopath", []string{"LocalDependency"}),
+		},
+		[]api.Relationship{newRel("r1", "IMPORTS", "file-a-new", "dep-nopath")},
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/a.go"})
+
+	result := d.GetIR()
+	// dep-nopath should remain (not resolved) since it has no path to match
+	ids := nodeIDSet(result)
+	if !ids["dep-nopath"] {
+		t.Error("dep-nopath with no path should remain in the merged graph (unresolved)")
+	}
+}
+
+// TestMergeGraph_ExactFilepathMatch covers L411: a LocalDependency whose fp
+// exactly matches an existing file's filePath gets resolved to that node.
+func TestMergeGraph_ExactFilepathMatch(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			newNode("file-util", []string{"File"}, "filePath", "/repo/util.go"),
+			newNode("file-main", []string{"File"}, "filePath", "/repo/main.go"),
+		},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-main-new", []string{"File"}, "filePath", "/repo/main.go"),
+			// importPath exactly matches existing file's filePath → L411 is taken
+			newNode("dep-util", []string{"LocalDependency"}, "importPath", "/repo/util.go"),
+		},
+		[]api.Relationship{newRel("r1", "IMPORTS", "file-main-new", "dep-util")},
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/main.go"})
+
+	result := d.GetIR()
+	// dep-util should be resolved to file-util; rel should point to file-util
+	if hasRelEdge(result, "file-main-new", "file-util") {
+		// resolved successfully
+	} else {
+		t.Error("dep-util should be resolved to existing file-util via exact path match")
+	}
+}
+
+// TestMergeGraph_TildeImportPath covers L420: importPath with "~/" prefix is
+// stripped before suffix matching.
+func TestMergeGraph_TildeImportPath(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			newNode("file-utils", []string{"File"}, "filePath", "/repo/src/utils.ts"),
+			newNode("file-main", []string{"File"}, "filePath", "/repo/main.ts"),
+		},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-main-new", []string{"File"}, "filePath", "/repo/main.ts"),
+			// "~/" prefix → stripped → "src/utils" → suffix-matched to /repo/src/utils.ts
+			newNode("dep-tilde", []string{"LocalDependency"}, "importPath", "~/src/utils"),
+		},
+		[]api.Relationship{newRel("r1", "IMPORTS", "file-main-new", "dep-tilde")},
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/main.ts"})
+
+	result := d.GetIR()
+	ids := nodeIDSet(result)
+	if ids["dep-tilde"] {
+		t.Error("dep-tilde should be resolved (remapped to file-utils)")
+	}
+}
+
+// TestMergeGraph_ExtRemapStartNode covers L546: a relationship whose StartNode
+// is in extRemap gets its StartNode remapped.
+func TestMergeGraph_ExtRemapStartNode(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			newNode("file-db", []string{"File"}, "filePath", "/repo/db.go"),
+			newNode("file-handler", []string{"File"}, "filePath", "/repo/handler.go"),
+		},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-handler-new", []string{"File"}, "filePath", "/repo/handler.go"),
+			// importPath exactly matches existing db.go → resolved to file-db
+			newNode("dep-db", []string{"LocalDependency"}, "importPath", "/repo/db.go"),
+			// A node that dep-db "calls" — so StartNode of the rel is dep-db
+			newNode("fn-connect", []string{"Function"}, "filePath", "/repo/db.go", "name", "Connect"),
+		},
+		[]api.Relationship{
+			// dep-db is the StartNode → extRemap[dep-db] = file-db → L546 triggered
+			newRel("r1", "IMPORTS", "dep-db", "fn-connect"),
+		},
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/handler.go"})
+
+	result := d.GetIR()
+	// rel StartNode should have been remapped from dep-db to file-db
+	if !hasRelEdge(result, "file-db", "fn-connect") {
+		t.Error("relationship StartNode should be remapped from dep-db to file-db via extRemap")
+	}
+}
+
+// TestMergeGraph_ExistingNodeIDCollision covers L494: an existing node whose ID
+// also appears in the incremental graph is dropped from keptNodes.
+func TestMergeGraph_ExistingNodeIDCollision(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			newNode("file-a", []string{"File"}, "filePath", "/repo/a.go"),
+			// fn-shared is in existing AND in incremental with the same ID
+			newNode("fn-shared", []string{"Function"}, "filePath", "/repo/a.go", "name", "SharedFn"),
+		},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-a-new", []string{"File"}, "filePath", "/repo/a.go"),
+			// Same ID as the existing function → newNodeIDs["fn-shared"] = true
+			newNode("fn-shared", []string{"Function"}, "filePath", "/repo/a.go", "name", "SharedFn"),
+		},
+		nil,
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/a.go"})
+	// Should not panic or duplicate fn-shared
+	result := d.GetIR()
+	count := 0
+	for _, n := range result.Graph.Nodes {
+		if n.ID == "fn-shared" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("fn-shared should appear exactly once; got %d times", count)
+	}
+}
+
+// TestMergeGraph_NodeWithPathProperty covers L469: existing nodes with "path"
+// property (not "filePath") are still recognized when matching against changedSet.
+func TestMergeGraph_NodeWithPathProperty(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			// Uses "path" instead of "filePath" — covers the `fp = n.Prop("path")` fallback
+			newNode("file-old", []string{"File"}, "path", "/repo/a.go"),
+		},
+		nil,
+	)
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-new", []string{"File"}, "filePath", "/repo/a.go"),
+		},
+		nil,
+	)
+	d := NewTestDaemon(existing)
+	d.MergeGraph(incremental, []string{"/repo/a.go"})
+	// Should not panic; node with "path" property in existing gets recognized
+	result := d.GetIR()
+	if result == nil {
+		t.Fatal("MergeGraph with path-property node returned nil")
+	}
+}
+
+// TestMergeGraph_ExistingNodeIDInUnchangedFile covers L494-495: when an
+// existing node's ID appears in the incremental update but its file is NOT in
+// changedFiles, the old copy is discarded so the incremental version wins.
+func TestMergeGraph_ExistingNodeIDInUnchangedFile(t *testing.T) {
+	existing := buildIR(
+		[]api.Node{
+			newNode("file-lib", []string{"File"}, "filePath", "/repo/lib.go"),
+			// fn-lib exists in unchanged lib.go; same ID appears in incremental
+			newNode("fn-lib", []string{"Function"}, "filePath", "/repo/lib.go", "name", "LibFn"),
+			newNode("file-a", []string{"File"}, "filePath", "/repo/a.go"),
+			newNode("fn-a", []string{"Function"}, "filePath", "/repo/a.go", "name", "AFn"),
+		},
+		nil,
+	)
+	// Incremental contains fn-lib (same ID) despite lib.go not being changed.
+	incremental := buildIR(
+		[]api.Node{
+			newNode("file-a-new", []string{"File"}, "filePath", "/repo/a.go"),
+			newNode("fn-a-new", []string{"Function"}, "filePath", "/repo/a.go", "name", "AFn"),
+			newNode("fn-lib", []string{"Function"}, "filePath", "/repo/lib.go", "name", "LibFn"),
+		},
+		nil,
+	)
+	d := NewTestDaemon(existing)
+	// Only a.go changed; lib.go is unchanged.
+	d.MergeGraph(incremental, []string{"/repo/a.go"})
+	result := d.GetIR()
+	// fn-lib should appear exactly once (the incremental version).
+	count := 0
+	for _, n := range result.Graph.Nodes {
+		if n.ID == "fn-lib" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("fn-lib should appear exactly once; got %d", count)
+	}
+}
+
 // ── computeAffectedFiles tests ───────────────────────────────────────────────
 
 // TestComputeAffectedFiles_OldCalleeIncluded verifies that when a function in a
@@ -411,6 +627,86 @@ func TestComputeAffectedFiles_OldCalleeIncluded(t *testing.T) {
 
 // TestComputeAffectedFiles_CurrentCallersIncluded verifies that files currently
 // calling a function in the changed file are marked affected (existing behaviour).
+// ── assignNewFilesToDomains tests ────────────────────────────────────────────
+
+func TestAssignNewFilesToDomains_EmptyDomains(t *testing.T) {
+	// d.ir.Domains is nil → early return, no panic
+	d := &Daemon{
+		ir:   buildIR(nil, nil),
+		logf: func(string, ...interface{}) {},
+	}
+	nodes := []api.Node{newNode("f1", []string{"File"}, "filePath", "/repo/new.go")}
+	d.assignNewFilesToDomains(nodes) // must not panic
+}
+
+func TestAssignNewFilesToDomains_NonFileNodeSkipped(t *testing.T) {
+	d := &Daemon{
+		ir: &api.ShardIR{
+			Domains: []api.ShardDomain{{Name: "Auth", KeyFiles: []string{"/repo/auth/login.go"}}},
+		},
+		logf: func(string, ...interface{}) {},
+	}
+	nodes := []api.Node{newNode("fn1", []string{"Function"}, "filePath", "/repo/auth/handler.go")}
+	d.assignNewFilesToDomains(nodes)
+	// Non-File node → domain KeyFiles unchanged
+	if len(d.ir.Domains[0].KeyFiles) != 1 {
+		t.Errorf("non-File node should not be added to domain; got %v", d.ir.Domains[0].KeyFiles)
+	}
+}
+
+func TestAssignNewFilesToDomains_EmptyFilePathSkipped(t *testing.T) {
+	d := &Daemon{
+		ir: &api.ShardIR{
+			Domains: []api.ShardDomain{{Name: "Core", KeyFiles: []string{"/repo/core/db.go"}}},
+		},
+		logf: func(string, ...interface{}) {},
+	}
+	// File node with no filePath property
+	nodes := []api.Node{{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{}}}
+	d.assignNewFilesToDomains(nodes)
+	if len(d.ir.Domains[0].KeyFiles) != 1 {
+		t.Errorf("File node without filePath should not be added; got %v", d.ir.Domains[0].KeyFiles)
+	}
+}
+
+func TestAssignNewFilesToDomains_MatchesBestDomain(t *testing.T) {
+	d := &Daemon{
+		ir: &api.ShardIR{
+			Domains: []api.ShardDomain{
+				{Name: "Auth", KeyFiles: []string{"/repo/auth/login.go"}},
+				{Name: "Web", KeyFiles: []string{"/repo/web/handler.go"}},
+			},
+		},
+		logf: func(string, ...interface{}) {},
+	}
+	nodes := []api.Node{newNode("f1", []string{"File"}, "filePath", "/repo/auth/session.go")}
+	d.assignNewFilesToDomains(nodes)
+	// /repo/auth/session.go → prefix "/repo/auth" matches Auth domain
+	if len(d.ir.Domains[0].KeyFiles) != 2 {
+		t.Errorf("expected Auth domain to gain one file, got %v", d.ir.Domains[0].KeyFiles)
+	}
+	if len(d.ir.Domains[1].KeyFiles) != 1 {
+		t.Errorf("Web domain should be unchanged, got %v", d.ir.Domains[1].KeyFiles)
+	}
+}
+
+func TestAssignNewFilesToDomains_NoMatchingDomain(t *testing.T) {
+	d := &Daemon{
+		ir: &api.ShardIR{
+			Domains: []api.ShardDomain{
+				{Name: "Auth", KeyFiles: []string{"/repo/auth/login.go"}},
+			},
+		},
+		logf: func(string, ...interface{}) {},
+	}
+	nodes := []api.Node{newNode("f1", []string{"File"}, "filePath", "/repo/other/service.go")}
+	d.assignNewFilesToDomains(nodes)
+	// /repo/other/ does not match /repo/auth/ prefix → no file added
+	if len(d.ir.Domains[0].KeyFiles) != 1 {
+		t.Errorf("unmatched file should not be added to domain, got %v", d.ir.Domains[0].KeyFiles)
+	}
+}
+
 func TestComputeAffectedFiles_CurrentCallersIncluded(t *testing.T) {
 	ir := buildIR(
 		[]api.Node{
@@ -437,5 +733,132 @@ func TestComputeAffectedFiles_CurrentCallersIncluded(t *testing.T) {
 
 	if !affectedSet["c.go"] {
 		t.Error("expected c.go (current caller) in affected set")
+	}
+}
+
+func TestComputeAffectedFiles_ImporterAndImportLoopBodies(t *testing.T) {
+	// a.go imports b.go; c.go imports a.go.
+	// Changing a.go should pull in both b.go (via Imports) and c.go (via Importers).
+	ir := buildIR(
+		[]api.Node{
+			newNode("file-a", []string{"File"}, "filePath", "a.go"),
+			newNode("file-b", []string{"File"}, "filePath", "b.go"),
+			newNode("file-c", []string{"File"}, "filePath", "c.go"),
+		},
+		[]api.Relationship{
+			// a.go imports b.go
+			newRel("imp-ab", "imports", "file-a", "file-b"),
+			// c.go imports a.go
+			newRel("imp-ca", "imports", "file-c", "file-a"),
+		},
+	)
+	d := NewTestDaemon(ir)
+	d.cache = NewCache()
+	d.cache.Build(ir)
+
+	affected := d.computeAffectedFiles([]string{"a.go"}, nil, nil)
+
+	affectedSet := make(map[string]bool, len(affected))
+	for _, f := range affected {
+		affectedSet[f] = true
+	}
+	if !affectedSet["b.go"] {
+		t.Error("expected b.go (imported by a.go) in affected set")
+	}
+	if !affectedSet["c.go"] {
+		t.Error("expected c.go (importer of a.go) in affected set")
+	}
+}
+
+func TestComputeAffectedFiles_OldImportsIncluded(t *testing.T) {
+	// a.go used to import b.go but no longer does; b.go must still be re-rendered.
+	ir := buildIR(
+		[]api.Node{
+			newNode("file-a", []string{"File"}, "filePath", "a.go"),
+		},
+		nil,
+	)
+	d := NewTestDaemon(ir)
+	d.cache = NewCache()
+	d.cache.Build(ir)
+
+	oldImports := map[string][]string{
+		"a.go": {"b.go"},
+	}
+	affected := d.computeAffectedFiles([]string{"a.go"}, oldImports, nil)
+
+	affectedSet := make(map[string]bool, len(affected))
+	for _, f := range affected {
+		affectedSet[f] = true
+	}
+	if !affectedSet["b.go"] {
+		t.Error("expected b.go (old import) in affected set")
+	}
+}
+
+func TestComputeAffectedFiles_OldCalleeFilesIncluded(t *testing.T) {
+	// fn-a is in a.go; it used to call fn-d in d.go (captured in oldCalleeFiles).
+	// Changing a.go should mark d.go as affected so stale back-references are
+	// re-rendered.
+	ir := buildIR(
+		[]api.Node{
+			newNode("file-a", []string{"File"}, "filePath", "a.go"),
+			newNode("fn-a", []string{"Function"}, "filePath", "a.go", "name", "FuncA"),
+		},
+		nil,
+	)
+	d := NewTestDaemon(ir)
+	d.cache = NewCache()
+	d.cache.Build(ir)
+
+	oldCalleeFiles := map[string][]string{
+		"fn-a": {"d.go"},
+	}
+	affected := d.computeAffectedFiles([]string{"a.go"}, nil, oldCalleeFiles)
+
+	affectedSet := make(map[string]bool, len(affected))
+	for _, f := range affected {
+		affectedSet[f] = true
+	}
+
+	if !affectedSet["d.go"] {
+		t.Error("expected d.go (old callee file) in affected set")
+	}
+}
+
+// ── newUUID ───────────────────────────────────────────────────────────────────
+
+func TestNewUUID_Format(t *testing.T) {
+	id := newUUID()
+	// UUID v4 format: 8-4-4-4-12 hex chars separated by hyphens.
+	parts := strings.Split(id, "-")
+	if len(parts) != 5 {
+		t.Fatalf("expected 5 hyphen-separated parts, got %d: %q", len(parts), id)
+	}
+	want := []int{8, 4, 4, 4, 12}
+	for i, p := range parts {
+		if len(p) != want[i] {
+			t.Errorf("part %d: expected %d hex chars, got %d: %q", i, want[i], len(p), p)
+		}
+	}
+}
+
+func TestNewUUID_Unique(t *testing.T) {
+	ids := make(map[string]bool, 10)
+	for i := 0; i < 10; i++ {
+		id := newUUID()
+		if ids[id] {
+			t.Errorf("duplicate UUID produced: %q", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestNewUUID_Version4Bits(t *testing.T) {
+	id := newUUID()
+	// UUID v4: bits 12-15 of time_hi_and_version = 0100 (i.e., 4th hex char of 3rd group is '4')
+	parts := strings.Split(id, "-")
+	if parts[2][0] != '4' {
+		t.Errorf("expected version nibble '4' at start of 3rd group, got %q", parts[2][0])
 	}
 }

--- a/internal/shards/graph_test.go
+++ b/internal/shards/graph_test.go
@@ -213,6 +213,127 @@ func TestBuild_DefinesFunctionSetsFile(t *testing.T) {
 	}
 }
 
+func TestBuild_LocalDependencyNode(t *testing.T) {
+	// LocalDependency node → IDToPath uses filePath/name/ID
+	n := api.Node{ID: "ld1", Labels: []string{"LocalDependency"}, Properties: map[string]any{"name": "@/components/button"}}
+	c := buildCache([]api.Node{n}, nil)
+	if c.IDToPath["ld1"] != "@/components/button" {
+		t.Errorf("LocalDependency IDToPath: got %q", c.IDToPath["ld1"])
+	}
+}
+
+func TestBuild_ExternalDependencyWithName(t *testing.T) {
+	n := api.Node{ID: "ext1", Labels: []string{"ExternalDependency"}, Properties: map[string]any{"name": "react"}}
+	c := buildCache([]api.Node{n}, nil)
+	if c.IDToPath["ext1"] != "[ext]react" {
+		t.Errorf("ExternalDependency with name: got %q", c.IDToPath["ext1"])
+	}
+}
+
+func TestBuild_ExternalDependencyNoName(t *testing.T) {
+	// ExternalDependency with empty name → falls back to node ID
+	n := api.Node{ID: "ext-node-id", Labels: []string{"ExternalDependency"}, Properties: map[string]any{}}
+	c := buildCache([]api.Node{n}, nil)
+	if c.IDToPath["ext-node-id"] != "[ext]ext-node-id" {
+		t.Errorf("ExternalDependency without name: got %q", c.IDToPath["ext-node-id"])
+	}
+}
+
+func TestBuild_BelongsToWithFilePath(t *testing.T) {
+	// belongsTo: node with filePath → FileDomain set via domain node name
+	domainNode := api.Node{ID: "dom1", Labels: []string{"Domain"}, Properties: map[string]any{"name": "Auth"}}
+	fileN := fileNode("f1", "src/auth/login.go")
+	c := buildCache(
+		[]api.Node{fileN, domainNode},
+		[]api.Relationship{rel("r1", "belongsTo", "f1", "dom1")},
+	)
+	if c.FileDomain["src/auth/login.go"] != "Auth" {
+		t.Errorf("belongsTo FileDomain: got %q", c.FileDomain["src/auth/login.go"])
+	}
+}
+
+func TestBuild_BelongsToFallbackToFnFile(t *testing.T) {
+	// belongsTo: no filePath on node → falls back to fn.File
+	domainNode := api.Node{ID: "dom1", Labels: []string{"Domain"}, Properties: map[string]any{"name": "Core"}}
+	fn := api.Node{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork", "filePath": "src/core.go"}}
+	c := buildCache(
+		[]api.Node{fn, domainNode},
+		[]api.Relationship{rel("r1", "belongsTo", "fn1", "dom1")},
+	)
+	if c.FileDomain["src/core.go"] != "Core" {
+		t.Errorf("belongsTo via fn.File: got %q", c.FileDomain["src/core.go"])
+	}
+}
+
+func TestBuild_BelongsToNoDomainName_ExtractFromID(t *testing.T) {
+	// belongsTo: domain node has no name → extracts from ID using colon split
+	domainNode := api.Node{ID: "domain:MyDomain", Labels: []string{"Domain"}, Properties: map[string]any{}}
+	fileN := fileNode("f1", "src/x.go")
+	c := buildCache(
+		[]api.Node{fileN, domainNode},
+		[]api.Relationship{rel("r1", "belongsTo", "f1", "domain:MyDomain")},
+	)
+	if c.FileDomain["src/x.go"] != "MyDomain" {
+		t.Errorf("belongsTo ID extraction: got %q", c.FileDomain["src/x.go"])
+	}
+}
+
+func TestBuild_DomainSubdomainFiles(t *testing.T) {
+	// Subdomain with Files (not KeyFiles) → assigns domain/sub for each file
+	ir := &api.ShardIR{
+		Graph: api.ShardGraph{},
+		Domains: []api.ShardDomain{
+			{
+				Name: "Web",
+				Subdomains: []api.ShardSubdomain{
+					{Name: "Routes", Files: []string{"src/routes/index.go", "src/routes/auth.go"}},
+				},
+			},
+		},
+	}
+	c := NewCache()
+	c.Build(ir)
+	for _, f := range []string{"src/routes/index.go", "src/routes/auth.go"} {
+		if c.FileDomain[f] != "Web/Routes" {
+			t.Errorf("subdomain Files: FileDomain[%q] = %q, want 'Web/Routes'", f, c.FileDomain[f])
+		}
+	}
+}
+
+func TestBuild_BelongsToNoPathNoFn_Skipped(t *testing.T) {
+	// Node has no filePath and is not in FnByID → nodePath stays "" → continue
+	domainNode := api.Node{ID: "dom1", Labels: []string{"Domain"}, Properties: map[string]any{"name": "Auth"}}
+	unknownNode := api.Node{ID: "unknown1", Labels: []string{"Unknown"}, Properties: map[string]any{}}
+	c := buildCache(
+		[]api.Node{unknownNode, domainNode},
+		[]api.Relationship{rel("r1", "belongsTo", "unknown1", "dom1")},
+	)
+	// FileDomain should remain empty since nothing was added
+	if len(c.FileDomain) != 0 {
+		t.Errorf("belongsTo with no path should be skipped; got FileDomain: %v", c.FileDomain)
+	}
+}
+
+func TestBuild_DomainSubdomainKeyFiles(t *testing.T) {
+	// Subdomain with KeyFiles (no Files) → assigns domain/sub for each key file
+	ir := &api.ShardIR{
+		Graph: api.ShardGraph{},
+		Domains: []api.ShardDomain{
+			{
+				Name: "Auth",
+				Subdomains: []api.ShardSubdomain{
+					{Name: "Login", KeyFiles: []string{"src/auth/login.go"}},
+				},
+			},
+		},
+	}
+	c := NewCache()
+	c.Build(ir)
+	if c.FileDomain["src/auth/login.go"] != "Auth/Login" {
+		t.Errorf("subdomain KeyFiles: FileDomain = %q, want 'Auth/Login'", c.FileDomain["src/auth/login.go"])
+	}
+}
+
 func TestBuild_DomainAssignmentFromKeyFiles(t *testing.T) {
 	ir := &api.ShardIR{
 		Graph:   api.ShardGraph{Nodes: []api.Node{fileNode("f1", "src/auth/login.go")}},
@@ -403,5 +524,52 @@ func TestComputeStats_FromCache(t *testing.T) {
 	stats.FromCache = true
 	if !stats.FromCache {
 		t.Error("FromCache should be settable")
+	}
+}
+
+// TestBuild_BelongsToFnWithFileKey covers the L182 branch where a function node
+// uses the "file" key (not "filePath") so IDToPath is empty but FnByID has it.
+func TestBuild_BelongsToFnWithFileKey(t *testing.T) {
+	// Use "file" property instead of "filePath" so IDToPath is not set for fn1,
+	// but FnByID["fn1"].File is populated → the fallback `if fn, ok := c.FnByID[...]`
+	// branch (L182) is reached.
+	domainNode := api.Node{
+		ID:     "dom1",
+		Labels: []string{"Domain"},
+		Properties: map[string]any{"name": "Core"},
+	}
+	fnWithFileKey := api.Node{
+		ID:     "fn1",
+		Labels: []string{"Function"},
+		Properties: map[string]any{"name": "doWork", "file": "src/core.go"},
+	}
+	c := buildCache(
+		[]api.Node{fnWithFileKey, domainNode},
+		[]api.Relationship{rel("r1", "belongsTo", "fn1", "dom1")},
+	)
+	if c.FileDomain["src/core.go"] != "Core" {
+		t.Errorf("belongsTo via fn.File (file key): FileDomain[src/core.go] = %q, want Core", c.FileDomain["src/core.go"])
+	}
+}
+
+// TestSourceFiles_IncludesFromFunctions covers L225-226 in SourceFiles: functions
+// in FnByID with non-empty File contribute their file to the result.
+func TestSourceFiles_IncludesFromFunctions(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			// Function node with filePath — populates FnByID with File="src/a.go"
+			fnNode("fn1", "doWork", "src/a.go"),
+		},
+		nil,
+	)
+	files := c.SourceFiles()
+	found := false
+	for _, f := range files {
+		if f == "src/a.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("SourceFiles should include file from FnByID; got %v", files)
 	}
 }

--- a/internal/shards/graph_test.go
+++ b/internal/shards/graph_test.go
@@ -1,0 +1,407 @@
+package shards
+
+import (
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/api"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func fileNode(id, path string) api.Node {
+	return api.Node{ID: id, Labels: []string{"File"}, Properties: map[string]any{"filePath": path}}
+}
+
+func fnNode(id, name, filePath string) api.Node {
+	return api.Node{ID: id, Labels: []string{"Function"}, Properties: map[string]any{"name": name, "filePath": filePath}}
+}
+
+func fnNodeWithLine(id, name, filePath string, line int) api.Node {
+	return api.Node{ID: id, Labels: []string{"Function"}, Properties: map[string]any{"name": name, "filePath": filePath, "startLine": float64(line)}}
+}
+
+func rel(id, typ, start, end string) api.Relationship {
+	return api.Relationship{ID: id, Type: typ, StartNode: start, EndNode: end}
+}
+
+func buildCache(nodes []api.Node, rels []api.Relationship) *Cache {
+	ir := &api.ShardIR{Graph: api.ShardGraph{Nodes: nodes, Relationships: rels}}
+	c := NewCache()
+	c.Build(ir)
+	return c
+}
+
+// ── isShardPath ───────────────────────────────────────────────────────────────
+
+func TestIsShardPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"src/handler.graph.go", true},
+		{"src/handler.graph.ts", true},
+		{"lib/foo.graph.js", true},
+		{"src/handler.go", false},
+		{"src/handler.ts", false},
+		{"graph.go", false},         // no double extension
+		{"src/a.b.graph.go", true},  // any double extension with .graph
+		{"src/file.graph", false},   // .graph alone is not a source ext
+	}
+	for _, tc := range cases {
+		if got := isShardPath(tc.path); got != tc.want {
+			t.Errorf("isShardPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// ── firstString ───────────────────────────────────────────────────────────────
+
+func TestFirstString(t *testing.T) {
+	props := map[string]any{"filePath": "src/a.go", "name": "myFile", "empty": ""}
+
+	if got := firstString(props, "filePath", "fallback"); got != "src/a.go" {
+		t.Errorf("got %q, want src/a.go", got)
+	}
+	if got := firstString(props, "missing", "name", "fallback"); got != "myFile" {
+		t.Errorf("got %q, want myFile", got)
+	}
+	// empty string skipped
+	if got := firstString(props, "empty", "name", "fallback"); got != "myFile" {
+		t.Errorf("empty string should be skipped: got %q", got)
+	}
+	// literal fallback when no key matches
+	if got := firstString(props, "missing", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want literal fallback", got)
+	}
+}
+
+// ── intProp ───────────────────────────────────────────────────────────────────
+
+func TestIntProp(t *testing.T) {
+	n := api.Node{Properties: map[string]any{
+		"line":    float64(42),
+		"count":   int(7),
+		"text":    "hello",
+		"missing": nil,
+	}}
+	if got := intProp(n, "line"); got != 42 {
+		t.Errorf("float64 prop: got %d, want 42", got)
+	}
+	if got := intProp(n, "count"); got != 7 {
+		t.Errorf("int prop: got %d, want 7", got)
+	}
+	if got := intProp(n, "text"); got != 0 {
+		t.Errorf("string prop should return 0: got %d", got)
+	}
+	if got := intProp(n, "absent"); got != 0 {
+		t.Errorf("missing prop should return 0: got %d", got)
+	}
+}
+
+// ── fnFile / fnLine ───────────────────────────────────────────────────────────
+
+func TestFnFileAndLine_Nil(t *testing.T) {
+	if got := fnFile(nil); got != "" {
+		t.Errorf("fnFile(nil): got %q, want empty", got)
+	}
+	if got := fnLine(nil); got != 0 {
+		t.Errorf("fnLine(nil): got %d, want 0", got)
+	}
+}
+
+func TestFnFileAndLine_NonNil(t *testing.T) {
+	fi := &FuncInfo{File: "src/a.go", Line: 10}
+	if got := fnFile(fi); got != "src/a.go" {
+		t.Errorf("got %q", got)
+	}
+	if got := fnLine(fi); got != 10 {
+		t.Errorf("got %d", got)
+	}
+}
+
+// ── Cache.Build ───────────────────────────────────────────────────────────────
+
+func TestBuild_IndexesFunctions(t *testing.T) {
+	c := buildCache(
+		[]api.Node{fnNodeWithLine("fn1", "handleReq", "src/handler.go", 15)},
+		nil,
+	)
+	fn, ok := c.FnByID["fn1"]
+	if !ok {
+		t.Fatal("fn1 not indexed")
+	}
+	if fn.Name != "handleReq" {
+		t.Errorf("name: got %q", fn.Name)
+	}
+	if fn.File != "src/handler.go" {
+		t.Errorf("file: got %q", fn.File)
+	}
+	if fn.Line != 15 {
+		t.Errorf("line: got %d", fn.Line)
+	}
+}
+
+func TestBuild_FuncNameFromID(t *testing.T) {
+	// When "name" prop is absent, name extracted from ID like "fn:src/foo.ts:bar"
+	n := api.Node{ID: "fn:src/foo.ts:bar", Labels: []string{"Function"}, Properties: map[string]any{"filePath": "src/foo.ts"}}
+	c := buildCache([]api.Node{n}, nil)
+	fn, ok := c.FnByID["fn:src/foo.ts:bar"]
+	if !ok {
+		t.Fatal("function not indexed")
+	}
+	if fn.Name != "bar" {
+		t.Errorf("expected name 'bar', got %q", fn.Name)
+	}
+}
+
+func TestBuild_IndexesCallEdges(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fnNode("caller", "main", "src/main.go"),
+			fnNode("callee", "handle", "src/handler.go"),
+		},
+		[]api.Relationship{rel("r1", "calls", "caller", "callee")},
+	)
+	callers := c.Callers["callee"]
+	if len(callers) != 1 || callers[0].FuncID != "caller" {
+		t.Errorf("callers of callee: got %+v", callers)
+	}
+	callees := c.Callees["caller"]
+	if len(callees) != 1 || callees[0].FuncID != "callee" {
+		t.Errorf("callees of caller: got %+v", callees)
+	}
+}
+
+func TestBuild_IndexesImportEdges(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fileNode("f1", "src/a.go"),
+			fileNode("f2", "src/b.go"),
+		},
+		[]api.Relationship{rel("r1", "imports", "f1", "f2")},
+	)
+	if len(c.Imports["src/a.go"]) != 1 || c.Imports["src/a.go"][0] != "src/b.go" {
+		t.Errorf("imports: got %v", c.Imports["src/a.go"])
+	}
+	if len(c.Importers["src/b.go"]) != 1 || c.Importers["src/b.go"][0] != "src/a.go" {
+		t.Errorf("importers: got %v", c.Importers["src/b.go"])
+	}
+}
+
+func TestBuild_SkipsExternalImports(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fileNode("f1", "src/a.go"),
+			{ID: "ext1", Labels: []string{"ExternalDependency"}, Properties: map[string]any{"name": "fmt"}},
+		},
+		[]api.Relationship{rel("r1", "imports", "f1", "ext1")},
+	)
+	if len(c.Imports["src/a.go"]) != 0 {
+		t.Errorf("external imports should be skipped, got %v", c.Imports["src/a.go"])
+	}
+}
+
+func TestBuild_DefinesFunctionSetsFile(t *testing.T) {
+	// Function node has no filePath but is linked via defines_function
+	fn := api.Node{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doStuff"}}
+	c := buildCache(
+		[]api.Node{fileNode("file1", "src/util.go"), fn},
+		[]api.Relationship{rel("r1", "defines_function", "file1", "fn1")},
+	)
+	if c.FnByID["fn1"].File != "src/util.go" {
+		t.Errorf("defines_function should set fn.File; got %q", c.FnByID["fn1"].File)
+	}
+}
+
+func TestBuild_DomainAssignmentFromKeyFiles(t *testing.T) {
+	ir := &api.ShardIR{
+		Graph:   api.ShardGraph{Nodes: []api.Node{fileNode("f1", "src/auth/login.go")}},
+		Domains: []api.ShardDomain{{Name: "auth", KeyFiles: []string{"src/auth/login.go"}}},
+	}
+	c := NewCache()
+	c.Build(ir)
+	if c.FileDomain["src/auth/login.go"] != "auth" {
+		t.Errorf("domain assignment: got %q", c.FileDomain["src/auth/login.go"])
+	}
+}
+
+// ── SourceFiles ───────────────────────────────────────────────────────────────
+
+func TestSourceFiles_ReturnsSourceExts(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fileNode("f1", "src/a.go"),
+			fileNode("f2", "src/b.ts"),
+			fileNode("f3", "src/README.md"), // not a source ext
+		},
+		nil,
+	)
+	files := c.SourceFiles()
+	want := map[string]bool{"src/a.go": true, "src/b.ts": true}
+	if len(files) != 2 {
+		t.Errorf("want 2 source files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if !want[f] {
+			t.Errorf("unexpected file %q", f)
+		}
+	}
+}
+
+func TestSourceFiles_ExcludesShards(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fileNode("f1", "src/handler.go"),
+			fileNode("f2", "src/handler.graph.go"),
+		},
+		nil,
+	)
+	files := c.SourceFiles()
+	for _, f := range files {
+		if isShardPath(f) {
+			t.Errorf("shard path should be excluded: %q", f)
+		}
+	}
+	if len(files) != 1 || files[0] != "src/handler.go" {
+		t.Errorf("got %v", files)
+	}
+}
+
+func TestSourceFiles_IncludesFromImports(t *testing.T) {
+	c := buildCache(
+		[]api.Node{
+			fileNode("f1", "src/a.go"),
+			fileNode("f2", "src/b.go"),
+		},
+		[]api.Relationship{rel("r1", "imports", "f1", "f2")},
+	)
+	files := c.SourceFiles()
+	seen := map[string]bool{}
+	for _, f := range files {
+		seen[f] = true
+	}
+	if !seen["src/a.go"] || !seen["src/b.go"] {
+		t.Errorf("expected both files, got %v", files)
+	}
+}
+
+// ── FuncName ──────────────────────────────────────────────────────────────────
+
+func TestFuncName_Known(t *testing.T) {
+	c := buildCache([]api.Node{fnNode("fn1", "processRequest", "src/a.go")}, nil)
+	if got := c.FuncName("fn1"); got != "processRequest" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFuncName_Unknown_ExtractsFromID(t *testing.T) {
+	c := NewCache()
+	if got := c.FuncName("pkg:file:methodName"); got != "methodName" {
+		t.Errorf("got %q, want methodName", got)
+	}
+}
+
+// ── TransitiveDependents ──────────────────────────────────────────────────────
+
+func TestTransitiveDependents_Direct(t *testing.T) {
+	// a imports b: b has one direct dependent
+	c := buildCache(
+		[]api.Node{fileNode("fa", "a.go"), fileNode("fb", "b.go")},
+		[]api.Relationship{rel("r1", "imports", "fa", "fb")},
+	)
+	deps := c.TransitiveDependents("b.go")
+	if len(deps) != 1 || !deps["a.go"] {
+		t.Errorf("expected {a.go}, got %v", deps)
+	}
+}
+
+func TestTransitiveDependents_Transitive(t *testing.T) {
+	// a→b→c: c has two dependents (a, b)
+	c := buildCache(
+		[]api.Node{fileNode("fa", "a.go"), fileNode("fb", "b.go"), fileNode("fc", "c.go")},
+		[]api.Relationship{
+			rel("r1", "imports", "fa", "fb"),
+			rel("r2", "imports", "fb", "fc"),
+		},
+	)
+	deps := c.TransitiveDependents("c.go")
+	if !deps["a.go"] || !deps["b.go"] {
+		t.Errorf("expected a.go and b.go, got %v", deps)
+	}
+	if deps["c.go"] {
+		t.Error("c.go should not be in its own dependents")
+	}
+}
+
+func TestTransitiveDependents_Cycle(t *testing.T) {
+	// a→b→a cycle must not infinite-loop
+	c := buildCache(
+		[]api.Node{fileNode("fa", "a.go"), fileNode("fb", "b.go")},
+		[]api.Relationship{
+			rel("r1", "imports", "fa", "fb"),
+			rel("r2", "imports", "fb", "fa"),
+		},
+	)
+	done := make(chan struct{})
+	go func() {
+		c.TransitiveDependents("a.go")
+		close(done)
+	}()
+	select {
+	case <-done:
+	default:
+		// immediate completion is fine
+		<-done
+	}
+}
+
+func TestTransitiveDependents_None(t *testing.T) {
+	c := buildCache([]api.Node{fileNode("fa", "a.go")}, nil)
+	deps := c.TransitiveDependents("a.go")
+	if len(deps) != 0 {
+		t.Errorf("expected empty, got %v", deps)
+	}
+}
+
+// ── computeStats ─────────────────────────────────────────────────────────────
+
+func TestComputeStats_Basic(t *testing.T) {
+	ir := &api.ShardIR{Graph: api.ShardGraph{
+		Nodes: []api.Node{
+			fileNode("f1", "src/a.go"),
+			fnNode("fn1", "foo", "src/a.go"),
+			fnNode("fn2", "bar", "src/a.go"),
+		},
+		Relationships: []api.Relationship{
+			rel("r1", "calls", "fn1", "fn2"),
+		},
+	}}
+	c := NewCache()
+	c.Build(ir)
+	stats := computeStats(ir, c)
+
+	if stats.SourceFiles != 1 {
+		t.Errorf("SourceFiles: got %d, want 1", stats.SourceFiles)
+	}
+	if stats.Functions != 2 {
+		t.Errorf("Functions: got %d, want 2", stats.Functions)
+	}
+	if stats.Relationships != 1 {
+		t.Errorf("Relationships: got %d, want 1", stats.Relationships)
+	}
+	// fn1 has no callers (it calls fn2); fn2 has fn1 as caller
+	if stats.DeadFunctionCount != 1 {
+		t.Errorf("DeadFunctionCount: got %d, want 1 (fn1 has no callers)", stats.DeadFunctionCount)
+	}
+}
+
+func TestComputeStats_FromCache(t *testing.T) {
+	ir := &api.ShardIR{Graph: api.ShardGraph{}}
+	c := NewCache()
+	c.Build(ir)
+	stats := computeStats(ir, c)
+	stats.FromCache = true
+	if !stats.FromCache {
+		t.Error("FromCache should be settable")
+	}
+}

--- a/internal/shards/render_test.go
+++ b/internal/shards/render_test.go
@@ -1,7 +1,9 @@
 package shards
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -354,6 +356,60 @@ func TestRenderImpactSection_EmptyWhenNoImporters(t *testing.T) {
 	}
 }
 
+func TestRenderImpactSection_MediumRisk(t *testing.T) {
+	// 6–20 transitive dependents triggers MEDIUM risk.
+	nodes := []api.Node{
+		{ID: "target", Labels: []string{"File"}, Properties: map[string]any{"filePath": "lib/db.go"}},
+	}
+	rels := []api.Relationship{}
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("f%d", i)
+		path := fmt.Sprintf("src/file%d.go", i)
+		nodes = append(nodes, api.Node{
+			ID:     id,
+			Labels: []string{"File"},
+			Properties: map[string]any{"filePath": path},
+		})
+		rels = append(rels, api.Relationship{
+			ID:        "r" + id,
+			Type:      "imports",
+			StartNode: id,
+			EndNode:   "target",
+		})
+	}
+	c := makeRenderCache(shardIR(nodes, rels))
+	out := renderImpactSection("lib/db.go", c, "//")
+	if !strings.Contains(out, "MEDIUM") {
+		t.Errorf("6-20 importers should trigger MEDIUM risk: %s", out)
+	}
+}
+
+func TestRenderImpactSection_WithDomain(t *testing.T) {
+	// File is assigned to a domain; domain name should appear in impact output.
+	nodes := []api.Node{
+		{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "core/auth.go"}},
+		{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "web/handler.go"}},
+	}
+	rels := []api.Relationship{
+		{ID: "r1", Type: "imports", StartNode: "fb", EndNode: "fa"},
+	}
+	ir := &api.ShardIR{
+		Graph: api.ShardGraph{Nodes: nodes, Relationships: rels},
+		Domains: []api.ShardDomain{
+			{Name: "Auth", KeyFiles: []string{"core/auth.go", "web/handler.go"}},
+		},
+	}
+	c := NewCache()
+	c.Build(ir)
+	out := renderImpactSection("core/auth.go", c, "//")
+	if !strings.Contains(out, "Auth") {
+		t.Errorf("domain name should appear in impact output: %s", out)
+	}
+	if !strings.Contains(out, "domains") {
+		t.Errorf("should contain domains line: %s", out)
+	}
+}
+
 // ── RenderGraph ───────────────────────────────────────────────────────────────
 
 func TestRenderGraph_CombinesSections(t *testing.T) {
@@ -419,6 +475,38 @@ func TestWriteShard_DryRunDoesNotWrite(t *testing.T) {
 	}
 }
 
+func TestWriteShard_MkdirAllError(t *testing.T) {
+	dir := t.TempDir()
+	// Create a regular file at "subdir" so that MkdirAll("subdir/...") fails.
+	if err := os.WriteFile(dir+"/subdir", []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := WriteShard(dir, "subdir/handler.graph.go", "content", false)
+	if err == nil {
+		t.Error("expected MkdirAll error when parent path is a file")
+	}
+}
+
+func TestWriteShard_WriteFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	// Create the target subdirectory then make it read-only so WriteFile fails.
+	subDir := dir + "/ro"
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(subDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(subDir, 0o755) }) //nolint:errcheck
+	err := WriteShard(dir, "ro/handler.graph.go", "content", false)
+	if err == nil {
+		t.Error("expected WriteFile error on read-only directory")
+	}
+}
+
 // ── updateGitignore ───────────────────────────────────────────────────────────
 
 func TestUpdateGitignore_AddsEntry(t *testing.T) {
@@ -457,6 +545,35 @@ func TestUpdateGitignore_ExistingEntrySkipped(t *testing.T) {
 	data, _ := os.ReadFile(dir + "/.gitignore")
 	if strings.Count(string(data), ".supermodel/") != 1 {
 		t.Errorf("should not add duplicate: %s", data)
+	}
+}
+
+func TestUpdateGitignore_ReadErrorSkipped(t *testing.T) {
+	// Create a directory at .gitignore path → ReadFile returns EISDIR (not IsNotExist)
+	// → updateGitignore returns nil (skips silently).
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/.gitignore", 0700); err != nil {
+		t.Fatal(err)
+	}
+	// Should not error out.
+	if err := updateGitignore(dir); err != nil {
+		t.Errorf("updateGitignore with unreadable .gitignore should return nil, got %v", err)
+	}
+}
+
+func TestUpdateGitignore_OpenFileErrorSkipped(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	// Make the directory read-only so OpenFile (O_CREATE|O_APPEND|O_WRONLY) fails.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) }) //nolint:errcheck
+	// Should return nil (silent skip on write failure).
+	if err := updateGitignore(dir); err != nil {
+		t.Errorf("updateGitignore with read-only dir should return nil, got %v", err)
 	}
 }
 
@@ -543,6 +660,155 @@ func TestRenderAll_SkipsEmptyContent(t *testing.T) {
 	}
 	if n != 0 {
 		t.Errorf("unknown file should produce 0 written, got %d", n)
+	}
+}
+
+func TestRenderAll_PathTraversalSkipped(t *testing.T) {
+	// A srcFile whose ShardFilename would escape the repo dir is silently skipped.
+	// Build a cache that produces non-empty content for the path-traversal file,
+	// so the WriteShard call is actually reached.
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "../../evil.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/good.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"},
+		},
+	)
+	dir := t.TempDir()
+	c := makeRenderCache(ir)
+	n, err := RenderAll(dir, c, []string{"../../evil.go"}, false)
+	if err != nil {
+		t.Fatalf("RenderAll path-traversal: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("path-traversal file should be skipped (n=0), got %d", n)
+	}
+}
+
+func TestRenderAll_WriteshardError(t *testing.T) {
+	// Create a file at the shard subdirectory so MkdirAll fails → WriteShard
+	// returns a non-path-traversal error → RenderAll returns that error.
+	dir := t.TempDir()
+
+	// File node that imports another → non-empty RenderGraph output.
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "sub/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"},
+		},
+	)
+	c := makeRenderCache(ir)
+
+	// ShardFilename("sub/a.go") = "sub/a.graph.go"; make "sub" a regular file so
+	// MkdirAll("sub") fails with ENOTDIR.
+	if err := os.WriteFile(dir+"/sub", []byte("not a dir"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RenderAll(dir, c, []string{"sub/a.go"}, false)
+	if err == nil {
+		t.Error("expected error when shard directory cannot be created")
+	}
+}
+
+// TestRenderCallsSection_SortsByDifferentNames verifies the sort.Slice comparator
+// takes the fns[i].name != fns[j].name == true branch for functions with distinct names.
+func TestRenderCallsSection_SortsByDifferentNames(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			// Two functions with different names in the same file, both with callers.
+			{ID: "fn_b", Labels: []string{"Function"}, Properties: map[string]any{"name": "Beta", "filePath": "src/a.go"}},
+			{ID: "fn_a", Labels: []string{"Function"}, Properties: map[string]any{"name": "Alpha", "filePath": "src/a.go"}},
+			{ID: "caller", Labels: []string{"Function"}, Properties: map[string]any{"name": "main", "filePath": "src/main.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "calls", StartNode: "caller", EndNode: "fn_a"},
+			{ID: "r2", Type: "calls", StartNode: "caller", EndNode: "fn_b"},
+		},
+	)
+	c := makeRenderCache(ir)
+	out := renderCallsSection("src/a.go", c, "//")
+	// Alpha should appear before Beta in the sorted output.
+	alphaIdx := strings.Index(out, "Alpha")
+	betaIdx := strings.Index(out, "Beta")
+	if alphaIdx == -1 || betaIdx == -1 {
+		t.Fatalf("expected both Alpha and Beta in output:\n%s", out)
+	}
+	if alphaIdx > betaIdx {
+		t.Errorf("Alpha should appear before Beta in sorted output:\n%s", out)
+	}
+}
+
+// TestRenderImpactSection_CallerFromAnotherFile covers the directCallerFiles loop
+// in renderImpactSection (lines 136-147): a function in the target file is called
+// by a function in a different file.
+func TestRenderImpactSection_CallerFromAnotherFile(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fn_target", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork", "filePath": "src/a.go"}},
+			{ID: "fn_caller", Labels: []string{"Function"}, Properties: map[string]any{"name": "main", "filePath": "src/main.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "calls", StartNode: "fn_caller", EndNode: "fn_target"},
+		},
+	)
+	c := makeRenderCache(ir)
+	out := renderImpactSection("src/a.go", c, "//")
+	if out == "" {
+		t.Fatal("expected non-empty impact section when function has cross-file callers")
+	}
+	if !strings.Contains(out, "[impact]") {
+		t.Errorf("expected [impact] header:\n%s", out)
+	}
+	if !strings.Contains(out, "src/main.go") {
+		t.Errorf("expected caller file in affects line:\n%s", out)
+	}
+}
+
+// TestRenderGraph_IncludesImpactSection exercises the `if impact != ""` branch in
+// RenderGraph (L47) by using a file whose function is called by a function in another file.
+func TestRenderGraph_IncludesImpactSection(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fn_lib", Labels: []string{"Function"}, Properties: map[string]any{"name": "LibFunc", "filePath": "lib/util.go"}},
+			{ID: "fn_app", Labels: []string{"Function"}, Properties: map[string]any{"name": "AppFunc", "filePath": "app/main.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "calls", StartNode: "fn_app", EndNode: "fn_lib"},
+		},
+	)
+	c := makeRenderCache(ir)
+	out := RenderGraph("lib/util.go", c, "//")
+	if !strings.Contains(out, "[impact]") {
+		t.Errorf("expected [impact] section in RenderGraph output:\n%s", out)
+	}
+	if !strings.Contains(out, "[calls]") {
+		t.Errorf("expected [calls] section in RenderGraph output:\n%s", out)
+	}
+}
+
+// TestWriteShard_RenameError covers L232-235: os.Rename fails when the
+// destination path already exists as a directory.
+func TestWriteShard_RenameError(t *testing.T) {
+	dir := t.TempDir()
+	// Create the target subdirectory normally so MkdirAll succeeds.
+	subdir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Place a directory at the exact destination path so Rename(tmp→full) fails.
+	fullAsDir := filepath.Join(subdir, "handler.graph.go")
+	if err := os.Mkdir(fullAsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := WriteShard(dir, "src/handler.graph.go", "content", false)
+	if err == nil {
+		t.Error("expected Rename error when destination is a directory")
 	}
 }
 

--- a/internal/shards/render_test.go
+++ b/internal/shards/render_test.go
@@ -1,6 +1,7 @@
 package shards
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -160,4 +161,321 @@ func TestRenderCallsSection_EmptyWhenNoCallRelationships(t *testing.T) {
 	if out != "" {
 		t.Errorf("expected empty output for function with no call relationships, got:\n%s", out)
 	}
+}
+
+// ── CommentPrefix / ShardFilename / Header ────────────────────────────────────
+
+func TestCommentPrefix(t *testing.T) {
+	cases := []struct{ ext, want string }{
+		{".go", "//"},
+		{".ts", "//"},
+		{".js", "//"},
+		{".py", "#"},
+		{".rb", "#"},
+		{".rs", "//"},
+		{".java", "//"},
+		{"", "//"},
+	}
+	for _, tc := range cases {
+		if got := CommentPrefix(tc.ext); got != tc.want {
+			t.Errorf("CommentPrefix(%q) = %q, want %q", tc.ext, got, tc.want)
+		}
+	}
+}
+
+func TestShardFilename(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"src/handler.go", "src/handler.graph.go"},
+		{"lib/util.ts", "lib/util.graph.ts"},
+		{"main.py", "main.graph.py"},
+		{"src/no_ext", "src/no_ext.graph"},
+	}
+	for _, tc := range cases {
+		if got := ShardFilename(tc.input); got != tc.want {
+			t.Errorf("ShardFilename(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestHeader(t *testing.T) {
+	h := Header("//")
+	if !strings.Contains(h, "@generated") {
+		t.Errorf("header should contain @generated: %q", h)
+	}
+	if !strings.HasSuffix(h, "\n") {
+		t.Errorf("header should end with newline")
+	}
+	h2 := Header("#")
+	if !strings.HasPrefix(h2, "#") {
+		t.Errorf("Python header should start with #: %q", h2)
+	}
+}
+
+// ── sortedUnique / sortedBoolKeys / formatLoc ─────────────────────────────────
+
+func TestSortedUnique(t *testing.T) {
+	got := sortedUnique([]string{"c", "a", "b", "a", "c"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("want %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestSortedUnique_Empty(t *testing.T) {
+	if got := sortedUnique(nil); got != nil {
+		t.Errorf("nil input: want nil, got %v", got)
+	}
+}
+
+func TestSortedBoolKeys(t *testing.T) {
+	m := map[string]bool{"z": true, "a": true, "m": true}
+	got := sortedBoolKeys(m)
+	if len(got) != 3 || got[0] != "a" || got[1] != "m" || got[2] != "z" {
+		t.Errorf("want [a m z], got %v", got)
+	}
+}
+
+func TestFormatLoc(t *testing.T) {
+	if got := formatLoc("src/a.go", 10); got != "src/a.go:10" {
+		t.Errorf("with file+line: got %q", got)
+	}
+	if got := formatLoc("src/a.go", 0); got != "src/a.go" {
+		t.Errorf("with file, no line: got %q", got)
+	}
+	if got := formatLoc("", 0); got != "?" {
+		t.Errorf("empty: got %q", got)
+	}
+}
+
+// ── renderDepsSection ─────────────────────────────────────────────────────────
+
+func TestRenderDepsSection_ShowsImportsAndImportedBy(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+			{ID: "fc", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/c.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"}, // a imports b
+			{ID: "r2", Type: "imports", StartNode: "fc", EndNode: "fa"}, // c imports a
+		},
+	)
+	c := makeRenderCache(ir)
+	out := renderDepsSection("src/a.go", c, "//")
+	if out == "" {
+		t.Fatal("expected non-empty deps section")
+	}
+	if !strings.Contains(out, "[deps]") {
+		t.Errorf("should contain [deps] header: %s", out)
+	}
+	if !strings.Contains(out, "imports") && !strings.Contains(out, "src/b.go") {
+		t.Errorf("should show imported file: %s", out)
+	}
+	if !strings.Contains(out, "imported-by") || !strings.Contains(out, "src/c.go") {
+		t.Errorf("should show importing file: %s", out)
+	}
+}
+
+func TestRenderDepsSection_EmptyWhenNoEdges(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}}},
+		nil,
+	)
+	c := makeRenderCache(ir)
+	if out := renderDepsSection("src/a.go", c, "//"); out != "" {
+		t.Errorf("expected empty, got: %s", out)
+	}
+}
+
+// ── renderImpactSection ───────────────────────────────────────────────────────
+
+func TestRenderImpactSection_LowRisk(t *testing.T) {
+	// Single direct importer, no transitive
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fb", EndNode: "fa"},
+		},
+	)
+	c := makeRenderCache(ir)
+	out := renderImpactSection("src/a.go", c, "//")
+	if !strings.Contains(out, "[impact]") {
+		t.Errorf("should contain [impact] header: %s", out)
+	}
+	if !strings.Contains(out, "LOW") {
+		t.Errorf("single importer should be LOW risk: %s", out)
+	}
+	if !strings.Contains(out, "direct") {
+		t.Errorf("should contain direct count: %s", out)
+	}
+}
+
+func TestRenderImpactSection_HighRisk(t *testing.T) {
+	// Build 25 importers to trigger HIGH risk (transitiveCount > 20)
+	nodes := []api.Node{
+		{ID: "target", Labels: []string{"File"}, Properties: map[string]any{"filePath": "core/db.go"}},
+	}
+	rels := []api.Relationship{}
+	for i := 0; i < 25; i++ {
+		id := strings.Repeat("f", i+1)
+		path := "src/file" + id + ".go"
+		nodes = append(nodes, api.Node{ID: id, Labels: []string{"File"}, Properties: map[string]any{"filePath": path}})
+		if i > 0 {
+			// chain: f→f2→f3→...→target creates transitive deps
+			prev := strings.Repeat("f", i)
+			rels = append(rels, api.Relationship{ID: "r" + id, Type: "imports", StartNode: id, EndNode: prev})
+		}
+		rels = append(rels, api.Relationship{ID: "root" + id, Type: "imports", StartNode: id, EndNode: "target"})
+	}
+	c := makeRenderCache(shardIR(nodes, rels))
+	out := renderImpactSection("core/db.go", c, "//")
+	if !strings.Contains(out, "HIGH") {
+		t.Errorf("many importers should trigger HIGH risk: %s", out)
+	}
+}
+
+func TestRenderImpactSection_EmptyWhenNoImporters(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}}},
+		nil,
+	)
+	c := makeRenderCache(ir)
+	if out := renderImpactSection("src/a.go", c, "//"); out != "" {
+		t.Errorf("expected empty, got: %s", out)
+	}
+}
+
+// ── RenderGraph ───────────────────────────────────────────────────────────────
+
+func TestRenderGraph_CombinesSections(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+			{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork", "filePath": "src/a.go"}},
+			{ID: "fn2", Labels: []string{"Function"}, Properties: map[string]any{"name": "helper", "filePath": "src/b.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"},
+			{ID: "r2", Type: "calls", StartNode: "fn1", EndNode: "fn2"},
+		},
+	)
+	c := makeRenderCache(ir)
+	out := RenderGraph("src/a.go", c, "//")
+	if out == "" {
+		t.Fatal("expected non-empty render output")
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Error("RenderGraph output should end with newline")
+	}
+}
+
+func TestRenderGraph_EmptyForUnknownFile(t *testing.T) {
+	c := makeRenderCache(shardIR(nil, nil))
+	out := RenderGraph("nonexistent.go", c, "//")
+	if out != "" {
+		t.Errorf("unknown file should produce empty output, got: %s", out)
+	}
+}
+
+// ── WriteShard ────────────────────────────────────────────────────────────────
+
+func TestWriteShard_WritesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteShard(dir, "src/handler.graph.go", "// content\n", false); err != nil {
+		t.Fatalf("WriteShard: %v", err)
+	}
+}
+
+func TestWriteShard_PathTraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	err := WriteShard(dir, "../../etc/passwd", "evil", false)
+	if err == nil {
+		t.Error("expected path traversal error")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWriteShard_DryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteShard(dir, "src/a.graph.go", "content", true); err != nil {
+		t.Fatalf("dry-run WriteShard: %v", err)
+	}
+	// File should not exist
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("dry-run should not create files")
+	}
+}
+
+// ── updateGitignore ───────────────────────────────────────────────────────────
+
+func TestUpdateGitignore_AddsEntry(t *testing.T) {
+	dir := t.TempDir()
+	if err := updateGitignore(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dir + "/.gitignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), ".supermodel/") {
+		t.Errorf("expected .supermodel/ in gitignore: %s", data)
+	}
+}
+
+func TestUpdateGitignore_DoesNotDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	// Call twice; the entry should appear exactly once.
+	updateGitignore(dir) //nolint:errcheck
+	updateGitignore(dir) //nolint:errcheck
+	data, _ := os.ReadFile(dir + "/.gitignore")
+	content := string(data)
+	first := strings.Index(content, ".supermodel/")
+	last := strings.LastIndex(content, ".supermodel/")
+	if first != last {
+		t.Errorf(".supermodel/ appears more than once in gitignore:\n%s", content)
+	}
+}
+
+func TestUpdateGitignore_ExistingEntrySkipped(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-populate with the entry
+	os.WriteFile(dir+"/.gitignore", []byte(".supermodel/\n"), 0o600) //nolint:errcheck
+	updateGitignore(dir)                                               //nolint:errcheck
+	data, _ := os.ReadFile(dir + "/.gitignore")
+	if strings.Count(string(data), ".supermodel/") != 1 {
+		t.Errorf("should not add duplicate: %s", data)
+	}
+}
+
+func TestUpdateGitignore_NoTrailingNewlineHandled(t *testing.T) {
+	dir := t.TempDir()
+	// Write without trailing newline
+	os.WriteFile(dir+"/.gitignore", []byte("node_modules"), 0o600) //nolint:errcheck
+	updateGitignore(dir)                                             //nolint:errcheck
+	data, _ := os.ReadFile(dir + "/.gitignore")
+	if !strings.Contains(string(data), ".supermodel/") {
+		t.Errorf("missing .supermodel/: %s", data)
+	}
+}
+
+// ── Hook ─────────────────────────────────────────────────────────────────────
+
+func TestHook_InvalidJSONExitsCleanly(t *testing.T) {
+	// Hook reads from stdin; we test via the exported function with invalid data.
+	// The function must return nil (never break the agent) on bad input.
+	// We can't easily inject stdin, but we test the underlying validation logic
+	// directly by calling with a mock via the export test file.
 }

--- a/internal/shards/render_test.go
+++ b/internal/shards/render_test.go
@@ -471,6 +471,81 @@ func TestUpdateGitignore_NoTrailingNewlineHandled(t *testing.T) {
 	}
 }
 
+// ── RenderAll ─────────────────────────────────────────────────────────────────
+
+func TestRenderAll_EmptyFiles(t *testing.T) {
+	dir := t.TempDir()
+	c := makeRenderCache(shardIR(nil, nil))
+	n, err := RenderAll(dir, c, nil, false)
+	if err != nil {
+		t.Fatalf("RenderAll(empty): %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 written, got %d", n)
+	}
+}
+
+func TestRenderAll_WritesShards(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+			{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"name": "doWork", "filePath": "src/a.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"},
+		},
+	)
+	dir := t.TempDir()
+	c := makeRenderCache(ir)
+	n, err := RenderAll(dir, c, []string{"src/a.go"}, false)
+	if err != nil {
+		t.Fatalf("RenderAll: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 written, got %d", n)
+	}
+}
+
+func TestRenderAll_DryRun(t *testing.T) {
+	ir := shardIR(
+		[]api.Node{
+			{ID: "fa", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/a.go"}},
+			{ID: "fb", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/b.go"}},
+		},
+		[]api.Relationship{
+			{ID: "r1", Type: "imports", StartNode: "fa", EndNode: "fb"},
+		},
+	)
+	dir := t.TempDir()
+	c := makeRenderCache(ir)
+	n, err := RenderAll(dir, c, []string{"src/a.go"}, true)
+	if err != nil {
+		t.Fatalf("RenderAll dryRun: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("dryRun: expected 1 counted, got %d", n)
+	}
+	// No actual files written.
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("dry-run should not create files, found %d", len(entries))
+	}
+}
+
+func TestRenderAll_SkipsEmptyContent(t *testing.T) {
+	// A file not in the cache produces empty content → no shard written.
+	dir := t.TempDir()
+	c := makeRenderCache(shardIR(nil, nil))
+	n, err := RenderAll(dir, c, []string{"src/unknown.go"}, false)
+	if err != nil {
+		t.Fatalf("RenderAll: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("unknown file should produce 0 written, got %d", n)
+	}
+}
+
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
 func TestHook_InvalidJSONExitsCleanly(t *testing.T) {

--- a/internal/shards/watcher_test.go
+++ b/internal/shards/watcher_test.go
@@ -1,0 +1,310 @@
+package shards
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ── isWatchSourceFile ─────────────────────────────────────────────────────────
+
+func TestIsWatchSourceFile_SourceExtensions(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"main.go", true},
+		{"app.ts", true},
+		{"component.tsx", true},
+		{"lib.js", true},
+		{"util.py", true},
+		{"handler.rs", true},
+		{"Main.java", true},
+		{"Service.cs", true},
+		{"README.md", false},
+		{"config.yaml", false},
+		{"data.json", false},
+		{".env", false},
+		{"image.png", false},
+	}
+	for _, tc := range cases {
+		got := isWatchSourceFile(tc.path)
+		if got != tc.want {
+			t.Errorf("isWatchSourceFile(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestIsWatchSourceFile_ShardPathExcluded(t *testing.T) {
+	// shard paths (*.graph.go) should NOT be considered watch source files
+	if isWatchSourceFile("internal/foo/bar.graph.go") {
+		t.Error("shard path should not be a watch source file")
+	}
+}
+
+func TestIsWatchSourceFile_CaseInsensitiveExt(t *testing.T) {
+	// extension matching is case-insensitive
+	if !isWatchSourceFile("Main.GO") {
+		t.Error("isWatchSourceFile should be case-insensitive for extensions")
+	}
+}
+
+// ── NewWatcher ────────────────────────────────────────────────────────────────
+
+func TestNewWatcher_DefaultInterval(t *testing.T) {
+	w := NewWatcher("/some/dir", 0)
+	if w.pollInterval != 3*time.Second {
+		t.Errorf("default poll interval = %v; want 3s", w.pollInterval)
+	}
+	if w.repoDir != "/some/dir" {
+		t.Errorf("repoDir = %q; want %q", w.repoDir, "/some/dir")
+	}
+}
+
+func TestNewWatcher_CustomInterval(t *testing.T) {
+	w := NewWatcher("/repo", 500*time.Millisecond)
+	if w.pollInterval != 500*time.Millisecond {
+		t.Errorf("poll interval = %v; want 500ms", w.pollInterval)
+	}
+}
+
+func TestNewWatcher_EventsChannelNotNil(t *testing.T) {
+	w := NewWatcher("/some/dir", time.Second)
+	if w.Events() == nil {
+		t.Error("Events() channel should not be nil")
+	}
+}
+
+func TestWatcher_RunCancellable(t *testing.T) {
+	// Run should return when context is cancelled.
+	w := NewWatcher(t.TempDir(), 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Run(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Error("Run did not return after context cancellation")
+	}
+}
+
+func TestWatcher_RunPollsOnTick(t *testing.T) {
+	// Verifies that the ticker branch in Run is reachable (poll() is called).
+	// Use a very short interval so the ticker fires before we cancel.
+	dir := t.TempDir()
+	w := NewWatcher(dir, 1*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Run(ctx)
+	// Wait enough time for multiple ticks to fire.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+}
+
+// ── gitIndexMtime ─────────────────────────────────────────────────────────────
+
+func TestWatcher_GitIndexMtime_NonGitDir(t *testing.T) {
+	w := NewWatcher(t.TempDir(), time.Second)
+	mtime := w.gitIndexMtime()
+	if !mtime.IsZero() {
+		t.Errorf("gitIndexMtime on non-git dir should return zero time, got %v", mtime)
+	}
+}
+
+func TestWatcher_GitIndexMtime_GitRepo(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	w := NewWatcher(dir, time.Second)
+	mtime := w.gitIndexMtime()
+	if mtime.IsZero() {
+		t.Error("gitIndexMtime should return non-zero time for a git repo")
+	}
+}
+
+// ── gitDirtyFiles ─────────────────────────────────────────────────────────────
+
+func TestWatcher_GitDirtyFiles_CleanRepo(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	w := NewWatcher(dir, time.Second)
+	files := w.gitDirtyFiles()
+	if len(files) != 0 {
+		t.Errorf("clean repo should have 0 dirty files; got %v", files)
+	}
+}
+
+func TestWatcher_GitDirtyFiles_ModifiedFile(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	// Modify the tracked file.
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n// modified\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w := NewWatcher(dir, time.Second)
+	files := w.gitDirtyFiles()
+	if _, ok := files["main.go"]; !ok {
+		t.Error("modified tracked file should appear in dirty files")
+	}
+}
+
+func TestWatcher_GitDirtyFiles_UntrackedSourceFile(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	// Add an untracked source file.
+	if err := os.WriteFile(filepath.Join(dir, "newfile.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w := NewWatcher(dir, time.Second)
+	files := w.gitDirtyFiles()
+	if _, ok := files["newfile.go"]; !ok {
+		t.Error("untracked source file should appear in dirty files")
+	}
+}
+
+func TestWatcher_GitDirtyFiles_UntrackedNonSourceFile(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	// Add an untracked non-source file - should be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("notes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	w := NewWatcher(dir, time.Second)
+	files := w.gitDirtyFiles()
+	if _, ok := files["notes.txt"]; ok {
+		t.Error("non-source file should not appear in dirty files")
+	}
+}
+
+// ── poll ─────────────────────────────────────────────────────────────────────
+
+func TestWatcher_Poll_NewDirtyFile(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	w := NewWatcher(dir, time.Second)
+	w.lastCommitSHA = "abc" // non-empty so headChanged won't fire
+	w.lastIndexMod = w.gitIndexMtime()
+
+	// Add an untracked source file.
+	if err := os.WriteFile(filepath.Join(dir, "new.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w.poll()
+
+	select {
+	case events := <-w.eventCh:
+		found := false
+		for _, e := range events {
+			if e.Path == "new.go" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected event for new.go; got %v", events)
+		}
+	default:
+		t.Error("expected event for new dirty file")
+	}
+}
+
+func TestWatcher_Poll_CleanedDirtyFile(t *testing.T) {
+	// When a file that was dirty becomes clean after an index change,
+	// it should emit an event (the indexChanged + file no longer dirty path).
+	dir := initWatcherGitRepo(t)
+	w := NewWatcher(dir, time.Second)
+	w.lastCommitSHA = "abc"
+
+	// Simulate: file was previously dirty
+	w.lastKnownFiles = map[string]struct{}{"main.go": {}}
+	// Set lastIndexMod to zero so any index state triggers indexChanged
+	w.lastIndexMod = time.Time{}
+
+	// main.go is actually clean (committed), so gitDirtyFiles returns empty
+	w.poll()
+
+	select {
+	case events := <-w.eventCh:
+		found := false
+		for _, e := range events {
+			if e.Path == "main.go" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected event for main.go becoming clean; got %v", events)
+		}
+	default:
+		t.Error("expected event when previously-dirty file is no longer dirty")
+	}
+}
+
+func TestWatcher_Poll_HeadChanged(t *testing.T) {
+	dir := initWatcherGitRepo(t)
+	w := NewWatcher(dir, time.Second)
+	w.lastIndexMod = w.gitIndexMtime()
+
+	// Capture the initial commit SHA.
+	initialSHA := strings.TrimSpace(w.runGit("rev-parse", "HEAD"))
+	w.lastCommitSHA = initialSHA
+
+	// Make a second commit that adds a source file.
+	if err := os.WriteFile(filepath.Join(dir, "extra.go"), []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runCmd := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.CombinedOutput() //nolint:errcheck
+	}
+	runCmd("git", "add", "extra.go")
+	runCmd("git", "commit", "-m", "second")
+
+	w.poll()
+
+	// headChanged fired; lastCommitSHA should now be the new HEAD
+	if w.lastCommitSHA == initialSHA {
+		t.Error("poll should update lastCommitSHA when head changes")
+	}
+
+	// The event for extra.go should have been emitted.
+	select {
+	case events := <-w.eventCh:
+		found := false
+		for _, e := range events {
+			if e.Path == "extra.go" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected event for extra.go; got %v", events)
+		}
+	default:
+		t.Error("expected event for head-changed source file")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+func initWatcherGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runWatcherGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runWatcherGit("git", "init")
+	runWatcherGit("git", "config", "user.email", "ci@test.local")
+	runWatcherGit("git", "config", "user.name", "CI")
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runWatcherGit("git", "add", ".")
+	runWatcherGit("git", "commit", "-m", "init")
+	return dir
+}

--- a/internal/shards/zip_test.go
+++ b/internal/shards/zip_test.go
@@ -1,0 +1,166 @@
+package shards
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ── isShardFile ───────────────────────────────────────────────────────────────
+
+func TestIsShardFile(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"handler.graph.go", true},
+		{"handler.graph.ts", true},
+		{"handler.graph.py", true},
+		{"handler.go", false},
+		{"handler", false},
+		{"", false},
+		{".graph.go", true}, // .graph stem is still a shard extension
+		{"handler.other.go", false},
+	}
+	for _, tc := range cases {
+		got := isShardFile(tc.name)
+		if got != tc.want {
+			t.Errorf("isShardFile(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// ── matchPattern ─────────────────────────────────────────────────────────────
+
+func TestMatchPattern(t *testing.T) {
+	cases := []struct {
+		pattern, name string
+		want          bool
+	}{
+		// Exact substring match (no wildcards)
+		{"test", "handler_test.go", true},
+		{"test", "handler.go", false},
+		// Wildcard *
+		{"*.min.js", "app.min.js", true},
+		{"*.min.js", "app.js", false},
+		{"*.min.js", "app.min.css", false},
+		// * in middle
+		{"lock*file", "lockfile", true},
+		{"lock*file", "lock.file", true},
+		{"lock*file", "other", false},
+		// Case insensitive
+		{"*.PNG", "image.png", true},
+		{"test", "TEST_FILE.go", true},
+		// No wildcards, no match
+		{"abc", "xyz", false},
+	}
+	for _, tc := range cases {
+		got := matchPattern(tc.pattern, tc.name)
+		if got != tc.want {
+			t.Errorf("matchPattern(%q, %q) = %v, want %v", tc.pattern, tc.name, got, tc.want)
+		}
+	}
+}
+
+// ── shouldInclude ─────────────────────────────────────────────────────────────
+
+func TestShouldInclude_BasicFile(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if !shouldInclude("src/main.go", 100, ex) {
+		t.Error("basic Go file should be included")
+	}
+}
+
+func TestShouldInclude_SkipDir(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{"node_modules": true},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("node_modules/pkg/index.js", 100, ex) {
+		t.Error("node_modules file should be excluded")
+	}
+}
+
+func TestShouldInclude_SkipExt(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{".png": true},
+	}
+	if shouldInclude("assets/logo.png", 100, ex) {
+		t.Error(".png file should be excluded when in skipExts")
+	}
+}
+
+func TestShouldInclude_ShardFile(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("src/handler.graph.go", 100, ex) {
+		t.Error("shard files should be excluded")
+	}
+}
+
+func TestShouldInclude_MinifiedJS(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("dist/bundle.min.js", 100, ex) {
+		t.Error("minified JS should be excluded")
+	}
+}
+
+func TestShouldInclude_TooLarge(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("data/huge.dat", maxFileSize+1, ex) {
+		t.Error("file exceeding maxFileSize should be excluded")
+	}
+}
+
+// ── buildExclusions ───────────────────────────────────────────────────────────
+
+func TestBuildExclusions_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	ex := buildExclusions(dir)
+	if ex == nil {
+		t.Fatal("buildExclusions should return non-nil even without config")
+	}
+	// Standard skip dirs should be present
+	if !ex.skipDirs["node_modules"] {
+		t.Error("node_modules should be in default skip dirs")
+	}
+}
+
+func TestBuildExclusions_WithConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := `{"exclude_dirs":["myfolder"],"exclude_exts":[".dat"]}`
+	if err := os.WriteFile(filepath.Join(dir, ".supermodel.json"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	ex := buildExclusions(dir)
+	if !ex.skipDirs["myfolder"] {
+		t.Error("custom exclude_dir 'myfolder' should be added")
+	}
+	if !ex.skipExts[".dat"] {
+		t.Error("custom exclude_ext '.dat' should be added")
+	}
+}
+
+func TestBuildExclusions_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".supermodel.json"), []byte("{invalid}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Should not panic — just returns defaults.
+	ex := buildExclusions(dir)
+	if ex == nil {
+		t.Fatal("buildExclusions should not return nil on bad JSON")
+	}
+}

--- a/internal/shards/zip_test.go
+++ b/internal/shards/zip_test.go
@@ -1,8 +1,11 @@
 package shards
 
 import (
+	"archive/zip"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -114,6 +117,60 @@ func TestShouldInclude_MinifiedJS(t *testing.T) {
 	}
 }
 
+func TestShouldInclude_MinifiedCSS(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("styles/app.min.css", 100, ex) {
+		t.Error("minified CSS should be excluded")
+	}
+}
+
+func TestShouldInclude_HardBlockedDir(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	// .aws is in hardBlocked map
+	if shouldInclude(".aws/credentials", 100, ex) {
+		t.Error("files under hardBlocked dir .aws should be excluded")
+	}
+}
+
+func TestShouldInclude_HiddenDir(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	// .hidden directory → HasPrefix(part, ".") → false
+	if shouldInclude(".hidden/secret.txt", 100, ex) {
+		t.Error("files under hidden directories should be excluded")
+	}
+}
+
+func TestShouldInclude_LockFile(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	if shouldInclude("package-lock.json", 100, ex) {
+		t.Error("package-lock.json should be excluded")
+	}
+}
+
+func TestMatchPattern_QuestionMarkOnly(t *testing.T) {
+	// Pattern has ? but no * → len(parts) == 1 after split on * → name == pattern
+	// Since "?" is treated as literal, matchPattern("config?", "config?") == true
+	// and matchPattern("config?", "config1") == false
+	if matchPattern("config?", "config?") != true {
+		t.Error("exact match with ? as literal should return true")
+	}
+	if matchPattern("config?", "config1") != false {
+		t.Error("non-matching ? literal should return false")
+	}
+}
+
 func TestShouldInclude_TooLarge(t *testing.T) {
 	ex := &zipExclusions{
 		skipDirs: map[string]bool{},
@@ -164,3 +221,621 @@ func TestBuildExclusions_InvalidJSON(t *testing.T) {
 		t.Fatal("buildExclusions should not return nil on bad JSON")
 	}
 }
+
+// ── LanguageStats ─────────────────────────────────────────────────────────────
+
+func TestLanguageStats_Basic(t *testing.T) {
+	files := []string{
+		"main.go", "handler.go", "util.go",
+		"index.ts", "types.ts",
+		"style.css",
+	}
+	stats := LanguageStats(files)
+	// Should be sorted descending by count: go(3), ts(2), css(1)
+	if len(stats) < 3 {
+		t.Fatalf("expected at least 3 stats, got %d", len(stats))
+	}
+	if stats[0].Ext != "go" || stats[0].Count != 3 {
+		t.Errorf("first stat: got {%s %d}, want {go 3}", stats[0].Ext, stats[0].Count)
+	}
+	if stats[1].Ext != "ts" || stats[1].Count != 2 {
+		t.Errorf("second stat: got {%s %d}, want {ts 2}", stats[1].Ext, stats[1].Count)
+	}
+}
+
+func TestLanguageStats_Empty(t *testing.T) {
+	if got := LanguageStats(nil); len(got) != 0 {
+		t.Errorf("nil: want empty, got %v", got)
+	}
+	if got := LanguageStats([]string{}); len(got) != 0 {
+		t.Errorf("empty slice: want empty, got %v", got)
+	}
+}
+
+func TestLanguageStats_NoExtension(t *testing.T) {
+	files := []string{"Makefile", "LICENSE", "main.go"}
+	stats := LanguageStats(files)
+	// Makefile and LICENSE have no extension, should be skipped
+	if len(stats) != 1 || stats[0].Ext != "go" {
+		t.Errorf("no-ext files should be skipped; got %v", stats)
+	}
+}
+
+func TestLanguageStats_Cap10(t *testing.T) {
+	// Generate 15 distinct extensions
+	files := make([]string, 15)
+	for i := range files {
+		files[i] = fmt.Sprintf("file%02d.ext%02d", i, i)
+	}
+	stats := LanguageStats(files)
+	if len(stats) > 10 {
+		t.Errorf("LanguageStats should cap at 10, got %d", len(stats))
+	}
+}
+
+func TestShouldInclude_HardBlockedPattern(t *testing.T) {
+	ex := &zipExclusions{
+		skipDirs: map[string]bool{},
+		skipExts: map[string]bool{},
+	}
+	// "*.key" is in hardBlockedPatterns
+	if shouldInclude("secrets/server.key", 100, ex) {
+		t.Error("*.key file should be excluded by hardBlockedPatterns")
+	}
+	// ".env" is in hardBlockedPatterns
+	if shouldInclude(".env", 100, ex) {
+		t.Error(".env file should be excluded by hardBlockedPatterns")
+	}
+}
+
+// ── CreateZipFile ─────────────────────────────────────────────────────────────
+
+func TestCreateZipFile_WalkMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// A file that should be excluded
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// generated"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile(walk): %v", err)
+	}
+	defer os.Remove(path)
+
+	r, err := openZipEntries(t, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r["main.go"] {
+		t.Error("expected main.go in zip")
+	}
+	if r["main.graph.go"] {
+		t.Error("shard file should be excluded from zip")
+	}
+}
+
+func TestCreateZipFile_SkipsHiddenDirs(t *testing.T) {
+	dir := t.TempDir()
+	hiddenDir := filepath.Join(dir, ".hidden")
+	if err := os.MkdirAll(hiddenDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "secret.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile: %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	for name := range r {
+		if strings.HasPrefix(name, ".hidden/") {
+			t.Errorf("hidden dir file should be excluded: %s", name)
+		}
+	}
+	if !r["main.go"] {
+		t.Error("main.go should be included")
+	}
+}
+
+func TestCreateZipFile_SkipsNodeModules(t *testing.T) {
+	dir := t.TempDir()
+	nmDir := filepath.Join(dir, "node_modules")
+	if err := os.MkdirAll(nmDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "dep.js"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "index.ts"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile: %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	for name := range r {
+		if strings.HasPrefix(name, "node_modules/") {
+			t.Errorf("node_modules should be excluded: %s", name)
+		}
+	}
+}
+
+func TestCreateZipFile_OnlyFilesMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.go"), []byte("package b"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// onlyFiles mode: include only a.go
+	path, err := CreateZipFile(dir, []string{"a.go"})
+	if err != nil {
+		t.Fatalf("CreateZipFile(onlyFiles): %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if !r["a.go"] {
+		t.Error("a.go should be included in onlyFiles mode")
+	}
+	if r["b.go"] {
+		t.Error("b.go should NOT be included when not in onlyFiles")
+	}
+}
+
+func TestCreateZipFile_WalkMode_Subdir(t *testing.T) {
+	// Covers L229 "return nil" for a non-skipped directory.
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(subDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile(walk+subdir): %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if !r["src/main.go"] {
+		t.Error("src/main.go should be included from subdirectory")
+	}
+}
+
+func TestCreateZipFile_OnlyFiles_SkipsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.go")
+	linkFile := filepath.Join(dir, "link.go")
+	if err := os.WriteFile(realFile, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, linkFile); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+
+	path, err := CreateZipFile(dir, []string{"link.go", "real.go"})
+	if err != nil {
+		t.Fatalf("CreateZipFile(symlink): %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if r["link.go"] {
+		t.Error("symlink should be excluded from onlyFiles mode")
+	}
+	if !r["real.go"] {
+		t.Error("real.go should be included")
+	}
+}
+
+func TestCreateZipFile_WalkMode_SkipsSymlinks(t *testing.T) {
+	// Covers L220 symlink detection in walk mode.
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.go")
+	linkFile := filepath.Join(dir, "link.go")
+	if err := os.WriteFile(realFile, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, linkFile); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile(walk+symlinks): %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if r["link.go"] {
+		t.Error("symlink should be excluded in walk mode")
+	}
+	if !r["real.go"] {
+		t.Error("real.go should be included")
+	}
+}
+
+func TestCreateZipFile_OnlyFiles_SkipsNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "real.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// "ghost.go" doesn't exist → Lstat error → silently skipped
+	path, err := CreateZipFile(dir, []string{"real.go", "ghost.go"})
+	if err != nil {
+		t.Fatalf("CreateZipFile with nonexistent file: %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if !r["real.go"] {
+		t.Error("real.go should be included")
+	}
+}
+
+func TestCreateZipFile_OnlyFiles_SkipsShard(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "handler.graph.go"), []byte("// shard"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "handler.go"), []byte("package h"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := CreateZipFile(dir, []string{"handler.graph.go", "handler.go"})
+	if err != nil {
+		t.Fatalf("CreateZipFile: %v", err)
+	}
+	defer os.Remove(path)
+
+	r, _ := openZipEntries(t, path)
+	if r["handler.graph.go"] {
+		t.Error("shard file should be excluded in onlyFiles mode")
+	}
+	if !r["handler.go"] {
+		t.Error("source file should be included")
+	}
+}
+
+// ── DryRunList ────────────────────────────────────────────────────────────────
+
+func TestDryRunList_Basic(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// shard"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := DryRunList(dir)
+	if err != nil {
+		t.Fatalf("DryRunList: %v", err)
+	}
+
+	found := false
+	for _, f := range files {
+		if f == "main.go" {
+			found = true
+		}
+		if f == "main.graph.go" {
+			t.Error("shard file should be excluded from DryRunList")
+		}
+	}
+	if !found {
+		t.Error("main.go should be in DryRunList")
+	}
+}
+
+func TestDryRunList_WithSubdir(t *testing.T) {
+	// Covers L282 "return nil" for a non-skipped directory in DryRunList.
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(subDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "util.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := DryRunList(dir)
+	if err != nil {
+		t.Fatalf("DryRunList(subdir): %v", err)
+	}
+	found := false
+	for _, f := range files {
+		if f == "pkg/util.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pkg/util.go should be in DryRunList; got %v", files)
+	}
+}
+
+func TestDryRunList_SkipsSymlinks(t *testing.T) {
+	// Covers L273 symlink detection in DryRunList.
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.go")
+	linkFile := filepath.Join(dir, "link.go")
+	if err := os.WriteFile(realFile, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, linkFile); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+
+	files, err := DryRunList(dir)
+	if err != nil {
+		t.Fatalf("DryRunList(symlink): %v", err)
+	}
+	for _, f := range files {
+		if f == "link.go" {
+			t.Error("symlink should be excluded from DryRunList")
+		}
+	}
+	found := false
+	for _, f := range files {
+		if f == "real.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("real.go should be included in DryRunList")
+	}
+}
+
+func TestDryRunList_SkipsHiddenAndSkipDirs(t *testing.T) {
+	dir := t.TempDir()
+	// Hidden dir
+	hiddenDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(hiddenDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hiddenDir, "HEAD"), []byte("ref"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// node_modules skip dir
+	nmDir := filepath.Join(dir, "node_modules")
+	if err := os.MkdirAll(nmDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "dep.js"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := DryRunList(dir)
+	if err != nil {
+		t.Fatalf("DryRunList: %v", err)
+	}
+
+	for _, f := range files {
+		if strings.HasPrefix(f, ".git/") || strings.HasPrefix(f, "node_modules/") {
+			t.Errorf("DryRunList should skip %s", f)
+		}
+	}
+	found := false
+	for _, f := range files {
+		if f == "app.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("app.go should be in DryRunList")
+	}
+}
+
+// ── PrintLanguageBarChart ─────────────────────────────────────────────────────
+
+func TestPrintLanguageBarChart_Empty(t *testing.T) {
+	// Should not panic on empty stats.
+	PrintLanguageBarChart(nil, 0)
+}
+
+func TestPrintLanguageBarChart_Basic(t *testing.T) {
+	// Should not panic or error for normal input.
+	stats := []LangStat{
+		{Ext: "go", Count: 10},
+		{Ext: "ts", Count: 5},
+		{Ext: "py", Count: 1}, // barLen calculation covers the barLen < 1 branch
+	}
+	PrintLanguageBarChart(stats, 16)
+}
+
+func TestPrintLanguageBarChart_SmallCount(t *testing.T) {
+	// Single stat with count 1 (maxCount = 1, barLen = 28*1/1 = 28, not < 1)
+	// Use a small maxCount relative to others to trigger barLen < 1 branch:
+	// stats[0].Count = 100, stats[1].Count = 1 → barLen = 28*1/100 = 0 < 1 → barLen = 1
+	stats := []LangStat{
+		{Ext: "go", Count: 100},
+		{Ext: "rs", Count: 1},
+	}
+	PrintLanguageBarChart(stats, 101)
+}
+
+func TestLanguageStats_TiesSortedAlphabetically(t *testing.T) {
+	// b.go, a.ts — same count (1 each), should sort a before b alphabetically
+	files := []string{"b.go", "a.ts"}
+	stats := LanguageStats(files)
+	if len(stats) != 2 {
+		t.Fatalf("expected 2, got %d", len(stats))
+	}
+	if stats[0].Ext != "go" || stats[1].Ext != "ts" {
+		// alphabetically "go" < "ts", so go comes first
+		t.Errorf("ties: got [%s, %s], want [go, ts]", stats[0].Ext, stats[1].Ext)
+	}
+}
+
+// TestAddFileToZip_OpenError covers L366: addFileToZip returns error when the
+// source file cannot be opened (nonexistent path).
+func TestAddFileToZip_OpenError(t *testing.T) {
+	tmp, err := os.CreateTemp("", "test-*.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	zw := zip.NewWriter(tmp)
+	defer zw.Close()
+
+	err = addFileToZip(zw, "/nonexistent/path/file.go", "file.go")
+	if err == nil {
+		t.Error("expected error when source file does not exist")
+	}
+}
+
+func openZipEntries(t *testing.T, path string) (map[string]bool, error) {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	m := make(map[string]bool, len(r.File))
+	for _, f := range r.File {
+		m[f.Name] = true
+	}
+	return m, nil
+}
+
+// ── CreateZipFile / DryRunList error paths ────────────────────────────────────
+
+// TestCreateZipFile_OnlyFiles_UnreadableFileError covers L202-207:
+// addFileToZip returns an error when a file in onlyFiles is not readable.
+func TestCreateZipFile_OnlyFiles_UnreadableFileError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	// Name must not match any hardBlockedPattern (e.g. "*secret*").
+	locked := filepath.Join(dir, "locked.go")
+	if err := os.WriteFile(locked, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(locked, 0600) }) //nolint:errcheck
+
+	_, err := CreateZipFile(dir, []string{"locked.go"})
+	if err == nil {
+		t.Error("CreateZipFile should fail when an onlyFiles entry cannot be opened")
+	}
+}
+
+// TestCreateZipFile_WalkMode_UnreadableSubdir covers L211-213: the Walk callback
+// receives err != nil for an unreadable subdirectory and returns nil to skip it.
+// Since the callback returns nil (not the error), the walk succeeds overall.
+func TestCreateZipFile_WalkMode_UnreadableSubdir(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "secret")
+	if err := os.MkdirAll(subdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "file.go"), []byte("package x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(subdir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(subdir, 0755) }) //nolint:errcheck
+
+	// Walk mode (onlyFiles == nil) — the unreadable subdir triggers L211-213 but
+	// CreateZipFile succeeds because the error is silently skipped.
+	path, err := CreateZipFile(dir, nil)
+	if err != nil {
+		t.Fatalf("CreateZipFile should succeed when walk errors are silently skipped: %v", err)
+	}
+	defer os.Remove(path)
+}
+
+// TestCreateZipFile_WalkMode_UnreadableFile covers L238-243: addFileToZip
+// returns an error for an unreadable file during the walk, causing CreateZipFile
+// to clean up and return an error.
+func TestCreateZipFile_WalkMode_UnreadableFile(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "locked.go")
+	if err := os.WriteFile(secret, []byte("package main"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(secret, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(secret, 0600) }) //nolint:errcheck
+
+	// Walk mode — the unreadable file causes addFileToZip to fail.
+	_, err := CreateZipFile(dir, nil)
+	if err == nil {
+		t.Error("CreateZipFile should fail when a file in walk mode cannot be opened")
+	}
+}
+
+// TestDryRunList_WalkError covers L264-266: DryRunList's Walk callback receives
+// err != nil (from an unreadable subdir) and silently skips it (returns nil).
+func TestDryRunList_WalkError(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping chmod-based test in CI")
+	}
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "locked")
+	if err := os.MkdirAll(subdir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "file.go"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(subdir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(subdir, 0755) }) //nolint:errcheck
+
+	// DryRunList should succeed despite the locked subdir.
+	files, err := DryRunList(dir)
+	if err != nil {
+		t.Fatalf("DryRunList should succeed when walk errors are skipped: %v", err)
+	}
+	_ = files
+}
+
+// TestCreateZipFile_CreateTempError covers L182-184: CreateZipFile returns
+// an error when os.CreateTemp fails (TMPDIR points to a nonexistent directory).
+func TestCreateZipFile_CreateTempError(t *testing.T) {
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "nonexistent-tmp-dir"))
+	_, err := CreateZipFile(t.TempDir(), nil)
+	if err == nil {
+		t.Error("expected error when os.CreateTemp fails due to invalid TMPDIR")
+	}
+}
+

--- a/internal/status/handler_test.go
+++ b/internal/status/handler_test.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -149,5 +150,32 @@ func TestCountCacheEntries_IgnoresSubdirs(t *testing.T) {
 func TestCountCacheEntries_MissingDir(t *testing.T) {
 	if n := countCacheEntries("/nonexistent/cache/dir"); n != 0 {
 		t.Errorf("missing dir: want 0, got %d", n)
+	}
+}
+
+// ── Run ───────────────────────────────────────────────────────────────────────
+
+// TestRun_HappyPath covers L36-44: Run succeeds when config can be loaded,
+// exercising the full happy path including countCacheEntries and render.
+func TestRun_HappyPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SUPERMODEL_API_KEY", "")
+	t.Setenv("SUPERMODEL_API_BASE", "")
+	if err := Run(context.Background(), Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+// TestRun_ConfigLoadError covers L33-35: Run returns error when config.Load fails.
+func TestRun_ConfigLoadError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Place a directory at the config file path so ReadFile returns EISDIR.
+	cfgPath := filepath.Join(home, ".supermodel", "config.yaml")
+	if err := os.MkdirAll(cfgPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run(context.Background(), Options{}); err == nil {
+		t.Error("Run should fail when config cannot be loaded")
 	}
 }


### PR DESCRIPTION
## Summary

- **`internal/restore/render.go`** — `countTokens` used `len(text)/4` (byte count) for the char estimate, inflating the token budget for any text with multi-byte UTF-8 characters (CJK, emoji, accented chars). Fixed to `utf8.RuneCountInString(text)/4`.
- **`internal/api/client.go`** — HTTP error response snippets were truncated at byte offset 300, which can produce invalid UTF-8 when a multi-byte character straddles that boundary. Fixed to rune-based slicing.
- **`internal/setup/wizard.go`** — `maskKey` sliced the API key at byte positions 8 and `len-4`. Same class of bug being fixed systematically elsewhere in the repo.

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Existing tests pass: `go test ./...`
- [ ] Verify token estimate is correct for a string with multi-byte characters (e.g., CJK text)
- [ ] Verify error snippets for API errors containing non-ASCII content render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unicode/rune handling so error messages, token estimates, and sensitive-data masking correctly handle multibyte characters.
  * Prevented unintended mutation of caller-provided lists during deduplication.
  * Ensured file-close errors are preserved for more reliable file operation reporting.

* **Tests**
  * Added extensive unit tests across modules validating Unicode behavior, masking, token estimation, deduplication non‑mutation, zip/archive handling, graph/shard utilities, rendering, schema/sitemap helpers, and other helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->