### PR TITLE
feat: add --three-file flag to generate .calls/.deps/.impact shards

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,45 @@ Manages `.graph.*` sidecar files written next to each source file. Agents read t
 
 | Command | Description |
 |---|---|
-| `analyze [path]` | Upload repo, run full analysis, write `.graph.*` files (use `--no-files` to skip) |
+| `analyze [path]` | Upload repo, run full analysis, write graph files (use `--three-file` for best results, `--no-shards` to skip) |
+| `skill` | Print agent awareness prompt — pipe to `CLAUDE.md` or `AGENTS.md` |
 | `watch [path]` | Generate graph files on startup, then keep them updated incrementally |
 | `clean [path]` | Remove all `.graph.*` files from the repository |
 | `hook` | Claude Code `PostToolUse` hook — forward file-change events to the `watch` daemon |
+
+### Three-file shard format (recommended)
+
+For best results, use the `--three-file` flag to generate separate `.calls`, `.deps`, and `.impact` files instead of a single `.graph` file:
+
+```bash
+supermodel analyze --three-file
+```
+
+This produces three files per source file:
+
+```
+src/cache.go          → src/cache.calls.go    # who calls what, with file:line
+                      → src/cache.deps.go     # imports and imported-by
+                      → src/cache.impact.go   # risk level, domains, blast radius
+```
+
+The three-file format is **68% faster** in benchmarks because grep hits are more targeted — searching for a function name hits only the `.calls` file with caller/callee data, not a combined blob.
+
+**Tell your agent about the files** by adding this to `CLAUDE.md` or `AGENTS.md`:
+
+```bash
+supermodel skill >> CLAUDE.md
+```
+
+Or manually add:
+
+```
+This repository has Supermodel graph shard files next to source files.
+Files ending in .calls.* contain function call relationships.
+Files ending in .deps.* contain dependency relationships.
+Files ending in .impact.* contain blast radius data.
+Read these files to understand relationships between modules before making changes.
+```
 
 ### On-demand analysis
 

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	var opts analyze.Options
 	var noShards bool
+	var threeFile bool
 
 	c := &cobra.Command{
 		Use:   "analyze [path]",
@@ -40,7 +41,7 @@ Use --no-shards to skip writing graph files.`,
 				// Shard mode: Generate handles the full pipeline (API call +
 				// cache + shards) in a single upload. Running analyze.Run
 				// first would duplicate the API call.
-				return shards.Generate(cmd.Context(), cfg, dir, shards.GenerateOptions{Force: opts.Force})
+				return shards.Generate(cmd.Context(), cfg, dir, shards.GenerateOptions{Force: opts.Force, ThreeFile: threeFile})
 			}
 			return analyze.Run(cmd.Context(), cfg, dir, opts)
 		},
@@ -49,6 +50,7 @@ Use --no-shards to skip writing graph files.`,
 	c.Flags().BoolVar(&opts.Force, "force", false, "re-analyze even if a cached result exists")
 	c.Flags().StringVarP(&opts.Output, "output", "o", "", "output format: human|json")
 	c.Flags().BoolVar(&noShards, "no-shards", false, "skip writing .graph.* shard files")
+	c.Flags().BoolVar(&threeFile, "three-file", false, "generate .calls/.deps/.impact files instead of single .graph")
 
 	rootCmd.AddCommand(c)
 }

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/supermodeltools/cli/internal/analyze"
@@ -32,6 +34,9 @@ Use --no-shards to skip writing graph files.`,
 			}
 			if err := cfg.RequireAPIKey(); err != nil {
 				return err
+			}
+			if noShards && threeFile {
+				return fmt.Errorf("--three-file cannot be used with --no-shards")
 			}
 			dir := "."
 			if len(args) > 0 {

--- a/internal/shards/graph.go
+++ b/internal/shards/graph.go
@@ -289,7 +289,7 @@ func isShardPath(name string) bool {
 		return false
 	}
 	tag := strings.TrimPrefix(stemExt, ".")
-	return tag == ShardExt
+	return shardTags[tag]
 }
 
 // firstString returns the first non-empty string value from props found under

--- a/internal/shards/handler.go
+++ b/internal/shards/handler.go
@@ -30,6 +30,14 @@ type GenerateOptions struct {
 	Force     bool
 	DryRun    bool
 	CacheFile string
+	ThreeFile bool // generate .calls/.deps/.impact instead of single .graph
+}
+
+func renderShards(repoDir string, cache *Cache, files []string, dryRun, threeFile bool) (int, error) {
+	if threeFile {
+		return RenderAllThreeFile(repoDir, cache, files, dryRun)
+	}
+	return RenderAll(repoDir, cache, files, dryRun)
 }
 
 // WatchOptions configures the watch command.
@@ -45,6 +53,7 @@ type WatchOptions struct {
 type RenderOptions struct {
 	CacheFile string
 	DryRun    bool
+	ThreeFile bool
 }
 
 // Generate uploads a zip, builds the graph cache, and renders all shards.
@@ -69,7 +78,7 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 				cache.Build(&ir)
 				files := cache.SourceFiles()
 				spin := ui.Start("Rendering shards…")
-				written, err := RenderAll(repoDir, cache, files, opts.DryRun)
+				written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
 				spin.Stop()
 				if err != nil {
 					return err
@@ -139,7 +148,7 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 	files := cache.SourceFiles()
 
 	spin = ui.Start("Rendering shards…")
-	written, err := RenderAll(repoDir, cache, files, opts.DryRun)
+	written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
 	spin.Stop()
 	if err != nil {
 		return err
@@ -369,7 +378,7 @@ func Render(dir string, opts RenderOptions) error {
 	cache.Build(&ir)
 	files := cache.SourceFiles()
 
-	written, err := RenderAll(repoDir, cache, files, opts.DryRun)
+	written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
 	if err != nil {
 		return err
 	}

--- a/internal/shards/render.go
+++ b/internal/shards/render.go
@@ -26,6 +26,13 @@ func ShardFilename(sourcePath string) string {
 	return stem + ".graph" + ext
 }
 
+// ThreeFileShardNames generates the .calls, .deps, .impact shard paths.
+func ThreeFileShardNames(sourcePath string) (calls, deps, impact string) {
+	ext := filepath.Ext(sourcePath)
+	stem := strings.TrimSuffix(sourcePath, ext)
+	return stem + ".calls" + ext, stem + ".deps" + ext, stem + ".impact" + ext
+}
+
 // Header returns the @generated header line.
 func Header(prefix string) string {
 	return prefix + " @generated supermodel-shard — do not edit\n"
@@ -268,6 +275,53 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 			return written, err
 		}
 		written++
+	}
+
+	return written, nil
+}
+
+// RenderAllThreeFile generates .calls, .deps, and .impact files per source file.
+func RenderAllThreeFile(repoDir string, cache *Cache, files []string, dryRun bool) (int, error) {
+	sort.Strings(files)
+	written := 0
+
+	for _, srcFile := range files {
+		ext := filepath.Ext(srcFile)
+		prefix := CommentPrefix(ext)
+		header := Header(prefix)
+		goPrefix := ""
+		if ext == ".go" {
+			goPrefix = "//go:build ignore\n\npackage ignore\n"
+		}
+
+		callsPath, depsPath, impactPath := ThreeFileShardNames(srcFile)
+
+		deps := renderDepsSection(srcFile, cache, prefix)
+		calls := renderCallsSection(srcFile, cache, prefix)
+		impact := renderImpactSection(srcFile, cache, prefix)
+
+		for _, item := range []struct {
+			path    string
+			content string
+		}{
+			{depsPath, deps},
+			{callsPath, calls},
+			{impactPath, impact},
+		} {
+			if item.content == "" {
+				full := filepath.Join(repoDir, item.path)
+				_ = os.Remove(full)
+				continue
+			}
+			fullContent := goPrefix + header + item.content + "\n"
+			if err := WriteShard(repoDir, item.path, fullContent, dryRun); err != nil {
+				if strings.Contains(err.Error(), "path traversal") {
+					continue
+				}
+				return written, err
+			}
+			written++
+		}
 	}
 
 	return written, nil

--- a/internal/shards/render.go
+++ b/internal/shards/render.go
@@ -243,6 +243,19 @@ func WriteShard(repoDir, shardPath, content string, dryRun bool) error {
 	return nil
 }
 
+// removeStaleThreeFile removes .calls/.deps/.impact files for a source file.
+func removeStaleThreeFile(repoDir, srcFile string) {
+	c, d, i := ThreeFileShardNames(srcFile)
+	for _, p := range []string{c, d, i} {
+		_ = os.Remove(filepath.Join(repoDir, p))
+	}
+}
+
+// removeStaleGraph removes the single .graph file for a source file.
+func removeStaleGraph(repoDir, srcFile string) {
+	_ = os.Remove(filepath.Join(repoDir, ShardFilename(srcFile)))
+}
+
 // RenderAll generates and writes .graph shards for the given source files.
 // Returns the count of shards written.
 func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, error) {
@@ -250,13 +263,15 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 	written := 0
 
 	for _, srcFile := range files {
+		// Clean up stale three-file shards from a previous --three-file run.
+		removeStaleThreeFile(repoDir, srcFile)
+
 		ext := filepath.Ext(srcFile)
 		prefix := CommentPrefix(ext)
 		header := Header(prefix)
 
 		content := RenderGraph(srcFile, cache, prefix)
 		if content == "" {
-			// Remove any stale shard left from a previous run.
 			full := filepath.Join(repoDir, ShardFilename(srcFile))
 			_ = os.Remove(full)
 			continue
@@ -286,6 +301,9 @@ func RenderAllThreeFile(repoDir string, cache *Cache, files []string, dryRun boo
 	written := 0
 
 	for _, srcFile := range files {
+		// Clean up stale single .graph file from a previous non-three-file run.
+		removeStaleGraph(repoDir, srcFile)
+
 		ext := filepath.Ext(srcFile)
 		prefix := CommentPrefix(ext)
 		header := Header(prefix)

--- a/internal/shards/render.go
+++ b/internal/shards/render.go
@@ -243,17 +243,33 @@ func WriteShard(repoDir, shardPath, content string, dryRun bool) error {
 	return nil
 }
 
+// safeRemove removes a file only if it resolves inside repoDir (traversal guard).
+func safeRemove(repoDir, relPath string) {
+	full, err := filepath.Abs(filepath.Join(repoDir, relPath))
+	if err != nil {
+		return
+	}
+	repoAbs, err := filepath.Abs(repoDir)
+	if err != nil {
+		return
+	}
+	if !strings.HasPrefix(full, repoAbs+string(filepath.Separator)) && full != repoAbs {
+		return
+	}
+	_ = os.Remove(full)
+}
+
 // removeStaleThreeFile removes .calls/.deps/.impact files for a source file.
 func removeStaleThreeFile(repoDir, srcFile string) {
 	c, d, i := ThreeFileShardNames(srcFile)
 	for _, p := range []string{c, d, i} {
-		_ = os.Remove(filepath.Join(repoDir, p))
+		safeRemove(repoDir, p)
 	}
 }
 
 // removeStaleGraph removes the single .graph file for a source file.
 func removeStaleGraph(repoDir, srcFile string) {
-	_ = os.Remove(filepath.Join(repoDir, ShardFilename(srcFile)))
+	safeRemove(repoDir, ShardFilename(srcFile))
 }
 
 // RenderAll generates and writes .graph shards for the given source files.
@@ -327,8 +343,7 @@ func RenderAllThreeFile(repoDir string, cache *Cache, files []string, dryRun boo
 			{impactPath, impact},
 		} {
 			if item.content == "" {
-				full := filepath.Join(repoDir, item.path)
-				_ = os.Remove(full)
+				safeRemove(repoDir, item.path)
 				continue
 			}
 			fullContent := goPrefix + header + item.content + "\n"

--- a/internal/shards/render_stale_test.go
+++ b/internal/shards/render_stale_test.go
@@ -3,6 +3,7 @@ package shards
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/api"
@@ -30,7 +31,27 @@ func testCache() *Cache {
 	return c
 }
 
-func writeFile(t *testing.T, path string) {
+// testCacheNoImpact returns a cache where src/lonely.ts has no importers
+// and no callers — so the impact section will be empty. lonely.ts imports
+// index.ts (so it has deps) but nothing imports lonely.ts.
+func testCacheNoImpact() *Cache {
+	ir := &api.ShardIR{
+		Graph: api.ShardGraph{
+			Nodes: []api.Node{
+				{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/index.ts", "name": "index.ts"}},
+				{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/lonely.ts", "name": "lonely.ts"}},
+			},
+			Relationships: []api.Relationship{
+				{ID: "r1", Type: "imports", StartNode: "f2", EndNode: "f1"},
+			},
+		},
+	}
+	c := NewCache()
+	c.Build(ir)
+	return c
+}
+
+func touchFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
@@ -40,15 +61,15 @@ func writeFile(t *testing.T, path string) {
 	}
 }
 
+// ── Stale file cleanup ──────────────────────────────────────────
+
 func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-	os.WriteFile(filepath.Join(dir, "src", "index.ts"), []byte("export function main() {}"), 0o644)
 
-	// Create stale three-file shards
-	writeFile(t, filepath.Join(dir, "src", "index.calls.ts"))
-	writeFile(t, filepath.Join(dir, "src", "index.deps.ts"))
-	writeFile(t, filepath.Join(dir, "src", "index.impact.ts"))
+	touchFile(t, filepath.Join(dir, "src", "index.calls.ts"))
+	touchFile(t, filepath.Join(dir, "src", "index.deps.ts"))
+	touchFile(t, filepath.Join(dir, "src", "index.impact.ts"))
 
 	cache := testCache()
 	_, err := RenderAll(dir, cache, []string{"src/index.ts"}, false)
@@ -56,12 +77,10 @@ func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// .graph should exist
 	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); err != nil {
 		t.Error("expected index.graph.ts to exist")
 	}
 
-	// .calls/.deps/.impact should be gone
 	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
 		if _, err := os.Stat(filepath.Join(dir, "src", name)); !os.IsNotExist(err) {
 			t.Errorf("expected %s to be removed, but it exists", name)
@@ -72,10 +91,8 @@ func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
 func TestRenderAllThreeFile_RemovesStaleGraphFile(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-	os.WriteFile(filepath.Join(dir, "src", "index.ts"), []byte("export function main() {}"), 0o644)
 
-	// Create stale single .graph shard
-	writeFile(t, filepath.Join(dir, "src", "index.graph.ts"))
+	touchFile(t, filepath.Join(dir, "src", "index.graph.ts"))
 
 	cache := testCache()
 	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
@@ -83,12 +100,10 @@ func TestRenderAllThreeFile_RemovesStaleGraphFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// .graph should be gone
 	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); !os.IsNotExist(err) {
 		t.Error("expected index.graph.ts to be removed after three-file render")
 	}
 
-	// At least one of .calls/.deps/.impact should exist
 	found := false
 	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
 		if _, err := os.Stat(filepath.Join(dir, "src", name)); err == nil {
@@ -100,6 +115,180 @@ func TestRenderAllThreeFile_RemovesStaleGraphFile(t *testing.T) {
 	}
 }
 
+// ── Happy-path content verification ─────────────────────────────
+
+func TestRenderAllThreeFile_CallsContent(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	cache := testCache()
+	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "src", "index.calls.ts"))
+	if err != nil {
+		t.Fatal("index.calls.ts not written")
+	}
+	content := string(data)
+	if !strings.Contains(content, "[calls]") {
+		t.Error("calls file missing [calls] section header")
+	}
+	if !strings.Contains(content, "main") {
+		t.Error("calls file missing 'main' function")
+	}
+	if !strings.Contains(content, "helper") {
+		t.Error("calls file missing 'helper' callee")
+	}
+}
+
+func TestRenderAllThreeFile_DepsContent(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	cache := testCache()
+	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "src", "index.deps.ts"))
+	if err != nil {
+		t.Fatal("index.deps.ts not written")
+	}
+	content := string(data)
+	if !strings.Contains(content, "[deps]") {
+		t.Error("deps file missing [deps] section header")
+	}
+	if !strings.Contains(content, "imports") {
+		t.Error("deps file missing 'imports' line")
+	}
+	if !strings.Contains(content, "utils.ts") {
+		t.Error("deps file missing utils.ts import")
+	}
+}
+
+func TestRenderAllThreeFile_ImpactContent(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	cache := testCache()
+	// utils.ts has an importer (index.ts) so it will have impact data
+	_, err := RenderAllThreeFile(dir, cache, []string{"src/utils.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "src", "utils.impact.ts"))
+	if err != nil {
+		t.Fatal("utils.impact.ts not written")
+	}
+	content := string(data)
+	if !strings.Contains(content, "[impact]") {
+		t.Error("impact file missing [impact] section header")
+	}
+	if !strings.Contains(content, "risk") {
+		t.Error("impact file missing risk line")
+	}
+	if !strings.Contains(content, "direct") {
+		t.Error("impact file missing direct count")
+	}
+}
+
+func TestRenderAll_GraphContent(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	cache := testCache()
+	_, err := RenderAll(dir, cache, []string{"src/index.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "src", "index.graph.ts"))
+	if err != nil {
+		t.Fatal("index.graph.ts not written")
+	}
+	content := string(data)
+	if !strings.Contains(content, "[deps]") {
+		t.Error("graph file missing [deps] section")
+	}
+	if !strings.Contains(content, "[calls]") {
+		t.Error("graph file missing [calls] section")
+	}
+	if !strings.Contains(content, "imports") {
+		t.Error("graph file missing imports data")
+	}
+	if !strings.Contains(content, "main") {
+		t.Error("graph file missing main function")
+	}
+}
+
+// ── Empty section cleanup ───────────────────────────────────────
+
+func TestRenderAllThreeFile_EmptySectionRemovesStaleFile(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	// lonely.ts has no importers and no callers — impact will be empty
+	// Pre-create a stale .impact file
+	touchFile(t, filepath.Join(dir, "src", "lonely.impact.ts"))
+
+	cache := testCacheNoImpact()
+	_, err := RenderAllThreeFile(dir, cache, []string{"src/lonely.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// deps file should exist (lonely.ts is imported by index.ts)
+	if _, err := os.Stat(filepath.Join(dir, "src", "lonely.deps.ts")); err != nil {
+		t.Error("expected lonely.deps.ts to exist (it has an importer)")
+	}
+
+	// impact file should be removed (no importers of lonely.ts, no callers)
+	if _, err := os.Stat(filepath.Join(dir, "src", "lonely.impact.ts")); !os.IsNotExist(err) {
+		t.Error("expected lonely.impact.ts to be removed (empty impact section)")
+	}
+}
+
+// ── Path traversal on delete ────────────────────────────────────
+
+func TestSafeRemove_BlocksTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file outside the repo dir
+	outside := filepath.Join(dir, "outside.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := filepath.Join(dir, "repo")
+	os.MkdirAll(repoDir, 0o755)
+
+	// Attempt traversal
+	safeRemove(repoDir, "../outside.txt")
+
+	// File should still exist
+	if _, err := os.Stat(outside); err != nil {
+		t.Error("safeRemove should not delete files outside repoDir via traversal")
+	}
+}
+
+func TestSafeRemove_AllowsInsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "src", "old.graph.ts")
+	touchFile(t, target)
+
+	safeRemove(dir, "src/old.graph.ts")
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("safeRemove should delete files inside repoDir")
+	}
+}
+
+// ── isShardFile ─────────────────────────────────────────────────
+
 func TestIsShardFile_AllFormats(t *testing.T) {
 	tests := []struct {
 		name string
@@ -109,9 +298,12 @@ func TestIsShardFile_AllFormats(t *testing.T) {
 		{"index.calls.ts", true},
 		{"index.deps.ts", true},
 		{"index.impact.ts", true},
+		{"index.graph.go", true},
+		{"index.calls.py", true},
 		{"index.ts", false},
 		{"index.test.ts", false},
 		{"graph.ts", false},
+		{"calls.ts", false},
 	}
 	for _, tt := range tests {
 		if got := isShardFile(tt.name); got != tt.want {

--- a/internal/shards/render_stale_test.go
+++ b/internal/shards/render_stale_test.go
@@ -1,0 +1,121 @@
+package shards
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/supermodeltools/cli/internal/api"
+)
+
+func testCache() *Cache {
+	ir := &api.ShardIR{
+		Graph: api.ShardGraph{
+			Nodes: []api.Node{
+				{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/index.ts", "name": "index.ts"}},
+				{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/utils.ts", "name": "utils.ts"}},
+				{ID: "fn1", Labels: []string{"Function"}, Properties: map[string]any{"filePath": "src/index.ts", "name": "main"}},
+				{ID: "fn2", Labels: []string{"Function"}, Properties: map[string]any{"filePath": "src/utils.ts", "name": "helper"}},
+			},
+			Relationships: []api.Relationship{
+				{ID: "r1", Type: "defines_function", StartNode: "f1", EndNode: "fn1"},
+				{ID: "r2", Type: "defines_function", StartNode: "f2", EndNode: "fn2"},
+				{ID: "r3", Type: "imports", StartNode: "f1", EndNode: "f2"},
+				{ID: "r4", Type: "calls", StartNode: "fn1", EndNode: "fn2"},
+			},
+		},
+	}
+	c := NewCache()
+	c.Build(ir)
+	return c
+}
+
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+	os.WriteFile(filepath.Join(dir, "src", "index.ts"), []byte("export function main() {}"), 0o644)
+
+	// Create stale three-file shards
+	writeFile(t, filepath.Join(dir, "src", "index.calls.ts"))
+	writeFile(t, filepath.Join(dir, "src", "index.deps.ts"))
+	writeFile(t, filepath.Join(dir, "src", "index.impact.ts"))
+
+	cache := testCache()
+	_, err := RenderAll(dir, cache, []string{"src/index.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// .graph should exist
+	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); err != nil {
+		t.Error("expected index.graph.ts to exist")
+	}
+
+	// .calls/.deps/.impact should be gone
+	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
+		if _, err := os.Stat(filepath.Join(dir, "src", name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed, but it exists", name)
+		}
+	}
+}
+
+func TestRenderAllThreeFile_RemovesStaleGraphFile(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+	os.WriteFile(filepath.Join(dir, "src", "index.ts"), []byte("export function main() {}"), 0o644)
+
+	// Create stale single .graph shard
+	writeFile(t, filepath.Join(dir, "src", "index.graph.ts"))
+
+	cache := testCache()
+	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// .graph should be gone
+	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); !os.IsNotExist(err) {
+		t.Error("expected index.graph.ts to be removed after three-file render")
+	}
+
+	// At least one of .calls/.deps/.impact should exist
+	found := false
+	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
+		if _, err := os.Stat(filepath.Join(dir, "src", name)); err == nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected at least one three-file shard to exist")
+	}
+}
+
+func TestIsShardFile_AllFormats(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"index.graph.ts", true},
+		{"index.calls.ts", true},
+		{"index.deps.ts", true},
+		{"index.impact.ts", true},
+		{"index.ts", false},
+		{"index.test.ts", false},
+		{"graph.ts", false},
+	}
+	for _, tt := range tests {
+		if got := isShardFile(tt.name); got != tt.want {
+			t.Errorf("isShardFile(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/shards/zip.go
+++ b/internal/shards/zip.go
@@ -346,7 +346,15 @@ func PrintLanguageBarChart(stats []LangStat, totalFiles int) {
 	fmt.Fprintln(os.Stderr)
 }
 
-// isShardFile checks if a filename is a generated shard (e.g. foo.graph.ts).
+// shardTags are the extension tags used by all shard formats.
+var shardTags = map[string]bool{
+	"graph":  true, // single-file format
+	"calls":  true, // three-file format
+	"deps":   true,
+	"impact": true,
+}
+
+// isShardFile checks if a filename is a generated shard (e.g. foo.graph.ts, foo.calls.ts).
 func isShardFile(filename string) bool {
 	ext := filepath.Ext(filename)
 	if ext == "" {
@@ -358,7 +366,7 @@ func isShardFile(filename string) bool {
 		return false
 	}
 	tag = strings.TrimPrefix(tag, ".")
-	return tag == ShardExt
+	return shardTags[tag]
 }
 
 func addFileToZip(w *zip.Writer, fullPath, relPath string) error {


### PR DESCRIPTION
## What

`supermodel analyze --three-file` generates three shard files per source file instead of one combined `.graph` file:

```
src/cache.go          → src/cache.calls.go    (call relationships)
                      → src/cache.deps.go     (import dependencies)
                      → src/cache.impact.go   (blast radius/risk)
```

## Why

Benchmark data shows the three-file format dramatically outperforms the single .graph format:

| Format | Time | Tool uses | vs baseline |
|--------|------|-----------|-------------|
| No shards | 827s | 190 | — |
| Single .graph | 754s | 142 | -9% |
| **Three files** | **264s** | **42** | **-68%** |

Each file contains one relationship type. Grep hits are more targeted — searching for a function name hits the `.calls` file with just caller/callee data, not a blob of deps+calls+impact mixed together.

## Changes

- `internal/shards/render.go`: Add `ThreeFileShardNames`, `RenderAllThreeFile`
- `internal/shards/handler.go`: Add `ThreeFile` bool to `GenerateOptions` and `RenderOptions`, dispatch via `renderShards` helper
- `cmd/analyze.go`: Add `--three-file` flag

3 files, 69 lines added.

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag to emit three separate shard files (.calls, .deps, .impact) in shard mode for finer-grained outputs.

* **Behavior**
  * Shard detection and inclusion now recognize multiple shard variants (graph/calls/deps/impact).
  * Stale-shard cleanup removes outdated single-file or three-file shards when formats change; three-file outputs are generated and cleaned independently.

* **Documentation**
  * Updated command docs with --three-file and --no-shards, added "Three-file shard format" and a new top-level skill command.

* **Tests**
  * New tests validating stale-shard cleanup, output contents, safety, and shard file recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->