### PR TITLE
fix: skill prompt covers both .graph and three-file formats

### DIFF
--- a/cmd/skill.go
+++ b/cmd/skill.go
@@ -8,14 +8,20 @@ import (
 
 const skillPrompt = `This repository has Supermodel graph shard files next to source files.
 
-Files ending in .calls.* contain function call relationships (who calls what, with file and line number).
-Files ending in .deps.* contain dependency relationships (imports and imported-by).
-Files ending in .impact.* contain blast radius data (risk level, affected domains, direct/transitive dependents).
+There are two formats — use whichever is present:
+
+Single-file format:
+  Files ending in .graph.* contain all graph data (deps, calls, impact) in one file with [deps], [calls], and [impact] sections.
+
+Three-file format (recommended):
+  Files ending in .calls.* contain function call relationships (who calls what, with file and line number).
+  Files ending in .deps.* contain dependency relationships (imports and imported-by).
+  Files ending in .impact.* contain blast radius data (risk level, affected domains, direct/transitive dependents).
 
 When navigating the codebase:
-- Read .deps files to understand what a module depends on and what depends on it
-- Read .calls files to trace call chains across files
-- Read .impact files to assess the blast radius before making changes
+- Read .deps or .graph files to understand what a module depends on and what depends on it
+- Read .calls or .graph files to trace call chains across files
+- Read .impact or .graph files to assess the blast radius before making changes
 - These files appear in grep/rg results alongside source code — use the data to navigate faster`
 
 func init() {


### PR DESCRIPTION
The skill prompt only mentioned .calls/.deps/.impact files. Users running without --three-file get single .graph files and the prompt didn't tell the agent about them.

Now covers both formats with a note that three-file is recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text describing support for multiple graph file formats, including both single-file and distributed layouts. Navigation guidance adjusted to reflect available file format options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->