### PR TITLE
feat: add supermodel skill command for agent awareness prompt

### DIFF
--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const skillPrompt = `This repository has Supermodel graph shard files next to source files.
+
+Files ending in .calls.* contain function call relationships (who calls what, with file and line number).
+Files ending in .deps.* contain dependency relationships (imports and imported-by).
+Files ending in .impact.* contain blast radius data (risk level, affected domains, direct/transitive dependents).
+
+When navigating the codebase:
+- Read .deps files to understand what a module depends on and what depends on it
+- Read .calls files to trace call chains across files
+- Read .impact files to assess the blast radius before making changes
+- These files appear in grep/rg results alongside source code — use the data to navigate faster`
+
+func init() {
+	c := &cobra.Command{
+		Use:   "skill",
+		Short: "Print agent awareness prompt for graph shard files",
+		Long: `Prints a prompt that teaches AI coding agents how to use Supermodel's
+graph shard files. Pipe into your agent's instructions:
+
+  supermodel skill >> CLAUDE.md
+  supermodel skill >> AGENTS.md
+  supermodel skill >> .cursorrules`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(skillPrompt)
+		},
+	}
+
+	rootCmd.AddCommand(c)
+}


### PR DESCRIPTION
## What

`supermodel skill` prints a prompt that teaches agents how to use graph shard files.

```bash
$ supermodel skill >> CLAUDE.md
$ supermodel skill >> AGENTS.md
```

## Why

Benchmark data shows agents need to be told about shard files. Without prompting, they ignore or filter them out. With prompting: 43% cost savings on complex tasks (Lance's 14-repo test), 68% faster on Medusa (our test).

## The prompt

```
This repository has Supermodel graph shard files next to source files.

Files ending in .calls.* contain function call relationships (who calls what, with file and line number).
Files ending in .deps.* contain dependency relationships (imports and imported-by).
Files ending in .impact.* contain blast radius data (risk level, affected domains, direct/transitive dependents).

When navigating the codebase:
- Read .deps files to understand what a module depends on and what depends on it
- Read .calls files to trace call chains across files
- Read .impact files to assess the blast radius before making changes
- These files appear in grep/rg results alongside source code — use the data to navigate faster
```

1 file, 38 lines.

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `skill` command that provides comprehensive documentation about Supermodel graph shard files. When executed, the command displays information explaining the `.calls.*`, `.deps.*`, and `.impact.*` file types, their purpose and semantics, along with guidance on how to effectively navigate and use them throughout the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->