### PR TITLE
Link to CLI docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Save 40%+ on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
+📖 **Full CLI docs:** [docs.supermodeltools.com/cli/overview](https://docs.supermodeltools.com/cli/overview)
+
 ## Linux / Mac
 
 ```bash
@@ -240,6 +242,7 @@ Exposed MCP tools: `analyze`, `dead_code`, `blast_radius`, `get_graph`.
 |---|---|
 | **Save 40%+ on tokens — start free** | [supermodeltools.com/trial](https://supermodeltools.com/trial) |
 | **Website** | [supermodeltools.com](https://supermodeltools.com) |
+| **CLI Docs** | [docs.supermodeltools.com/cli/overview](https://docs.supermodeltools.com/cli/overview) |
 | **API Docs** | [api.supermodeltools.com](https://api.supermodeltools.com) |
 | **Dashboard** | [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com) |
 | **Twitter / X** | [@supermodeltools](https://x.com/supermodeltools) |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Save 40%+ on agent token costs with code graphs.
 
 Supermodel maps every file, function, and call relationship in your repo and writes a `.graph` file next to each source file. Your agent reads them automatically via grep and cat. No prompt changes. No extra context windows. No new tools to learn.
 
-📖 **Full CLI docs:** [docs.supermodeltools.com/cli/overview](https://docs.supermodeltools.com/cli/overview)
+📖 **Full CLI docs:** [docs.supermodeltools.com/cli/install](https://docs.supermodeltools.com/cli/install)
 
 ## Linux / Mac
 
@@ -242,7 +242,7 @@ Exposed MCP tools: `analyze`, `dead_code`, `blast_radius`, `get_graph`.
 |---|---|
 | **Save 40%+ on tokens — start free** | [supermodeltools.com/trial](https://supermodeltools.com/trial) |
 | **Website** | [supermodeltools.com](https://supermodeltools.com) |
-| **CLI Docs** | [docs.supermodeltools.com/cli/overview](https://docs.supermodeltools.com/cli/overview) |
+| **CLI Docs** | [docs.supermodeltools.com/cli/install](https://docs.supermodeltools.com/cli/install) |
 | **API Docs** | [api.supermodeltools.com](https://api.supermodeltools.com) |
 | **Dashboard** | [dashboard.supermodeltools.com](https://dashboard.supermodeltools.com) |
 | **Twitter / X** | [@supermodeltools](https://x.com/supermodeltools) |


### PR DESCRIPTION
## Summary
- Adds a prominent link to the new CLI docs site (`docs.supermodeltools.com/cli/overview`) near the top of the README
- Adds a **CLI Docs** row to the Links table

Companion PR on the docs repo: supermodeltools/docs#7

## Test plan
- [ ] README renders cleanly on GitHub
- [ ] Both new links resolve once supermodeltools/docs#7 is merged and deployed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated to include direct links to the full CLI documentation in multiple visible locations for easier access.
  * Added a standalone "Full CLI docs" callout near the top and an additional "CLI Docs" entry in the Links table to improve discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->