### PR TITLE
Replace stale 'supermodel watch' references with 'supermodel'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -g @supermodeltools/cli
 
 **1. Map your codebase**
 ```bash
-supermodel watch
+supermodel
 ```
 Uploads your repo to the Supermodel API, builds a full call graph, and writes `.graph` shard files next to every source file. Stays running to keep files updated as you code.
 
@@ -43,12 +43,12 @@ Your agent now has full visibility into your call graph, imports, domains, and b
 
 | Agent | Setup |
 |---|---|
-| **Claude Code** | Run `supermodel watch`; install the hook for live updates (setup wizard handles this) |
-| **Cursor** | Run `supermodel watch`; `.graph` files appear in context when you open any source file |
-| **GitHub Copilot** | Run `supermodel watch`; open `.graph` files in the editor to include them in context |
+| **Claude Code** | Run `supermodel`; install the hook for live updates (setup wizard handles this) |
+| **Cursor** | Run `supermodel`; `.graph` files appear in context when you open any source file |
+| **GitHub Copilot** | Run `supermodel`; open `.graph` files in the editor to include them in context |
 | **Windsurf** | Same as Cursor |
-| **Aider** | Run `supermodel watch`, then pass `--read '**/*.graph.*'` to include all graph files |
-| **Any other agent** | Run `supermodel watch` — if it can read files, it can read `.graph` files |
+| **Aider** | Run `supermodel`, then pass `--read '**/*.graph.*'` to include all graph files |
+| **Any other agent** | Run `supermodel` — if it can read files, it can read `.graph` files |
 
 For live updates in Claude Code, add this hook to `.claude/settings.json`:
 
@@ -98,7 +98,7 @@ go build -o supermodel .
 ```bash
 supermodel setup          # authenticate + configure (runs automatically after install)
 cd your/repo
-supermodel watch          # generate graph files and keep them updated
+supermodel                # generate graph files and keep them updated
 ```
 
 ---

--- a/internal/setup/wizard.go
+++ b/internal/setup/wizard.go
@@ -130,7 +130,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 		fmt.Printf("  %s}%s\n", dim, reset)
 		fmt.Println()
 		fmt.Printf("  %sOther agents (Cursor, Copilot, Windsurf, Aider) read .graph%s\n", dWhite, reset)
-		fmt.Printf("  %sfiles directly — no hook needed, just run `supermodel watch`.%s\n", dWhite, reset)
+		fmt.Printf("  %sfiles directly — no hook needed, just run `supermodel`.%s\n", dWhite, reset)
 	}
 	fmt.Println()
 
@@ -191,7 +191,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 	fmt.Printf("  %sgrep and cat — no extra steps needed.%s\n", dWhite, reset)
 	fmt.Println()
 	fmt.Printf("  %sPress %sCtrl+C%s%s to stop.%s\n", dWhite, bWhite, reset, dWhite, reset)
-	fmt.Printf("  %sRun %ssupermodel watch%s%s to restart at any time.%s\n", dWhite, bWhite, reset, dWhite, reset)
+	fmt.Printf("  %sRun %ssupermodel%s%s to restart at any time.%s\n", dWhite, bWhite, reset, dWhite, reset)
 	fmt.Println()
 
 	return shards.Watch(ctx, cfg, repoDir, shards.WatchOptions{})


### PR DESCRIPTION
Closes #149.

The \`watch\` subcommand was removed in #60 (\"Make watch the default command\"). Running \`supermodel [path]\` is now the daemon, but the setup wizard's exit message and several spots in the README still told users to run \`supermodel watch\` — which fails with \`Error: unknown command \"watch\" for \"supermodel\"\`.

## Changes
- \`internal/setup/wizard.go:133\` — *\"just run \\\`supermodel watch\\\`\"* → *\"just run \\\`supermodel\\\`\"*
- \`internal/setup/wizard.go:194\` — *\"Run \\\`supermodel watch\\\` to restart at any time.\"* → *\"Run \\\`supermodel\\\` to restart at any time.\"*
- \`README.md\` — *How it works*, *Works with any AI agent* table, and *Quick start* all use the bare command now.

## Test plan
- [ ] \`supermodel setup\` prints \"Run \\\`supermodel\\\` to restart at any time.\" on exit
- [ ] No remaining occurrences: \`grep -rn 'supermodel watch' .\` returns nothing in tracked files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command references and setup instructions to use `supermodel` instead of `supermodel watch` across all agent-specific setup guides and quickstart examples.
  * Updated setup wizard to reflect the new command naming in on-screen instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->