### PR TITLE
fix(mcp): add return after t.Fatal to satisfy staticcheck SA5011

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -312,6 +312,7 @@ func TestDispatch_UnknownMethod(t *testing.T) {
 	_, rpcErr := s.dispatch(context.Background(), "unknown/method", nil)
 	if rpcErr == nil {
 		t.Fatal("expected rpcError for unknown method")
+		return
 	}
 	if rpcErr.Code != codeMethodNotFound {
 		t.Errorf("expected codeMethodNotFound (%d), got %d", codeMethodNotFound, rpcErr.Code)
@@ -325,6 +326,7 @@ func TestDispatch_ToolsCall_UnknownTool(t *testing.T) {
 	_, rpcErr := s.dispatch(context.Background(), "tools/call", params)
 	if rpcErr == nil {
 		t.Fatal("expected rpcError for unknown tool name in tools/call")
+		return
 	}
 	if rpcErr.Code != codeInternalError {
 		t.Errorf("expected codeInternalError (%d), got %d", codeInternalError, rpcErr.Code)
@@ -566,6 +568,7 @@ func TestHandleToolCall_ParseError(t *testing.T) {
 	_, rpcErr := s.handleToolCall(context.Background(), badParams)
 	if rpcErr == nil {
 		t.Fatal("expected rpcError for invalid params JSON")
+		return
 	}
 	if rpcErr.Code != codeParseError {
 		t.Errorf("expected codeParseError (%d), got %d", codeParseError, rpcErr.Code)


### PR DESCRIPTION
## Summary

- Adds an unreachable `return` after each `t.Fatal` call in three `server_test.go` tests where staticcheck SA5011 was flagging a potential nil pointer dereference
- staticcheck does not recognise `t.Fatal` as goroutine-terminating, so it considers a pointer that was checked for nil and then dereferenced in the next block as potentially nil — the `return` satisfies the analyser without changing behaviour

Affected tests:
- `TestDispatch_UnknownMethod`
- `TestDispatch_ToolsCall_UnknownTool`
- `TestHandleToolCall_ParseError`

## Test plan

- [ ] `make lint` — 0 issues
- [ ] `go test ./internal/mcp/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with additional error handling checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->