### PR TITLE
[codex] Refine README graph messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Supermodel CLI
 
-Save up to 40% on agent token costs with code graphs.
+Save 40%+ on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
@@ -23,11 +23,11 @@ npm install -g @supermodeltools/cli
 ```bash
 supermodel watch
 ```
-Uploads your repo to the Supermodel API, builds a full call graph, and writes `.graph` files next to every source file. Stays running to keep files updated as you code.
+Uploads your repo to the Supermodel API, builds a full call graph, and writes `.graph` shard files next to every source file. Stays running to keep files updated as you code.
 
 **2. Your agent reads the graph automatically**
 
-`.graph` files are plain text. Any agent that can read files — Claude Code, Cursor, Copilot, Windsurf — picks them up automatically through its normal file-reading tools. No configuration needed on the agent side.
+`.graph` files are plain text. Any agent that can read files, including Claude Code, Cursor, Copilot, and Windsurf, picks them up automatically through their normal file-reading and search tools. No configuration needed on the agent side.
 
 **3. Ask anything**
 
@@ -142,11 +142,10 @@ supermodel skill >> CLAUDE.md
 Or manually add:
 
 ```
-This repository has Supermodel graph shard files next to source files.
-Files ending in .calls.* contain function call relationships.
-Files ending in .deps.* contain dependency relationships.
-Files ending in .impact.* contain blast radius data.
-Read these files to understand relationships between modules before making changes.
+This repository has .graph.* files next to source files containing code relationship data from Supermodel.
+For src/Foo.py, the graph file is src/Foo.graph.py.
+Each .graph file can include [deps], [calls], and [impact] sections.
+Read the .graph file before the source file to understand dependencies, call relationships, and blast radius before making changes.
 ```
 
 ### On-demand analysis

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,6 +1,6 @@
 # Supermodel CLI
 
-Save up to 40% on agent token costs with code graphs.
+Save 40%+ on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
@@ -36,7 +36,7 @@ supermodel update
 
 `supermodel analyze` uploads your repo to the Supermodel API, which builds a call graph and writes a small `.graph` file next to each source file. Each file contains pre-computed context: what the file exports, what it calls, what calls it, and how it connects to the rest of the codebase.
 
-Your agent reads these files automatically when it opens or greps through your project. It spends fewer turns exploring and more turns writing.
+Your agent reads these files automatically when it opens or searches through your project. It spends fewer turns exploring and more turns writing.
 
 ## Benchmark
 


### PR DESCRIPTION
## What changed
- updated the README and npm README headline to say `Save 40%+ on agent token costs with code graphs`
- clarified that agents pick up `.graph` files through their normal file-reading and search tools
- updated the `watch` description to say it writes `.graph` shard files next to source files
- replaced the outdated manual snippet that described `.calls/.deps/.impact` files as the default format

## Why
The README copy was slightly inconsistent with the current product behavior and messaging. The default output format in the code is a single `.graph` file with `[deps]`, `[calls]`, and `[impact]` sections, while the old snippet still described the optional three-file format as if it were standard.

## Impact
This makes the primary install surfaces more credible and easier to trust by aligning the docs with the actual CLI behavior.

## Validation
- reviewed `cmd/skill.go` to confirm the current agent guidance
- reviewed `internal/shards/render.go` to confirm the default shard format


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened token-cost savings claims for clarity and accuracy
  * Clarified the structure and format of generated graph files
  * Enhanced documentation on agent compatibility and search tool usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->