### PR TITLE
fix: print getting-started message after npm global install

### DIFF
--- a/cmd/npm_package_test.go
+++ b/cmd/npm_package_test.go
@@ -28,7 +28,7 @@ func TestNpmPackageHasPostinstallMessage(t *testing.T) {
 		lower := strings.ToLower(content)
 		hasRunSupermodel := strings.Contains(lower, "run 'supermodel'") || strings.Contains(lower, `run "supermodel"`)
 		hasGetStarted := strings.Contains(lower, "get started")
-		if !hasRunSupermodel && !hasGetStarted {
+		if !hasRunSupermodel || !hasGetStarted {
 			t.Error("npm/install.js must print a getting-started message directing users to run 'supermodel' in their project directory")
 		}
 	})

--- a/cmd/npm_package_test.go
+++ b/cmd/npm_package_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestNpmPackageHasPostinstallMessage verifies that npm/install.js prints a
+// getting-started message after the binary is installed, directing users to
+// run 'supermodel' inside their project directory.
+//
+// Resolves: https://github.com/supermodeltools/cli/issues/159
+func TestNpmPackageHasPostinstallMessage(t *testing.T) {
+	data, err := os.ReadFile("../npm/install.js")
+	if err != nil {
+		t.Fatalf("could not read npm/install.js: %v", err)
+	}
+	content := string(data)
+
+	t.Run("does not run setup wizard at install time", func(t *testing.T) {
+		if strings.Contains(content, `" setup`) || strings.Contains(content, "supermodel setup") {
+			t.Error("npm/install.js must not run the setup subcommand at install time")
+		}
+	})
+
+	t.Run("includes getting-started message", func(t *testing.T) {
+		lower := strings.ToLower(content)
+		hasRunSupermodel := strings.Contains(lower, "run 'supermodel'") || strings.Contains(lower, `run "supermodel"`)
+		hasGetStarted := strings.Contains(lower, "get started")
+		if !hasRunSupermodel && !hasGetStarted {
+			t.Error("npm/install.js must print a getting-started message directing users to run 'supermodel' in their project directory")
+		}
+	})
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -125,6 +125,7 @@ if (require.main === module) {
     if (process.platform !== "win32") fs.chmodSync(BIN_PATH, 0o755);
     fs.unlinkSync(tmpArchive);
     console.log(`[supermodel] Installed to ${BIN_PATH}`);
+    console.log("\nsupermodel installed. Run 'supermodel' inside your project directory to get started.\n");
   });
 }
 


### PR DESCRIPTION
Closes #159.

`npm install -g @supermodeltools/cli` installs the binary but gives no guidance to the user. This PR adds a postinstall message to `npm/install.js` that directs users to run `supermodel` inside their project directory.

## Changes

- Add a getting-started message at the end of `npm/install.js` postinstall script
- Add a Go test (`cmd/npm_package_test.go`) that verifies the message exists

## TDD

Failing test committed first — the `includes getting-started message` subtest fails before the fix, and passes after.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for installation script behavior and messaging
  * Implemented npm postinstall messaging verification
  * Enhanced terminal detection and authentication fallback scenario coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->