### PR TITLE
CLI cleanup: production-ready file-mode workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,31 +110,15 @@ Manages `.graph.*` shards written next to each source file. Agents read these wi
 
 | Command | Description |
 |---|---|
-| `analyze [path]` | Upload repo, run full analysis, write graph files (use `--three-file` for best results, `--no-shards` to skip) |
+| `analyze [path]` | Upload repo, run full analysis, write `.graph.*` files (`--no-shards` skips file writing) |
 | `skill` | Print agent awareness prompt — pipe to `CLAUDE.md` or `AGENTS.md` |
-| `watch [path]` | Generate graph files on startup, then keep them updated incrementally |
+| `supermodel` | Generate graph files on startup, then keep them updated incrementally |
 | `clean [path]` | Remove all `.graph.*` files from the repository |
-| `hook` | Claude Code `PostToolUse` hook — forward file-change events to the `watch` daemon |
+| `hook` | Claude Code `PostToolUse` hook — forward file-change events to the `supermodel` daemon |
 
-### Three-file shard format (recommended)
+### Tell your agent about graph files
 
-For best results, use the `--three-file` flag to generate separate `.calls`, `.deps`, and `.impact` files instead of a single `.graph` file:
-
-```bash
-supermodel analyze --three-file
-```
-
-This produces three files per source file:
-
-```
-src/cache.go          → src/cache.calls.go    # who calls what, with file:line
-                      → src/cache.deps.go     # imports and imported-by
-                      → src/cache.impact.go   # risk level, domains, blast radius
-```
-
-The three-file format is **68% faster** in benchmarks because grep hits are more targeted — searching for a function name hits only the `.calls` file with caller/callee data, not a combined blob.
-
-**Tell your agent about the files** by adding this to `CLAUDE.md` or `AGENTS.md`:
+Add the Supermodel graph-file prompt to `CLAUDE.md`, `AGENTS.md`, or your agent's instruction file:
 
 ```bash
 supermodel skill >> CLAUDE.md

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -11,7 +11,6 @@ import (
 func init() {
 	var opts analyze.Options
 	var noShards bool
-	var threeFile bool
 
 	c := &cobra.Command{
 		Use:   "analyze [path]",
@@ -50,9 +49,6 @@ Use --no-shards to skip writing graph files.`,
 	c.Flags().BoolVar(&opts.Force, "force", false, "re-analyze even if a cached result exists")
 	c.Flags().StringVarP(&opts.Output, "output", "o", "", "output format: human|json")
 	c.Flags().BoolVar(&noShards, "no-shards", false, "skip writing .graph.* shard files")
-	c.Flags().BoolVar(&threeFile, "three-file", false, "deprecated: standard .graph.* shards are now the only supported file mode")
-	_ = c.Flags().MarkDeprecated("three-file", "standard .graph.* shards are now the only supported file mode")
-	_ = c.Flags().MarkHidden("three-file")
 
 	rootCmd.AddCommand(c)
 }

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/supermodeltools/cli/internal/analyze"
@@ -35,9 +33,6 @@ Use --no-shards to skip writing graph files.`,
 			if err := cfg.RequireAPIKey(); err != nil {
 				return err
 			}
-			if noShards && threeFile {
-				return fmt.Errorf("--three-file cannot be used with --no-shards")
-			}
 			dir := "."
 			if len(args) > 0 {
 				dir = args[0]
@@ -46,7 +41,7 @@ Use --no-shards to skip writing graph files.`,
 				// Shard mode: Generate handles the full pipeline (API call +
 				// cache + shards) in a single upload. Running analyze.Run
 				// first would duplicate the API call.
-				return shards.Generate(cmd.Context(), cfg, dir, shards.GenerateOptions{Force: opts.Force, ThreeFile: threeFile})
+				return shards.Generate(cmd.Context(), cfg, dir, shards.GenerateOptions{Force: opts.Force})
 			}
 			return analyze.Run(cmd.Context(), cfg, dir, opts)
 		},
@@ -55,7 +50,9 @@ Use --no-shards to skip writing graph files.`,
 	c.Flags().BoolVar(&opts.Force, "force", false, "re-analyze even if a cached result exists")
 	c.Flags().StringVarP(&opts.Output, "output", "o", "", "output format: human|json")
 	c.Flags().BoolVar(&noShards, "no-shards", false, "skip writing .graph.* shard files")
-	c.Flags().BoolVar(&threeFile, "three-file", false, "generate .calls/.deps/.impact files instead of single .graph")
+	c.Flags().BoolVar(&threeFile, "three-file", false, "deprecated: standard .graph.* shards are now the only supported file mode")
+	_ = c.Flags().MarkDeprecated("three-file", "standard .graph.* shards are now the only supported file mode")
+	_ = c.Flags().MarkHidden("three-file")
 
 	rootCmd.AddCommand(c)
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -11,14 +11,14 @@ func init() {
 
 	c := &cobra.Command{
 		Use:   "hook",
-		Short: "Forward Claude Code file-change events to the watch daemon",
-		Long:  `Reads a Claude Code PostToolUse JSON payload from stdin and forwards the file path to the running watch daemon via UDP. Install as a PostToolUse hook in .claude/settings.json.`,
+		Short: "Forward Claude Code file-change events to the Supermodel daemon",
+		Long:  `Reads a Claude Code PostToolUse JSON payload from stdin and forwards the file path to the running Supermodel daemon via UDP. Install as a PostToolUse hook in .claude/settings.json.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return shards.Hook(port)
 		},
 	}
 
-	c.Flags().IntVar(&port, "port", 7734, "UDP port of the watch daemon")
+	c.Flags().IntVar(&port, "port", 7734, "UDP port of the Supermodel daemon")
 	rootCmd.AddCommand(c)
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -17,7 +17,7 @@ func init() {
 For CI or headless environments, pass the key directly:
   supermodel login --token smsk_live_...`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if token != "" {
+			if cmd.Flags().Changed("token") {
 				return auth.LoginWithToken(token)
 			}
 			return auth.Login(cmd.Context())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"syscall"
 	"time"
 
@@ -176,8 +178,22 @@ func init() {
 
 // Execute is the entry point called by main.
 func Execute() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			stop()
+		case <-done:
+		}
+	}()
+	rootCmd.SetContext(ctx)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		close(done)
+		stop()
 		os.Exit(1)
 	}
+	close(done)
+	stop()
 }

--- a/internal/cache/fingerprint.go
+++ b/internal/cache/fingerprint.go
@@ -155,11 +155,29 @@ func ignoreFingerprintPath(path string) bool {
 	if len(parts) == 0 {
 		return false
 	}
+	if len(parts) > 1 && strings.HasPrefix(parts[0], ".") {
+		return true
+	}
 	switch parts[0] {
 	case ".supermodel", "docs-output", "node_modules", "vendor", "dist", "build", "coverage":
 		return true
 	}
-	return isGeneratedShardPath(path)
+	return isGeneratedShardPath(path) || isSensitiveFingerprintPath(path)
+}
+
+func isSensitiveFingerprintPath(path string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	if base == ".env" {
+		return true
+	}
+	for _, suffix := range []string{".key", ".pem", ".p12", ".pfx", ".crt", ".cert", ".tfstate", ".tfstate.backup"} {
+		if strings.HasSuffix(base, suffix) {
+			return true
+		}
+	}
+	return strings.Contains(base, "secret") ||
+		strings.Contains(base, "credential") ||
+		strings.Contains(base, "password")
 }
 
 func isGeneratedShardPath(path string) bool {

--- a/internal/cache/fingerprint.go
+++ b/internal/cache/fingerprint.go
@@ -18,26 +18,27 @@ import (
 // For dirty git repos (~100ms): returns commitSHA:dirtyHash.
 // For non-git dirs: returns empty string and an error.
 func RepoFingerprint(dir string) (string, error) {
-	commitSHA, err := gitOutput(dir, "rev-parse", "HEAD")
+	commitSHA, err := gitOutputTrim(dir, "rev-parse", "HEAD")
 	if err != nil {
 		return "", fmt.Errorf("not a git repo: %w", err)
 	}
 
-	dirty, err := gitOutput(dir, "status", "--porcelain", "--untracked-files=all")
+	statusOut, err := gitOutputRaw(dir, "status", "--porcelain=v1", "-z", "--untracked-files=all")
 	if err != nil {
 		return commitSHA, nil
 	}
-	dirty = filterFingerprintStatus(dirty)
+	dirtyEntries := filterFingerprintStatus(parseGitStatusZ(statusOut))
 
-	if dirty == "" {
+	if len(dirtyEntries) == 0 {
 		return commitSHA, nil
 	}
 
 	// Dirty: hash tracked changes plus untracked file contents. Generated
 	// files are filtered because they are not uploaded for analysis.
 	h := sha256.New()
-	fmt.Fprintf(h, "status\x00%s\x00", dirty)
-	if err := hashDirtyFiles(h, dir, dirty); err != nil {
+	fmt.Fprint(h, "status\x00")
+	writeStatusEntries(h, dirtyEntries)
+	if err := hashDirtyFiles(h, dir, dirtyEntries); err != nil {
 		return commitSHA + ":dirty", nil
 	}
 	if err := hashUntrackedFiles(h, dir); err != nil {
@@ -47,106 +48,172 @@ func RepoFingerprint(dir string) (string, error) {
 	return commitSHA + ":" + hex.EncodeToString(sum[:8]), nil
 }
 
-func hashDirtyFiles(h io.Writer, dir, status string) error {
-	for _, line := range strings.Split(status, "\n") {
-		if line == "" || strings.HasPrefix(line, "?? ") {
+type gitStatusEntry struct {
+	code  string
+	paths []string
+}
+
+func parseGitStatusZ(status string) []gitStatusEntry {
+	if status == "" {
+		return nil
+	}
+	records := strings.Split(status, "\x00")
+	entries := make([]gitStatusEntry, 0, len(records))
+	for i := 0; i < len(records); i++ {
+		record := records[i]
+		if record == "" || len(record) < 4 {
 			continue
 		}
-		rel := statusPath(line)
+		entry := gitStatusEntry{
+			code:  record[:2],
+			paths: []string{filepath.ToSlash(record[3:])},
+		}
+		if isRenameOrCopyStatus(entry.code) && i+1 < len(records) && records[i+1] != "" {
+			entry.paths = append(entry.paths, filepath.ToSlash(records[i+1]))
+			i++
+		}
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func filterFingerprintStatus(entries []gitStatusEntry) []gitStatusEntry {
+	kept := make([]gitStatusEntry, 0, len(entries))
+	for _, entry := range entries {
+		if !statusEntryTouchesUploadablePath(entry) {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	sort.Slice(kept, func(i, j int) bool {
+		return statusEntryKey(kept[i]) < statusEntryKey(kept[j])
+	})
+	return kept
+}
+
+func statusEntryTouchesUploadablePath(entry gitStatusEntry) bool {
+	for _, path := range entry.paths {
+		if path != "" && !ignoreFingerprintPath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func statusEntryKey(entry gitStatusEntry) string {
+	return entry.code + "\x00" + strings.Join(entry.paths, "\x00")
+}
+
+func writeStatusEntries(h io.Writer, entries []gitStatusEntry) {
+	for _, entry := range entries {
+		fmt.Fprintf(h, "%s\x00", entry.code)
+		for _, path := range entry.paths {
+			fmt.Fprintf(h, "%s\x00", path)
+		}
+	}
+}
+
+func isRenameOrCopyStatus(code string) bool {
+	return strings.ContainsAny(code, "RC")
+}
+
+func isRenameStatus(code string) bool {
+	return strings.Contains(code, "R")
+}
+
+func hashDirtyFiles(h io.Writer, dir string, entries []gitStatusEntry) error {
+	for _, entry := range entries {
+		if entry.code == "??" || len(entry.paths) == 0 {
+			continue
+		}
+
+		if isRenameOrCopyStatus(entry.code) && len(entry.paths) > 1 {
+			newPath := entry.paths[0]
+			oldPath := entry.paths[1]
+			if isRenameStatus(entry.code) && !ignoreFingerprintPath(oldPath) && oldPath != newPath {
+				fmt.Fprintf(h, "tracked\x00%s\x00deleted\x00", oldPath)
+			}
+			if !ignoreFingerprintPath(newPath) {
+				if err := hashFileState(h, dir, "tracked", newPath, true); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		rel := entry.paths[0]
 		if rel == "" || ignoreFingerprintPath(rel) {
 			continue
 		}
-		full := filepath.Join(dir, rel)
-		info, err := os.Lstat(full)
-		if os.IsNotExist(err) {
-			fmt.Fprintf(h, "tracked\x00%s\x00deleted\x00", rel)
-			continue
-		}
-		if err != nil {
+		if err := hashFileState(h, dir, "tracked", rel, true); err != nil {
 			return err
 		}
-		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-			continue
-		}
-		fmt.Fprintf(h, "tracked\x00%s\x00%d\x00", rel, info.Size())
-		f, err := os.Open(full)
-		if err != nil {
-			return err
-		}
-		if _, err := io.Copy(h, f); err != nil {
-			f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-		fmt.Fprint(h, "\x00")
 	}
 	return nil
 }
 
 func hashUntrackedFiles(h io.Writer, dir string) error {
-	out, err := gitOutput(dir, "ls-files", "--others", "--exclude-standard")
+	out, err := gitOutputRaw(dir, "ls-files", "-z", "--others", "--exclude-standard")
 	if err != nil || out == "" {
 		return err
 	}
-	files := strings.Split(out, "\n")
+	files := splitNUL(out)
 	sort.Strings(files)
 	for _, rel := range files {
 		if rel == "" {
 			continue
 		}
+		rel = filepath.ToSlash(rel)
 		if ignoreFingerprintPath(rel) {
 			continue
 		}
-		full := filepath.Join(dir, rel)
-		info, err := os.Lstat(full)
-		if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
-			continue
-		}
-		fmt.Fprintf(h, "untracked\x00%s\x00%d\x00", rel, info.Size())
-		f, err := os.Open(full)
-		if err != nil {
+		if err := hashFileState(h, dir, "untracked", rel, false); err != nil {
 			return err
 		}
-		if _, err := io.Copy(h, f); err != nil {
-			f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-		fmt.Fprint(h, "\x00")
 	}
 	return nil
 }
 
-func filterFingerprintStatus(status string) string {
-	var kept []string
-	for _, line := range strings.Split(status, "\n") {
-		line = strings.TrimRight(line, "\r")
-		if strings.TrimSpace(line) == "" {
-			continue
-		}
-		path := statusPath(line)
-		if path == "" || ignoreFingerprintPath(path) {
-			continue
-		}
-		kept = append(kept, line)
+func splitNUL(out string) []string {
+	if out == "" {
+		return nil
 	}
-	sort.Strings(kept)
-	return strings.Join(kept, "\n")
+	fields := strings.Split(out, "\x00")
+	if len(fields) > 0 && fields[len(fields)-1] == "" {
+		fields = fields[:len(fields)-1]
+	}
+	return fields
 }
 
-func statusPath(line string) string {
-	if len(line) < 4 {
-		return ""
+func hashFileState(h io.Writer, dir, kind, rel string, missingAsDeleted bool) error {
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	info, err := os.Lstat(full)
+	if os.IsNotExist(err) {
+		if missingAsDeleted {
+			fmt.Fprintf(h, "%s\x00%s\x00deleted\x00", kind, rel)
+		}
+		return nil
 	}
-	path := strings.TrimSpace(line[3:])
-	if _, after, ok := strings.Cut(path, " -> "); ok {
-		path = after
+	if err != nil {
+		return err
 	}
-	return filepath.ToSlash(path)
+	if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
+	fmt.Fprintf(h, "%s\x00%s\x00%d\x00", kind, rel, info.Size())
+	f, err := os.Open(full)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(h, f); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	fmt.Fprint(h, "\x00")
+	return nil
 }
 
 func ignoreFingerprintPath(path string) bool {
@@ -155,14 +222,54 @@ func ignoreFingerprintPath(path string) bool {
 	if len(parts) == 0 {
 		return false
 	}
-	if len(parts) > 1 && strings.HasPrefix(parts[0], ".") {
-		return true
+	for _, part := range parts[:len(parts)-1] {
+		if strings.HasPrefix(part, ".") || defaultUploadSkipDir(part) {
+			return true
+		}
 	}
-	switch parts[0] {
-	case ".supermodel", "docs-output", "node_modules", "vendor", "dist", "build", "coverage":
+	filename := parts[len(parts)-1]
+	return isGeneratedShardPath(path) ||
+		isSensitiveFingerprintPath(path) ||
+		defaultUploadSkipFile(filename) ||
+		defaultUploadSkipExtension(filename)
+}
+
+func defaultUploadSkipDir(name string) bool {
+	// Keep this in lockstep with internal/shards/zip.go upload exclusions.
+	// The cache package cannot import shards because shards already imports cache.
+	switch name {
+	case ".git", "node_modules", "vendor", ".venv", "venv", "__pycache__", "dist", "build",
+		".next", ".nuxt", ".cache", ".turbo", "coverage", ".nyc_output", "__snapshots__",
+		"docs-output", ".terraform":
 		return true
+	default:
+		return false
 	}
-	return isGeneratedShardPath(path) || isSensitiveFingerprintPath(path)
+}
+
+func defaultUploadSkipFile(name string) bool {
+	// Keep this in lockstep with internal/shards/zip.go upload exclusions.
+	switch name {
+	case "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb", "Gemfile.lock",
+		"poetry.lock", "go.sum", "Cargo.lock":
+		return true
+	default:
+		return false
+	}
+}
+
+func defaultUploadSkipExtension(name string) bool {
+	// Keep this in lockstep with internal/shards/zip.go upload exclusions.
+	ext := strings.ToLower(filepath.Ext(name))
+	switch ext {
+	case ".map", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".otf", ".mp4", ".mp3",
+		".wav", ".png", ".jpg", ".jpeg", ".gif", ".webp":
+		return true
+	default:
+		return strings.HasSuffix(name, ".min.js") ||
+			strings.HasSuffix(name, ".min.css") ||
+			strings.HasSuffix(name, ".bundle.js")
+	}
 }
 
 func isSensitiveFingerprintPath(path string) bool {
@@ -196,10 +303,18 @@ func isGeneratedShardPath(path string) bool {
 	}
 }
 
-// gitOutput runs a git command in dir and returns its trimmed stdout.
-func gitOutput(dir string, args ...string) (string, error) {
+func gitOutputRaw(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
 	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// gitOutputTrim runs a git command in dir and returns stdout without trailing whitespace.
+func gitOutputTrim(dir string, args ...string) (string, error) {
+	out, err := gitOutputRaw(dir, args...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cache/fingerprint.go
+++ b/internal/cache/fingerprint.go
@@ -4,7 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -19,22 +23,159 @@ func RepoFingerprint(dir string) (string, error) {
 		return "", fmt.Errorf("not a git repo: %w", err)
 	}
 
-	dirty, err := gitOutput(dir, "status", "--porcelain", "--untracked-files=no")
+	dirty, err := gitOutput(dir, "status", "--porcelain", "--untracked-files=all")
 	if err != nil {
 		return commitSHA, nil
 	}
+	dirty = filterFingerprintStatus(dirty)
 
 	if dirty == "" {
 		return commitSHA, nil
 	}
 
-	// Dirty: hash the diff to capture uncommitted changes.
-	diff, err := gitOutput(dir, "diff", "HEAD")
-	if err != nil {
+	// Dirty: hash tracked changes plus untracked file contents. Generated
+	// files are filtered because they are not uploaded for analysis.
+	h := sha256.New()
+	fmt.Fprintf(h, "status\x00%s\x00", dirty)
+	if err := hashDirtyFiles(h, dir, dirty); err != nil {
 		return commitSHA + ":dirty", nil
 	}
-	h := sha256.Sum256([]byte(diff))
-	return commitSHA + ":" + hex.EncodeToString(h[:8]), nil
+	if err := hashUntrackedFiles(h, dir); err != nil {
+		return commitSHA + ":dirty", nil
+	}
+	sum := h.Sum(nil)
+	return commitSHA + ":" + hex.EncodeToString(sum[:8]), nil
+}
+
+func hashDirtyFiles(h io.Writer, dir, status string) error {
+	for _, line := range strings.Split(status, "\n") {
+		if line == "" || strings.HasPrefix(line, "?? ") {
+			continue
+		}
+		rel := statusPath(line)
+		if rel == "" || ignoreFingerprintPath(rel) {
+			continue
+		}
+		full := filepath.Join(dir, rel)
+		info, err := os.Lstat(full)
+		if os.IsNotExist(err) {
+			fmt.Fprintf(h, "tracked\x00%s\x00deleted\x00", rel)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		fmt.Fprintf(h, "tracked\x00%s\x00%d\x00", rel, info.Size())
+		f, err := os.Open(full)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(h, f); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		fmt.Fprint(h, "\x00")
+	}
+	return nil
+}
+
+func hashUntrackedFiles(h io.Writer, dir string) error {
+	out, err := gitOutput(dir, "ls-files", "--others", "--exclude-standard")
+	if err != nil || out == "" {
+		return err
+	}
+	files := strings.Split(out, "\n")
+	sort.Strings(files)
+	for _, rel := range files {
+		if rel == "" {
+			continue
+		}
+		if ignoreFingerprintPath(rel) {
+			continue
+		}
+		full := filepath.Join(dir, rel)
+		info, err := os.Lstat(full)
+		if err != nil || info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		fmt.Fprintf(h, "untracked\x00%s\x00%d\x00", rel, info.Size())
+		f, err := os.Open(full)
+		if err != nil {
+			return err
+		}
+		if _, err := io.Copy(h, f); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+		fmt.Fprint(h, "\x00")
+	}
+	return nil
+}
+
+func filterFingerprintStatus(status string) string {
+	var kept []string
+	for _, line := range strings.Split(status, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		path := statusPath(line)
+		if path == "" || ignoreFingerprintPath(path) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	sort.Strings(kept)
+	return strings.Join(kept, "\n")
+}
+
+func statusPath(line string) string {
+	if len(line) < 4 {
+		return ""
+	}
+	path := strings.TrimSpace(line[3:])
+	if _, after, ok := strings.Cut(path, " -> "); ok {
+		path = after
+	}
+	return filepath.ToSlash(path)
+}
+
+func ignoreFingerprintPath(path string) bool {
+	path = filepath.ToSlash(path)
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case ".supermodel", "docs-output", "node_modules", "vendor", "dist", "build", "coverage":
+		return true
+	}
+	return isGeneratedShardPath(path)
+}
+
+func isGeneratedShardPath(path string) bool {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return false
+	}
+	stem := strings.TrimSuffix(base, ext)
+	tag := strings.TrimPrefix(filepath.Ext(stem), ".")
+	switch tag {
+	case "graph", "calls", "deps", "impact":
+		return true
+	default:
+		return false
+	}
 }
 
 // gitOutput runs a git command in dir and returns its trimmed stdout.

--- a/internal/cache/fingerprint.go
+++ b/internal/cache/fingerprint.go
@@ -318,7 +318,7 @@ func gitOutputTrim(dir string, args ...string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(out), nil
 }
 
 // AnalysisKey builds a cache key for a specific analysis type on a repo state.

--- a/internal/cache/fingerprint_test.go
+++ b/internal/cache/fingerprint_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -118,6 +119,109 @@ func TestRepoFingerprint_ChangesForUntrackedFile(t *testing.T) {
 	}
 }
 
+func TestRepoFingerprint_ChangesForUntrackedQuotedFilename(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filesystems do not allow double quotes in filenames")
+	}
+	dir := initGitRepo(t)
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rel := `quote" file.go`
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte("package main\nfunc one() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Fatal("fingerprint should change for an untracked filename requiring git quoting")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte("package main\nfunc two() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp3, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp2 == fp3 {
+		t.Fatal("fingerprint should change when quoted untracked file contents change")
+	}
+}
+
+func TestRepoFingerprint_ChangesForTrackedQuotedFilename(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filesystems do not allow double quotes in filenames")
+	}
+	dir := initGitRepo(t)
+	rel := `quote" file.go`
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte("package main\nfunc one() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", rel)
+	run(t, dir, "git", "commit", "-m", "quoted filename")
+
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte("package main\nfunc two() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Fatal("fingerprint should change for a dirty tracked filename requiring git quoting")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte("package main\nfunc three() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp3, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp2 == fp3 {
+		t.Fatal("fingerprint should change when quoted tracked file contents change")
+	}
+}
+
+func TestRepoFingerprint_RenameToIgnoredDirInvalidatesSource(t *testing.T) {
+	dir := initGitRepo(t)
+	src := filepath.Join("src", "keep.go")
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, src), []byte("package main\nfunc keep() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", src)
+	run(t, dir, "git", "commit", "-m", "source file")
+
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "docs-output"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "mv", src, filepath.Join("docs-output", "keep.go"))
+
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Fatal("renaming an uploadable source into an ignored directory should invalidate the source fingerprint")
+	}
+}
+
 func TestRepoFingerprint_IgnoresGeneratedArtifacts(t *testing.T) {
 	dir := initGitRepo(t)
 	fp1, err := RepoFingerprint(dir)
@@ -160,6 +264,9 @@ func TestRepoFingerprint_IgnoresHiddenDirsAndSecrets(t *testing.T) {
 	for _, rel := range []string{
 		filepath.Join(".claude", "settings.json"),
 		filepath.Join(".github", "workflows", "ci.yml"),
+		filepath.Join("frontend", "__snapshots__", "component.snap"),
+		filepath.Join("web", ".cache", "vite.json"),
+		filepath.Join("app", ".venv", "pyvenv.cfg"),
 		".env",
 		"prod.key",
 		"credentials.txt",

--- a/internal/cache/fingerprint_test.go
+++ b/internal/cache/fingerprint_test.go
@@ -88,6 +88,99 @@ func TestRepoFingerprint_ChangesAfterCommit(t *testing.T) {
 	}
 }
 
+func TestRepoFingerprint_ChangesForUntrackedFile(t *testing.T) {
+	dir := initGitRepo(t)
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "generated.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 == fp2 {
+		t.Error("fingerprint should change when an untracked uploadable file appears")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "generated.go"), []byte("package main\nfunc generated() {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fp3, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp2 == fp3 {
+		t.Error("fingerprint should change when untracked file contents change")
+	}
+}
+
+func TestRepoFingerprint_IgnoresGeneratedArtifacts(t *testing.T) {
+	dir := initGitRepo(t)
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, ".supermodel"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".supermodel", "shards.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// generated graph\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "docs-output"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docs-output", "index.html"), []byte("<html></html>\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint should ignore generated artifacts: %q != %q", fp1, fp2)
+	}
+}
+
+func TestRepoFingerprint_IgnoresGeneratedArtifactsWhenSourceIsDirty(t *testing.T) {
+	dir := initGitRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// generated graph\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", "-f", "main.graph.go")
+	run(t, dir, "git", "commit", "-m", "track generated artifact")
+
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n// dirty\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// regenerated graph\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fpWithGeneratedDirty, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// generated graph\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fpSourceOnlyDirty, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fpWithGeneratedDirty != fpSourceOnlyDirty {
+		t.Fatalf("generated shard changes should not affect source fingerprint: %q != %q", fpWithGeneratedDirty, fpSourceOnlyDirty)
+	}
+}
+
 func TestRepoFingerprint_NotGitRepo(t *testing.T) {
 	dir := t.TempDir()
 	_, err := RepoFingerprint(dir)

--- a/internal/cache/fingerprint_test.go
+++ b/internal/cache/fingerprint_test.go
@@ -150,6 +150,38 @@ func TestRepoFingerprint_IgnoresGeneratedArtifacts(t *testing.T) {
 	}
 }
 
+func TestRepoFingerprint_IgnoresHiddenDirsAndSecrets(t *testing.T) {
+	dir := initGitRepo(t)
+	fp1, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{
+		filepath.Join(".claude", "settings.json"),
+		filepath.Join(".github", "workflows", "ci.yml"),
+		".env",
+		"prod.key",
+		"credentials.txt",
+	} {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("ignored\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fp2, err := RepoFingerprint(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fp1 != fp2 {
+		t.Fatalf("fingerprint should ignore non-uploaded hidden dirs and secrets: %q != %q", fp1, fp2)
+	}
+}
+
 func TestRepoFingerprint_IgnoresGeneratedArtifactsWhenSourceIsDirty(t *testing.T) {
 	dir := initGitRepo(t)
 	if err := os.WriteFile(filepath.Join(dir, "main.graph.go"), []byte("// generated graph\n"), 0o600); err != nil {

--- a/internal/restore/local.go
+++ b/internal/restore/local.go
@@ -348,6 +348,9 @@ func collectFiles(ctx context.Context, rootDir string) (extCounts map[string]int
 		if strings.HasPrefix(d.Name(), ".") {
 			return nil
 		}
+		if isGeneratedShardPath(rel) {
+			return nil
+		}
 
 		ext := strings.ToLower(filepath.Ext(path))
 		if _, ok := extToLanguage[ext]; !ok {
@@ -368,6 +371,22 @@ func collectFiles(ctx context.Context, rootDir string) (extCounts map[string]int
 		return nil
 	})
 	return extCounts, dirFiles, total, walkErr
+}
+
+func isGeneratedShardPath(path string) bool {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	if ext == "" {
+		return false
+	}
+	stem := strings.TrimSuffix(base, ext)
+	tag := strings.TrimPrefix(filepath.Ext(stem), ".")
+	switch tag {
+	case "graph", "calls", "deps", "impact":
+		return true
+	default:
+		return false
+	}
 }
 
 func detectLanguages(extCounts map[string]int) (primary string, languages []string) {

--- a/internal/restore/local.go
+++ b/internal/restore/local.go
@@ -29,7 +29,7 @@ var ignoreDirs = map[string]bool{
 	"build": true, "target": true, ".tox": true, "venv": true,
 	".venv": true, "coverage": true, ".nyc_output": true, "out": true,
 	".next": true, ".nuxt": true, ".turbo": true, "Pods": true,
-	"elm-stuff": true, "_build": true, "env": true,
+	"elm-stuff": true, "_build": true, "env": true, "docs-output": true,
 }
 
 // extToLanguage maps common file extensions to language display names.
@@ -332,7 +332,7 @@ func collectFiles(ctx context.Context, rootDir string) (extCounts map[string]int
 		}
 		if d.IsDir() {
 			name := d.Name()
-			if ignoreDirs[name] || strings.HasPrefix(name, ".") {
+			if path != rootDir && (ignoreDirs[name] || strings.HasPrefix(name, ".")) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -350,9 +350,10 @@ func collectFiles(ctx context.Context, rootDir string) (extCounts map[string]int
 		}
 
 		ext := strings.ToLower(filepath.Ext(path))
-		if ext != "" {
-			extCounts[ext]++
+		if _, ok := extToLanguage[ext]; !ok {
+			return nil
 		}
+		extCounts[ext]++
 		total++
 
 		parts := strings.SplitN(rel, string(filepath.Separator), 3)

--- a/internal/restore/render.go
+++ b/internal/restore/render.go
@@ -45,7 +45,7 @@ const contextBombTmpl = `# Supermodel Context — {{.ProjectName}}
 **Language:** {{.Graph.Language}}{{if .Graph.Framework}}
 **Framework:** {{.Graph.Framework}}{{end}}{{if .Graph.Description}}
 **Description:** {{.Graph.Description}}{{end}}
-**Codebase:** {{.Graph.Stats.TotalFiles}} files · {{.Graph.Stats.TotalFunctions}} functions
+**Codebase:** {{.Graph.Stats.TotalFiles}} source files{{if and .LocalMode (eq .Graph.Stats.TotalFunctions 0)}} · functions not counted locally{{else}} · {{.Graph.Stats.TotalFunctions}} functions{{end}}
 {{- if .Graph.Stats.Languages}}
 
 **Languages:** {{languageList .Graph.Stats.Languages}}{{end}}{{if .Graph.ExternalDeps}}
@@ -168,9 +168,14 @@ func truncateToTokenBudget(graph *ProjectGraph, projectName string, opts RenderO
 		fmt.Fprintf(&hdr, "> ⚠️ %d circular dependency %s detected\n", graph.Stats.CircularDependencyCycles, label)
 	}
 	fmt.Fprintf(&hdr,
-		"\n**Language:** %s · **Files:** %d · **Functions:** %d",
-		graph.Language, graph.Stats.TotalFiles, graph.Stats.TotalFunctions,
+		"\n**Language:** %s · **Files:** %d",
+		graph.Language, graph.Stats.TotalFiles,
 	)
+	if opts.LocalMode && graph.Stats.TotalFunctions == 0 {
+		hdr.WriteString(" · **Functions:** not counted locally")
+	} else {
+		fmt.Fprintf(&hdr, " · **Functions:** %d", graph.Stats.TotalFunctions)
+	}
 	required := hdr.String()
 
 	reqTokens := CountTokens(required)

--- a/internal/restore/restore_test.go
+++ b/internal/restore/restore_test.go
@@ -254,6 +254,29 @@ func TestBuildProjectGraph_LocalModeExcludesDocsOutput(t *testing.T) {
 	}
 }
 
+func TestBuildProjectGraph_LocalModeExcludesGeneratedShards(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"main.graph.go", "main.calls.go", "main.deps.go", "main.impact.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("// generated\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	graph, err := BuildProjectGraph(context.Background(), dir, "smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graph.Stats.TotalFiles != 1 {
+		t.Fatalf("generated shard files should be ignored by local restore scan: got %d files", graph.Stats.TotalFiles)
+	}
+	if len(graph.Domains) != 1 || len(graph.Domains[0].KeyFiles) != 1 || graph.Domains[0].KeyFiles[0] != "main.go" {
+		t.Fatalf("generated shard files should not become key files, got %#v", graph.Domains)
+	}
+}
+
 // ── buildDomains ──────────────────────────────────────────────────────────────
 
 func TestBuildDomains_Empty(t *testing.T) {

--- a/internal/restore/restore_test.go
+++ b/internal/restore/restore_test.go
@@ -195,6 +195,65 @@ func TestDetectLanguages_UnknownExtensionsIgnored(t *testing.T) {
 	}
 }
 
+func TestBuildProjectGraph_LocalModeCountsRootSourceFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Smoke\n\nExample project.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph, err := BuildProjectGraph(context.Background(), dir, "smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graph.Stats.TotalFiles != 1 {
+		t.Fatalf("local mode should count recognized source files only: got %d", graph.Stats.TotalFiles)
+	}
+	if graph.Language != "Go" {
+		t.Fatalf("primary language: got %q, want Go", graph.Language)
+	}
+	if len(graph.Domains) != 1 || graph.Domains[0].Name != "Root" {
+		t.Fatalf("root source file should produce Root domain, got %#v", graph.Domains)
+	}
+
+	out, _, err := Render(graph, "smoke", RenderOptions{LocalMode: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "1 source files") {
+		t.Fatalf("rendered output should report source file count, got:\n%s", out)
+	}
+	if strings.Contains(out, "0 functions") {
+		t.Fatalf("local mode should not claim zero functions, got:\n%s", out)
+	}
+	if !strings.Contains(out, "functions not counted locally") {
+		t.Fatalf("local mode should explain function count limitation, got:\n%s", out)
+	}
+}
+
+func TestBuildProjectGraph_LocalModeExcludesDocsOutput(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "docs-output"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docs-output", "generated.js"), []byte("console.log('generated')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph, err := BuildProjectGraph(context.Background(), dir, "smoke")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graph.Stats.TotalFiles != 1 {
+		t.Fatalf("docs-output should be ignored by local restore scan: got %d files", graph.Stats.TotalFiles)
+	}
+}
+
 // ── buildDomains ──────────────────────────────────────────────────────────────
 
 func TestBuildDomains_Empty(t *testing.T) {

--- a/internal/shards/daemon.go
+++ b/internal/shards/daemon.go
@@ -185,10 +185,13 @@ func (d *Daemon) loadOrGenerate(ctx context.Context) error {
 		if unmarshalErr := json.Unmarshal(data, &ir); unmarshalErr != nil {
 			d.logf("Warning: cache file invalid, regenerating: %v", unmarshalErr)
 		} else if len(ir.Graph.Nodes) > 0 {
-			fingerprint, _ := repocache.RepoFingerprint(d.cfg.RepoDir)
-			if !shardCacheMatchesFingerprint(&ir, fingerprint) {
+			fingerprint, fingerprintErr := repocache.RepoFingerprint(d.cfg.RepoDir)
+			switch {
+			case fingerprintErr != nil:
+				d.logf("Unable to validate cached graph for current repo contents, regenerating")
+			case !shardCacheMatchesFingerprint(&ir, fingerprint):
 				d.logf("Cache is stale for current repo contents, regenerating")
-			} else {
+			default:
 				d.logf("Loaded existing cache (%d nodes, %d relationships)",
 					len(ir.Graph.Nodes), len(ir.Graph.Relationships))
 

--- a/internal/shards/daemon.go
+++ b/internal/shards/daemon.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/supermodeltools/cli/internal/api"
+	repocache "github.com/supermodeltools/cli/internal/cache"
 )
 
 // DaemonConfig holds watch daemon configuration.
@@ -174,29 +175,38 @@ func (d *Daemon) Run(ctx context.Context) error {
 // loadOrGenerate loads an existing cache if available and re-renders shards.
 // If no cache exists, it does a full API fetch.
 func (d *Daemon) loadOrGenerate(ctx context.Context) error {
+	if err := updateGitignore(d.cfg.RepoDir); err != nil {
+		return err
+	}
+
 	data, err := os.ReadFile(d.cfg.CacheFile)
 	if err == nil {
 		var ir api.ShardIR
 		if unmarshalErr := json.Unmarshal(data, &ir); unmarshalErr != nil {
 			d.logf("Warning: cache file invalid, regenerating: %v", unmarshalErr)
 		} else if len(ir.Graph.Nodes) > 0 {
-			d.logf("Loaded existing cache (%d nodes, %d relationships)",
-				len(ir.Graph.Nodes), len(ir.Graph.Relationships))
+			fingerprint, _ := repocache.RepoFingerprint(d.cfg.RepoDir)
+			if !shardCacheMatchesFingerprint(&ir, fingerprint) {
+				d.logf("Cache is stale for current repo contents, regenerating")
+			} else {
+				d.logf("Loaded existing cache (%d nodes, %d relationships)",
+					len(ir.Graph.Nodes), len(ir.Graph.Relationships))
 
-			d.mu.Lock()
-			d.ir = &ir
-			d.cache = NewCache()
-			d.cache.Build(&ir)
-			d.loadedCache = true
-			d.mu.Unlock()
+				d.mu.Lock()
+				d.ir = &ir
+				d.cache = NewCache()
+				d.cache.Build(&ir)
+				d.loadedCache = true
+				d.mu.Unlock()
 
-			files := d.cache.SourceFiles()
-			written, renderErr := RenderAll(d.cfg.RepoDir, d.cache, files, false)
-			if renderErr != nil {
-				return renderErr
+				files := d.cache.SourceFiles()
+				written, renderErr := RenderAll(d.cfg.RepoDir, d.cache, files, false)
+				if renderErr != nil {
+					return renderErr
+				}
+				d.logf("Rendered %d shards for %d source files", written, len(files))
+				return nil
 			}
-			d.logf("Rendered %d shards for %d source files", written, len(files))
-			return nil
 		}
 	}
 
@@ -209,6 +219,7 @@ func (d *Daemon) loadOrGenerate(ctx context.Context) error {
 func (d *Daemon) fullGenerate(ctx context.Context) error {
 	d.logf("Fetching full graph from Supermodel API...")
 	idemKey := newUUID()
+	fingerprint, _ := repocache.RepoFingerprint(d.cfg.RepoDir)
 
 	if fileList, listErr := DryRunList(d.cfg.RepoDir); listErr == nil {
 		stats := LanguageStats(fileList)
@@ -227,10 +238,11 @@ func (d *Daemon) fullGenerate(ctx context.Context) error {
 	}
 
 	d.mu.Lock()
+	setShardCacheFingerprint(ir, fingerprint)
 	d.ir = ir
 	d.cache = NewCache()
 	d.cache.Build(ir)
-	d.saveCache()
+	d.saveCacheWithFingerprint(fingerprint)
 	d.mu.Unlock()
 
 	files := d.cache.SourceFiles()
@@ -339,9 +351,15 @@ func (d *Daemon) incrementalUpdate(ctx context.Context, changedFiles []string) {
 
 // saveCache writes the current merged ShardIR to the cache file. Must be called with d.mu held.
 func (d *Daemon) saveCache() {
+	fingerprint, _ := repocache.RepoFingerprint(d.cfg.RepoDir)
+	d.saveCacheWithFingerprint(fingerprint)
+}
+
+func (d *Daemon) saveCacheWithFingerprint(fingerprint string) {
 	if d.ir == nil {
 		return
 	}
+	setShardCacheFingerprint(d.ir, fingerprint)
 	// Ensure cache directory exists
 	if err := os.MkdirAll(filepath.Dir(d.cfg.CacheFile), 0o755); err != nil {
 		d.logf("Error creating cache directory: %v", err)

--- a/internal/shards/daemon_test.go
+++ b/internal/shards/daemon_test.go
@@ -2,12 +2,16 @@ package shards
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/supermodeltools/cli/internal/api"
+	repocache "github.com/supermodeltools/cli/internal/cache"
 )
 
 // ── helpers ─────────────────────────────────────────────────────────────────
@@ -964,6 +968,82 @@ func TestOnSyncing_NilSafe(t *testing.T) {
 		logf:   func(string, ...interface{}) {},
 	}
 	d.incrementalUpdate(context.Background(), []string{"a.go"})
+}
+
+func TestLoadOrGenerate_RegeneratesStaleFingerprintCache(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "main.go"), []byte("package main\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	shardsRunGit(t, repoDir, "init")
+	shardsRunGit(t, repoDir, "config", "user.email", "test@example.com")
+	shardsRunGit(t, repoDir, "config", "user.name", "Test")
+	shardsRunGit(t, repoDir, "add", "main.go")
+	shardsRunGit(t, repoDir, "commit", "-m", "init")
+
+	cacheFile := filepath.Join(repoDir, ".supermodel", "shards.json")
+	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := buildIR(
+		[]api.Node{newNode("old-file", []string{"File"}, "filePath", "old.go")},
+		nil,
+	)
+	stale.Summary = map[string]any{shardCacheFingerprintKey: "stale"}
+	staleJSON, err := json.Marshal(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cacheFile, staleJSON, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fresh := buildIR(
+		[]api.Node{newNode("file-main", []string{"File"}, "filePath", "main.go")},
+		nil,
+	)
+	client := &mockAnalyzeClient{result: fresh}
+	d := &Daemon{
+		cfg: DaemonConfig{
+			RepoDir:   repoDir,
+			CacheFile: cacheFile,
+			LogFunc:   func(string, ...interface{}) {},
+		},
+		client:   client,
+		cache:    NewCache(),
+		logf:     func(string, ...interface{}) {},
+		notifyCh: make(chan string, 256),
+	}
+	if err := d.loadOrGenerate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if client.called == 0 {
+		t.Fatal("stale fingerprint cache should trigger API regeneration")
+	}
+	current, err := repocache.RepoFingerprint(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved api.ShardIR
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := saved.Summary[shardCacheFingerprintKey].(string); got != current {
+		t.Fatalf("saved fingerprint = %q, want %q", got, current)
+	}
+}
+
+func shardsRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
 }
 
 // ── Port-conflict UX ─────────────────────────────────────────────────────────

--- a/internal/shards/daemon_test.go
+++ b/internal/shards/daemon_test.go
@@ -1037,6 +1037,15 @@ func TestLoadOrGenerate_RegeneratesStaleFingerprintCache(t *testing.T) {
 	}
 }
 
+func TestShardCacheMatchesFingerprint_FailsClosedForMissingFingerprint(t *testing.T) {
+	ir := buildIR([]api.Node{newNode("file-main", []string{"File"}, "filePath", "main.go")}, nil)
+	ir.Summary = map[string]any{shardCacheFingerprintKey: "known"}
+
+	if shardCacheMatchesFingerprint(ir, "") {
+		t.Fatal("missing current fingerprint should not be treated as a cache hit")
+	}
+}
+
 func shardsRunGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/shards/handler.go
+++ b/internal/shards/handler.go
@@ -85,16 +85,19 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 	if cacheFile == "" {
 		cacheFile = filepath.Join(repoDir, ".supermodel", "shards.json")
 	}
-	fingerprint, _ := repocache.RepoFingerprint(repoDir)
+	fingerprint, fingerprintErr := repocache.RepoFingerprint(repoDir)
 
 	// Check for existing cache unless --force
 	if !opts.Force {
 		if data, err := os.ReadFile(cacheFile); err == nil {
 			var ir api.ShardIR
 			if err := json.Unmarshal(data, &ir); err == nil && len(ir.Graph.Nodes) > 0 {
-				if !shardCacheMatchesFingerprint(&ir, fingerprint) {
+				switch {
+				case fingerprintErr != nil:
+					ui.Warn("Unable to validate cached graph for current repo contents — re-fetching")
+				case !shardCacheMatchesFingerprint(&ir, fingerprint):
 					ui.Warn("Cached graph is stale for current repo contents — re-fetching")
-				} else {
+				default:
 					ui.Success("Using cached graph (%d nodes) — use --force to re-fetch", len(ir.Graph.Nodes))
 					cache := NewCache()
 					cache.Build(&ir)
@@ -223,7 +226,7 @@ func setShardCacheFingerprint(ir *api.ShardIR, fingerprint string) {
 
 func shardCacheMatchesFingerprint(ir *api.ShardIR, fingerprint string) bool {
 	if fingerprint == "" {
-		return true
+		return false
 	}
 	if ir == nil || ir.Summary == nil {
 		return false

--- a/internal/shards/handler.go
+++ b/internal/shards/handler.go
@@ -33,14 +33,6 @@ type GenerateOptions struct {
 	Force     bool
 	DryRun    bool
 	CacheFile string
-	ThreeFile bool // deprecated: render .calls/.deps/.impact instead of single .graph
-}
-
-func renderShards(repoDir string, cache *Cache, files []string, dryRun, threeFile bool) (int, error) {
-	if threeFile {
-		return RenderAllThreeFile(repoDir, cache, files, dryRun)
-	}
-	return RenderAll(repoDir, cache, files, dryRun)
 }
 
 // WatchOptions configures the watch command.
@@ -56,7 +48,6 @@ type WatchOptions struct {
 type RenderOptions struct {
 	CacheFile string
 	DryRun    bool
-	ThreeFile bool
 }
 
 // guardDir returns an error if dir is the filesystem root or the user's home
@@ -109,7 +100,7 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 					cache.Build(&ir)
 					files := cache.SourceFiles()
 					spin := ui.Start("Rendering shards…")
-					written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
+					written, err := RenderAll(repoDir, cache, files, opts.DryRun)
 					spin.Stop()
 					if err != nil {
 						return err
@@ -173,7 +164,7 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 				staleCache := NewCache()
 				staleCache.Build(&staleIR)
 				files := staleCache.SourceFiles()
-				written, renderErr := renderShards(repoDir, staleCache, files, opts.DryRun, opts.ThreeFile)
+				written, renderErr := RenderAll(repoDir, staleCache, files, opts.DryRun)
 				if renderErr != nil {
 					return fmt.Errorf("API error: %w; stale render also failed: %v", err, renderErr)
 				}
@@ -208,7 +199,7 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 	files := cache.SourceFiles()
 
 	spin = ui.Start("Rendering shards…")
-	written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
+	written, err := RenderAll(repoDir, cache, files, opts.DryRun)
 	spin.Stop()
 	if err != nil {
 		return err
@@ -472,7 +463,7 @@ func Render(dir string, opts RenderOptions) error {
 	cache.Build(&ir)
 	files := cache.SourceFiles()
 
-	written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
+	written, err := RenderAll(repoDir, cache, files, opts.DryRun)
 	if err != nil {
 		return err
 	}

--- a/internal/shards/handler.go
+++ b/internal/shards/handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/supermodeltools/cli/internal/api"
+	repocache "github.com/supermodeltools/cli/internal/cache"
 	"github.com/supermodeltools/cli/internal/config"
 	"github.com/supermodeltools/cli/internal/ui"
 )
@@ -25,12 +26,14 @@ const (
 	ansiDim    = "\033[2m"
 )
 
+const shardCacheFingerprintKey = "_supermodelFingerprint"
+
 // GenerateOptions configures the generate command.
 type GenerateOptions struct {
 	Force     bool
 	DryRun    bool
 	CacheFile string
-	ThreeFile bool // generate .calls/.deps/.impact instead of single .graph
+	ThreeFile bool // deprecated: render .calls/.deps/.impact instead of single .graph
 }
 
 func renderShards(repoDir string, cache *Cache, files []string, dryRun, threeFile bool) (int, error) {
@@ -83,29 +86,37 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 	if err := guardDir(repoDir); err != nil {
 		return err
 	}
+	if err := updateGitignore(repoDir); err != nil {
+		return err
+	}
 
 	cacheFile := opts.CacheFile
 	if cacheFile == "" {
 		cacheFile = filepath.Join(repoDir, ".supermodel", "shards.json")
 	}
+	fingerprint, _ := repocache.RepoFingerprint(repoDir)
 
 	// Check for existing cache unless --force
 	if !opts.Force {
 		if data, err := os.ReadFile(cacheFile); err == nil {
 			var ir api.ShardIR
 			if err := json.Unmarshal(data, &ir); err == nil && len(ir.Graph.Nodes) > 0 {
-				ui.Success("Using cached graph (%d nodes) — use --force to re-fetch", len(ir.Graph.Nodes))
-				cache := NewCache()
-				cache.Build(&ir)
-				files := cache.SourceFiles()
-				spin := ui.Start("Rendering shards…")
-				written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
-				spin.Stop()
-				if err != nil {
-					return err
+				if !shardCacheMatchesFingerprint(&ir, fingerprint) {
+					ui.Warn("Cached graph is stale for current repo contents — re-fetching")
+				} else {
+					ui.Success("Using cached graph (%d nodes) — use --force to re-fetch", len(ir.Graph.Nodes))
+					cache := NewCache()
+					cache.Build(&ir)
+					files := cache.SourceFiles()
+					spin := ui.Start("Rendering shards…")
+					written, err := renderShards(repoDir, cache, files, opts.DryRun, opts.ThreeFile)
+					spin.Stop()
+					if err != nil {
+						return err
+					}
+					ui.Success("Wrote %d shards for %d source files", written, len(files))
+					return updateGitignore(repoDir)
 				}
-				ui.Success("Wrote %d shards for %d source files", written, len(files))
-				return updateGitignore(repoDir)
 			}
 		}
 	}
@@ -173,6 +184,8 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 		return err
 	}
 
+	setShardCacheFingerprint(ir, fingerprint)
+
 	// Persist cache
 	if err := os.MkdirAll(filepath.Dir(cacheFile), 0o755); err != nil {
 		return fmt.Errorf("create cache dir: %w", err)
@@ -205,6 +218,27 @@ func Generate(ctx context.Context, cfg *config.Config, dir string, opts Generate
 		written, len(files), len(ir.Graph.Nodes), len(ir.Graph.Relationships))
 
 	return updateGitignore(repoDir)
+}
+
+func setShardCacheFingerprint(ir *api.ShardIR, fingerprint string) {
+	if ir == nil || fingerprint == "" {
+		return
+	}
+	if ir.Summary == nil {
+		ir.Summary = make(map[string]any)
+	}
+	ir.Summary[shardCacheFingerprintKey] = fingerprint
+}
+
+func shardCacheMatchesFingerprint(ir *api.ShardIR, fingerprint string) bool {
+	if fingerprint == "" {
+		return true
+	}
+	if ir == nil || ir.Summary == nil {
+		return false
+	}
+	got, _ := ir.Summary[shardCacheFingerprintKey].(string)
+	return got == fingerprint
 }
 
 // Watch runs generate on startup, then enters daemon mode.

--- a/internal/shards/render.go
+++ b/internal/shards/render.go
@@ -253,7 +253,10 @@ func safeRemove(repoDir, relPath string) {
 }
 
 // removeStaleSplitShards removes legacy .calls/.deps/.impact files for a source file.
-func removeStaleSplitShards(repoDir, srcFile string) {
+func removeStaleSplitShards(repoDir, srcFile string, dryRun bool) {
+	if dryRun {
+		return
+	}
 	ext := filepath.Ext(srcFile)
 	stem := strings.TrimSuffix(srcFile, ext)
 	for _, p := range []string{
@@ -273,7 +276,7 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 
 	for _, srcFile := range files {
 		// Clean up stale legacy split shards when writing the supported .graph file.
-		removeStaleSplitShards(repoDir, srcFile)
+		removeStaleSplitShards(repoDir, srcFile, dryRun)
 
 		ext := filepath.Ext(srcFile)
 		prefix := CommentPrefix(ext)
@@ -281,8 +284,9 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 
 		content := RenderGraph(srcFile, cache, prefix)
 		if content == "" {
-			full := filepath.Join(repoDir, ShardFilename(srcFile))
-			_ = os.Remove(full)
+			if !dryRun {
+				safeRemove(repoDir, ShardFilename(srcFile))
+			}
 			continue
 		}
 

--- a/internal/shards/render.go
+++ b/internal/shards/render.go
@@ -26,13 +26,6 @@ func ShardFilename(sourcePath string) string {
 	return stem + ".graph" + ext
 }
 
-// ThreeFileShardNames generates the .calls, .deps, .impact shard paths.
-func ThreeFileShardNames(sourcePath string) (calls, deps, impact string) {
-	ext := filepath.Ext(sourcePath)
-	stem := strings.TrimSuffix(sourcePath, ext)
-	return stem + ".calls" + ext, stem + ".deps" + ext, stem + ".impact" + ext
-}
-
 // Header returns the @generated header line.
 func Header(prefix string) string {
 	return prefix + " @generated supermodel-shard — do not edit\n"
@@ -259,17 +252,17 @@ func safeRemove(repoDir, relPath string) {
 	_ = os.Remove(full)
 }
 
-// removeStaleThreeFile removes .calls/.deps/.impact files for a source file.
-func removeStaleThreeFile(repoDir, srcFile string) {
-	c, d, i := ThreeFileShardNames(srcFile)
-	for _, p := range []string{c, d, i} {
+// removeStaleSplitShards removes legacy .calls/.deps/.impact files for a source file.
+func removeStaleSplitShards(repoDir, srcFile string) {
+	ext := filepath.Ext(srcFile)
+	stem := strings.TrimSuffix(srcFile, ext)
+	for _, p := range []string{
+		stem + ".calls" + ext,
+		stem + ".deps" + ext,
+		stem + ".impact" + ext,
+	} {
 		safeRemove(repoDir, p)
 	}
-}
-
-// removeStaleGraph removes the single .graph file for a source file.
-func removeStaleGraph(repoDir, srcFile string) {
-	safeRemove(repoDir, ShardFilename(srcFile))
 }
 
 // RenderAll generates and writes .graph shards for the given source files.
@@ -279,8 +272,8 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 	written := 0
 
 	for _, srcFile := range files {
-		// Clean up stale three-file shards from a previous --three-file run.
-		removeStaleThreeFile(repoDir, srcFile)
+		// Clean up stale legacy split shards when writing the supported .graph file.
+		removeStaleSplitShards(repoDir, srcFile)
 
 		ext := filepath.Ext(srcFile)
 		prefix := CommentPrefix(ext)
@@ -306,55 +299,6 @@ func RenderAll(repoDir string, cache *Cache, files []string, dryRun bool) (int, 
 			return written, err
 		}
 		written++
-	}
-
-	return written, nil
-}
-
-// RenderAllThreeFile generates .calls, .deps, and .impact files per source file.
-func RenderAllThreeFile(repoDir string, cache *Cache, files []string, dryRun bool) (int, error) {
-	sort.Strings(files)
-	written := 0
-
-	for _, srcFile := range files {
-		// Clean up stale single .graph file from a previous non-three-file run.
-		removeStaleGraph(repoDir, srcFile)
-
-		ext := filepath.Ext(srcFile)
-		prefix := CommentPrefix(ext)
-		header := Header(prefix)
-		goPrefix := ""
-		if ext == ".go" {
-			goPrefix = "//go:build ignore\n\npackage ignore\n"
-		}
-
-		callsPath, depsPath, impactPath := ThreeFileShardNames(srcFile)
-
-		deps := renderDepsSection(srcFile, cache, prefix)
-		calls := renderCallsSection(srcFile, cache, prefix)
-		impact := renderImpactSection(srcFile, cache, prefix)
-
-		for _, item := range []struct {
-			path    string
-			content string
-		}{
-			{depsPath, deps},
-			{callsPath, calls},
-			{impactPath, impact},
-		} {
-			if item.content == "" {
-				safeRemove(repoDir, item.path)
-				continue
-			}
-			fullContent := goPrefix + header + item.content + "\n"
-			if err := WriteShard(repoDir, item.path, fullContent, dryRun); err != nil {
-				if strings.Contains(err.Error(), "path traversal") {
-					continue
-				}
-				return written, err
-			}
-			written++
-		}
 	}
 
 	return written, nil

--- a/internal/shards/render_stale_test.go
+++ b/internal/shards/render_stale_test.go
@@ -68,6 +68,30 @@ func TestRenderAll_RemovesStaleSplitShards(t *testing.T) {
 	}
 }
 
+func TestRenderAll_DryRunDoesNotRemoveStaleSplitShards(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+
+	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
+		touchFile(t, filepath.Join(dir, "src", name))
+	}
+
+	cache := testCache()
+	_, err := RenderAll(dir, cache, []string{"src/index.ts"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); !os.IsNotExist(err) {
+		t.Error("dry-run should not write index.graph.ts")
+	}
+	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
+		if _, err := os.Stat(filepath.Join(dir, "src", name)); err != nil {
+			t.Errorf("dry-run should not remove %s: %v", name, err)
+		}
+	}
+}
+
 func TestRenderAll_GraphContent(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, "src"), 0o755)

--- a/internal/shards/render_stale_test.go
+++ b/internal/shards/render_stale_test.go
@@ -31,26 +31,6 @@ func testCache() *Cache {
 	return c
 }
 
-// testCacheNoImpact returns a cache where src/lonely.ts has no importers
-// and no callers — so the impact section will be empty. lonely.ts imports
-// index.ts (so it has deps) but nothing imports lonely.ts.
-func testCacheNoImpact() *Cache {
-	ir := &api.ShardIR{
-		Graph: api.ShardGraph{
-			Nodes: []api.Node{
-				{ID: "f1", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/index.ts", "name": "index.ts"}},
-				{ID: "f2", Labels: []string{"File"}, Properties: map[string]any{"filePath": "src/lonely.ts", "name": "lonely.ts"}},
-			},
-			Relationships: []api.Relationship{
-				{ID: "r1", Type: "imports", StartNode: "f2", EndNode: "f1"},
-			},
-		},
-	}
-	c := NewCache()
-	c.Build(ir)
-	return c
-}
-
 func touchFile(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -63,7 +43,7 @@ func touchFile(t *testing.T, path string) {
 
 // ── Stale file cleanup ──────────────────────────────────────────
 
-func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
+func TestRenderAll_RemovesStaleSplitShards(t *testing.T) {
 	dir := t.TempDir()
 	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
 
@@ -85,114 +65,6 @@ func TestRenderAll_RemovesStaleThreeFiles(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dir, "src", name)); !os.IsNotExist(err) {
 			t.Errorf("expected %s to be removed, but it exists", name)
 		}
-	}
-}
-
-func TestRenderAllThreeFile_RemovesStaleGraphFile(t *testing.T) {
-	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-
-	touchFile(t, filepath.Join(dir, "src", "index.graph.ts"))
-
-	cache := testCache()
-	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := os.Stat(filepath.Join(dir, "src", "index.graph.ts")); !os.IsNotExist(err) {
-		t.Error("expected index.graph.ts to be removed after three-file render")
-	}
-
-	found := false
-	for _, name := range []string{"index.calls.ts", "index.deps.ts", "index.impact.ts"} {
-		if _, err := os.Stat(filepath.Join(dir, "src", name)); err == nil {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected at least one three-file shard to exist")
-	}
-}
-
-// ── Happy-path content verification ─────────────────────────────
-
-func TestRenderAllThreeFile_CallsContent(t *testing.T) {
-	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-
-	cache := testCache()
-	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, "src", "index.calls.ts"))
-	if err != nil {
-		t.Fatal("index.calls.ts not written")
-	}
-	content := string(data)
-	if !strings.Contains(content, "[calls]") {
-		t.Error("calls file missing [calls] section header")
-	}
-	if !strings.Contains(content, "main") {
-		t.Error("calls file missing 'main' function")
-	}
-	if !strings.Contains(content, "helper") {
-		t.Error("calls file missing 'helper' callee")
-	}
-}
-
-func TestRenderAllThreeFile_DepsContent(t *testing.T) {
-	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-
-	cache := testCache()
-	_, err := RenderAllThreeFile(dir, cache, []string{"src/index.ts"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, "src", "index.deps.ts"))
-	if err != nil {
-		t.Fatal("index.deps.ts not written")
-	}
-	content := string(data)
-	if !strings.Contains(content, "[deps]") {
-		t.Error("deps file missing [deps] section header")
-	}
-	if !strings.Contains(content, "imports") {
-		t.Error("deps file missing 'imports' line")
-	}
-	if !strings.Contains(content, "utils.ts") {
-		t.Error("deps file missing utils.ts import")
-	}
-}
-
-func TestRenderAllThreeFile_ImpactContent(t *testing.T) {
-	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-
-	cache := testCache()
-	// utils.ts has an importer (index.ts) so it will have impact data
-	_, err := RenderAllThreeFile(dir, cache, []string{"src/utils.ts"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, "src", "utils.impact.ts"))
-	if err != nil {
-		t.Fatal("utils.impact.ts not written")
-	}
-	content := string(data)
-	if !strings.Contains(content, "[impact]") {
-		t.Error("impact file missing [impact] section header")
-	}
-	if !strings.Contains(content, "risk") {
-		t.Error("impact file missing risk line")
-	}
-	if !strings.Contains(content, "direct") {
-		t.Error("impact file missing direct count")
 	}
 }
 
@@ -222,33 +94,6 @@ func TestRenderAll_GraphContent(t *testing.T) {
 	}
 	if !strings.Contains(content, "main") {
 		t.Error("graph file missing main function")
-	}
-}
-
-// ── Empty section cleanup ───────────────────────────────────────
-
-func TestRenderAllThreeFile_EmptySectionRemovesStaleFile(t *testing.T) {
-	dir := t.TempDir()
-	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
-
-	// lonely.ts has no importers and no callers — impact will be empty
-	// Pre-create a stale .impact file
-	touchFile(t, filepath.Join(dir, "src", "lonely.impact.ts"))
-
-	cache := testCacheNoImpact()
-	_, err := RenderAllThreeFile(dir, cache, []string{"src/lonely.ts"}, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// deps file should exist (lonely.ts is imported by index.ts)
-	if _, err := os.Stat(filepath.Join(dir, "src", "lonely.deps.ts")); err != nil {
-		t.Error("expected lonely.deps.ts to exist (it has an importer)")
-	}
-
-	// impact file should be removed (no importers of lonely.ts, no callers)
-	if _, err := os.Stat(filepath.Join(dir, "src", "lonely.impact.ts")); !os.IsNotExist(err) {
-		t.Error("expected lonely.impact.ts to be removed (empty impact section)")
 	}
 }
 

--- a/internal/shards/zip.go
+++ b/internal/shards/zip.go
@@ -25,7 +25,8 @@ var zipSkipDirs = map[string]bool{
 	"venv": true, "__pycache__": true, "dist": true, "build": true,
 	".next": true, ".nuxt": true, ".cache": true, ".turbo": true,
 	"coverage": true, ".nyc_output": true, "__snapshots__": true,
-	".terraform": true,
+	"docs-output": true,
+	".terraform":  true,
 }
 
 var zipSkipFiles = map[string]bool{

--- a/internal/shards/zip.go
+++ b/internal/shards/zip.go
@@ -404,7 +404,7 @@ func PrintLanguageBarChart(stats []LangStat, totalFiles int) {
 // shardTags are the extension tags used by all shard formats.
 var shardTags = map[string]bool{
 	"graph":  true, // single-file format
-	"calls":  true, // three-file format
+	"calls":  true, // legacy split-shard format
 	"deps":   true,
 	"impact": true,
 }

--- a/internal/shards/zip_test.go
+++ b/internal/shards/zip_test.go
@@ -17,6 +17,9 @@ func TestIsShardFile(t *testing.T) {
 		want bool
 	}{
 		{"handler.graph.go", true},
+		{"handler.calls.go", true},
+		{"handler.deps.go", true},
+		{"handler.impact.go", true},
 		{"handler.graph.ts", true},
 		{"handler.graph.py", true},
 		{"handler.go", false},
@@ -84,6 +87,13 @@ func TestShouldInclude_SkipDir(t *testing.T) {
 	}
 	if shouldInclude("node_modules/pkg/index.js", 100, ex) {
 		t.Error("node_modules file should be excluded")
+	}
+}
+
+func TestShouldInclude_DefaultDocsOutputDir(t *testing.T) {
+	ex := buildExclusions(t.TempDir())
+	if shouldInclude("docs-output/index.html", 100, ex) {
+		t.Error("default docs-output directory should be excluded from analysis uploads")
 	}
 }
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://supermodeltools.com/install | sh
 supermodel analyze
 
 # Watch for changes and keep graphs up to date
-supermodel watch
+supermodel
 
 # Print the Claude Code skill prompt
 supermodel skill


### PR DESCRIPTION
## Summary

Production-readiness cleanup for the local file-mode CLI workflow from #166.

Implemented:

- Replaced stale public `supermodel watch` / `watch [path]` references with the bare `supermodel` daemon command.
- Removed `analyze --three-file` entirely; passing it now fails as an unknown flag. Legacy `.calls/.deps/.impact` cleanup remains so old split shards are removed during normal `.graph.*` rendering.
- Fixed bare `supermodel` Ctrl-C handling so the daemon receives cancellation and removes generated shard files.
- Hardened shard cache correctness with repo fingerprints, stale-cache detection, generated/non-uploaded artifact filtering, NUL-safe git path parsing, rename-aware fingerprinting, and fail-closed cache validation when fingerprints cannot be computed.
- Fixed shard dry-run behavior so stale legacy split shards are not deleted during dry-run.
- Fixed `restore --local` root scanning, source-file counting, generated shard exclusion, `docs-output` exclusion, and misleading `0 functions` output.
- Excluded `docs-output` from analysis uploads and local restore scans.
- Fixed reverse-path auth behavior for `login --token ""` and avoided fingerprinting hidden directories / sensitive hard-blocked files that are not uploaded.
- Verified `update` with a temporary older binary self-replacing to the latest release.

Out of scope for this pass:

- MCP cleanup beyond surface verification.
- `compact` cleanup beyond surface verification.
- Larger share/audit product changes.

Refs #166.

## Command Surface Verification

Local binary built from this branch and tested against a temp repo, temp HOME, and local mock Supermodel API.

Happy paths covered:

- Root/help/safe: `supermodel --help`, `help analyze`, `completion`, `version`, `skill`, `status`, `update --check`.
- Auth/config: `login --token`, `logout`, authed and unauthenticated `status`.
- File mode: `analyze`, cached `analyze`, removed `--three-file` expected-failure check, `clean --dry-run`, `clean`, bare `supermodel` daemon + Ctrl-C cleanup, `hook`.
- API-backed commands through mock API: `analyze --no-shards`, `graph`, `find`, `focus`, `dead-code`, `blast-radius`, `audit`, `share`, `restore`, `docs`, `mcp` initialize/tools-list.
- Local/offline: `restore --local`, `compact` file and dry-run directory mode.
- Setup: full PTY walkthrough with auth, repo selection, hook install, shard mode enablement, daemon startup, and Ctrl-C cleanup.

Reverse paths covered:

- No-auth failures for root daemon, `analyze`, `graph`, `find`, `focus`, `dead-code`, `blast-radius`, `audit`, `share`, `docs`, and `mcp`.
- Invalid/missing args for `focus`, `find`, `restore --local`, `clean`, root-dir guard for `analyze`, missing diff for `blast-radius`, unsupported file for `compact`, missing `login --token` value, and removed `analyze --three-file`.

## Testing

- `go test ./...`
- `go test ./internal/cache ./internal/shards ./internal/restore`
- `GOTOOLCHAIN=go1.25.9 make test`
- `GOTOOLCHAIN=go1.25.9 go vet ./...`
- `GOTOOLCHAIN=go1.25.9 golangci-lint run --new-from-rev=upstream/main ./...`
- Local command-surface harness: 57/57 passing.
- `supermodel update` smoke: temporary `v0.6.12` binary updated to `0.6.13 (66432f6, 2026-04-30T15:18:18Z)`.

Note: full-repo `golangci-lint run ./...` still reports pre-existing staticcheck SA5011 warnings in untouched focus/zip tests; PR-diff lint is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Improved cache freshness detection for faster incremental updates

* **Bug Fixes**
  - Better handling of generated and output files in analysis
  - Enhanced cache invalidation detection

* **Documentation**
  - Updated commands: `watch` renamed to `supermodel`
  - Simplified setup instructions
  - Updated daemon references in CLI

* **Changes**
  - Removed `--three-file` option
  - Unified shard output format
  - Excluded `docs-output` directory from analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->