### PR TITLE
Create supergraph.go

### DIFF
--- a/cmd/supergraph.go
+++ b/cmd/supergraph.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/supermodeltools/cli/internal/config"
+	"github.com/supermodeltools/cli/internal/graph"
+)
+
+func init() {
+	var opts graph.Options
+
+	c := &cobra.Command{
+		Use:   "graph [path]",
+		Short: "Display the repository graph",
+		Long: `Fetches or loads the cached graph and renders it.
+
+Output formats:
+  human  — aligned table of nodes (default)
+  json   — full graph as JSON
+  dot    — Graphviz DOT for use with dot/graphviz`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			if err := cfg.RequireAPIKey(); err != nil {
+				return err
+			}
+			dir := "."
+			if len(args) > 0 {
+				dir = args[0]
+			}
+			return graph.Run(cmd.Context(), cfg, dir, opts)
+		},
+	}
+
+	c.Flags().BoolVar(&opts.Force, "force", false, "re-analyze even if a cached result exists")
+	c.Flags().StringVarP(&opts.Output, "output", "o", "human", "output format: human|json|dot")
+	c.Flags().StringVar(&opts.Filter, "label", "", "filter nodes by label (File, Function, Class, …)")
+
+	rootCmd.AddCommand(c)
+}


### PR DESCRIPTION
## What

beginning work on implementing contextplus into golang

## Why

because go just works, and this repo deserves transliteration work commit

<!-- Motivation or context. Link related issues with "Closes #N". -->

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Manually tested: <!-- describe what you ran -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `graph` command for analyzing a directory and displaying its dependency graph.
  * Supports human-readable, JSON, and DOT output formats.
  * Added options to force re-analysis and filter graph nodes by label.
  * The directory to analyze can be provided as an argument, defaulting to the current directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->