### PR TITLE
Add supermodeltools.com/trial CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Read the .graph file before the source file to understand dependencies, call rel
 
 ## Configuration
 
-Get your API key at [supermodeltools.com/trial](https://supermodeltools.com/trial).
+**Save 40%+ on agent token costs — start free → [supermodeltools.com/trial](https://supermodeltools.com/trial)**
 
 Settings are stored at `~/.supermodel/config.yaml`. Environment variables override file values.
 
@@ -238,7 +238,7 @@ Exposed MCP tools: `analyze`, `dead_code`, `blast_radius`, `get_graph`.
 
 | | |
 |---|---|
-| **Start free trial** | [supermodeltools.com/trial](https://supermodeltools.com/trial) |
+| **Save 40%+ on tokens — start free** | [supermodeltools.com/trial](https://supermodeltools.com/trial) |
 | **Website** | [supermodeltools.com](https://supermodeltools.com) |
 | **API Docs** | [api.supermodeltools.com](https://api.supermodeltools.com) |
 | **Dashboard** | [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com) |

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Read the .graph file before the source file to understand dependencies, call rel
 
 ## Configuration
 
+Get your API key at [supermodeltools.com/trial](https://supermodeltools.com/trial).
+
 Settings are stored at `~/.supermodel/config.yaml`. Environment variables override file values.
 
 ```yaml
@@ -236,6 +238,7 @@ Exposed MCP tools: `analyze`, `dead_code`, `blast_radius`, `get_graph`.
 
 | | |
 |---|---|
+| **Start free trial** | [supermodeltools.com/trial](https://supermodeltools.com/trial) |
 | **Website** | [supermodeltools.com](https://supermodeltools.com) |
 | **API Docs** | [api.supermodeltools.com](https://api.supermodeltools.com) |
 | **Dashboard** | [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com) |


### PR DESCRIPTION
Adds the new `/trial` signup page link to the README so readers have a one-click path to start a free trial and get an API key.

Part of a coordinated set of PRs across the supermodeltools org adding `/trial` to each product's main user-facing surface.

Verified: https://supermodeltools.com/trial returns 200 (Pro $19/mo, Growth $199/mo, 14-day trial via Stripe).

Draft for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two trial callouts to the README: one in the Configuration section (bold link) and one as a new Links table row, both pointing to the trial page to highlight token-cost savings and simplify onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->