### PR TITLE
Handle Windows installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ Save up to 40% on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
+### Linux / Mac
+
 ```bash
 curl -fsSL https://supermodeltools.com/install.sh | sh
 ```
 
+### npm (cross-platform)
+
+```bash
+npm install -g @supermodeltools/cli
+```
 ---
 
 ## How it works
@@ -88,7 +95,7 @@ go build -o supermodel .
 
 ```bash
 supermodel setup          # authenticate + configure (runs automatically after install)
-cd /path/to/your/repo
+cd your/repo
 supermodel watch          # generate graph files and keep them updated
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Save up to 40% on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
-### Linux / Mac
+## Linux / Mac
 
 ```bash
 curl -fsSL https://supermodeltools.com/install.sh | sh
 ```
 
-### npm (cross-platform)
+## npm (cross-platform)
 
 ```bash
 npm install -g @supermodeltools/cli

--- a/npm/install.js
+++ b/npm/install.js
@@ -65,9 +65,9 @@ download(url, tmpArchive, () => {
   if (ext === "tar.gz") {
     execSync(`tar -xzf "${tmpArchive}" -C "${BIN_DIR}" supermodel`);
   } else {
-    // Windows (peasants): Expand-Archive extracts everything, so extract to a temp dir
-    // and copy only the binary.
-    const tmpDir = path.join(os.tmpdir(), "supermodel-extract");
+    // Windows: Expand-Archive extracts all files, so extract to a temporary
+    // directory and copy only the binary.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "supermodel-extract-"));
     execSync(
       `powershell -NoProfile -Command "Expand-Archive -Force -Path '${tmpArchive}' -DestinationPath '${tmpDir}'"`,
     );

--- a/npm/install.js
+++ b/npm/install.js
@@ -65,9 +65,16 @@ download(url, tmpArchive, () => {
   if (ext === "tar.gz") {
     execSync(`tar -xzf "${tmpArchive}" -C "${BIN_DIR}" supermodel`);
   } else {
-    execSync(`unzip -o "${tmpArchive}" supermodel.exe -d "${BIN_DIR}"`);
+    // Windows (peasants): Expand-Archive extracts everything, so extract to a temp dir
+    // and copy only the binary.
+    const tmpDir = path.join(os.tmpdir(), "supermodel-extract");
+    execSync(
+      `powershell -NoProfile -Command "Expand-Archive -Force -Path '${tmpArchive}' -DestinationPath '${tmpDir}'"`,
+    );
+    fs.copyFileSync(path.join(tmpDir, "supermodel.exe"), BIN_PATH);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
-  fs.chmodSync(BIN_PATH, 0o755);
+  if (process.platform !== "win32") fs.chmodSync(BIN_PATH, 0o755);
   fs.unlinkSync(tmpArchive);
   console.log(`[supermodel] Installed to ${BIN_PATH}`);
 });


### PR DESCRIPTION
Picks up supermodeltools/cli#129 with CodeRabbit fixes applied:

- Unique tmpDir via `mkdtempSync` to prevent parallel-install collisions
- Neutral comment on Windows extraction block
- Fix heading hierarchy in README (H3 → H2)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)