### PR TITLE
fix: remove install-time setup wizard from install.sh

### DIFF
--- a/cmd/install_script_test.go
+++ b/cmd/install_script_test.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"os"
-	"strings"
+	"regexp"
 	"testing"
 )
 
@@ -14,17 +14,17 @@ func TestInstallScript(t *testing.T) {
 	content := string(data)
 
 	t.Run("does not run setup wizard at install time", func(t *testing.T) {
-		// The script uses $BINARY variable, so match the literal subcommand argument
-		if strings.Contains(content, `" setup`) || strings.Contains(content, "supermodel setup") {
+		// Match command execution shape only — not arbitrary text mentions.
+		setupInvocation := regexp.MustCompile(`(?m)^\s*"\$INSTALL_DIR/\$BINARY"\s+setup\b`)
+		if setupInvocation.MatchString(content) {
 			t.Error("install.sh must not run the setup subcommand at install time — the wizard now auto-launches from bare 'supermodel' in a project directory (PR #152)")
 		}
 	})
 
 	t.Run("includes getting-started message", func(t *testing.T) {
-		lower := strings.ToLower(content)
-		hasRunSupermodel := strings.Contains(lower, "run 'supermodel'") || strings.Contains(lower, "run \"supermodel\"")
-		hasGetStarted := strings.Contains(lower, "get started")
-		if !hasRunSupermodel && !hasGetStarted {
+		hasRunSupermodel := regexp.MustCompile(`(?i)\brun\s+['"]?supermodel['"]?\b`).MatchString(content)
+		hasProjectContext := regexp.MustCompile(`(?i)\b(in|inside)\s+your\s+project\b|\bproject\s+directory\b`).MatchString(content)
+		if !hasRunSupermodel || !hasProjectContext {
 			t.Error("install.sh must include a getting-started message directing users to run 'supermodel' in their project directory")
 		}
 	})

--- a/cmd/install_script_test.go
+++ b/cmd/install_script_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInstallScript(t *testing.T) {
+	data, err := os.ReadFile("../install.sh")
+	if err != nil {
+		t.Fatalf("could not read install.sh: %v", err)
+	}
+	content := string(data)
+
+	t.Run("does not run setup wizard at install time", func(t *testing.T) {
+		// The script uses $BINARY variable, so match the literal subcommand argument
+		if strings.Contains(content, `" setup`) || strings.Contains(content, "supermodel setup") {
+			t.Error("install.sh must not run the setup subcommand at install time — the wizard now auto-launches from bare 'supermodel' in a project directory (PR #152)")
+		}
+	})
+
+	t.Run("includes getting-started message", func(t *testing.T) {
+		lower := strings.ToLower(content)
+		hasRunSupermodel := strings.Contains(lower, "run 'supermodel'") || strings.Contains(lower, "run \"supermodel\"")
+		hasGetStarted := strings.Contains(lower, "get started")
+		if !hasRunSupermodel && !hasGetStarted {
+			t.Error("install.sh must include a getting-started message directing users to run 'supermodel' in their project directory")
+		}
+	})
+}

--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,5 @@ install -m755 "$TMP/$BINARY" "$INSTALL_DIR/$BINARY"
 echo "Installed: $INSTALL_DIR/$BINARY"
 "$INSTALL_DIR/$BINARY" version
 
-# Run the setup wizard when a controlling terminal is available.
-# Use /dev/tty as stdin so interactive prompts work even in piped installs
-# (e.g. curl … | sh), where stdin is the pipe rather than the terminal.
-if { </dev/tty; } 2>/dev/null; then
-  echo ""
-  "$INSTALL_DIR/$BINARY" setup </dev/tty
-fi
+echo ""
+echo "Run 'supermodel' inside your project directory to get started."


### PR DESCRIPTION
Closes #153. Closes #158.

The install-time wizard runs in the wrong directory (wherever curl was run, not the user's project). Since bare `supermodel` now auto-launches setup (PR #152), the install.sh wizard call is redundant.

TDD: added failing test first, implementing fix now.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for the installation script to verify it provides users with appropriate getting-started instructions upon completion and maintains script integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->